### PR TITLE
fix two typos, inavlid -> invalid

### DIFF
--- a/generator/lib/src/realm_object_generator.dart
+++ b/generator/lib/src/realm_object_generator.dart
@@ -59,14 +59,13 @@ class RealmObjectGenerator extends Generator {
       var className = schemaClass.name.substring(1);
 
       StringBuffer getSchemaPropertyBuffer = new StringBuffer();
-      
+
       /// The `const dynamic type = ...` is there to remove the warning of unused_element for the Realm data model class in the user dart file
       getSchemaPropertyBuffer.writeln("""
             static dynamic getSchema() {
               const dynamic type = ${schemaClass.name};
               return RealmObject.getSchema('${className}', [
             """);
-
 
       //Class._constructor() is used from native code when creating new instances of this type
       //Class() constructor is used to be able to create new detached objects and add them to the realm
@@ -114,10 +113,8 @@ class RealmObjectGenerator extends Generator {
             InterfaceType fieldType = field.type as InterfaceType;
             var listTypeArument = fieldType.typeArguments[0].element;
             listTypeArumentName = listTypeArument.name;
-            var isDartType = listTypeArumentName == "String" ||
-              listTypeArumentName == "int" ||
-              listTypeArumentName == "double" ||
-              listTypeArumentName == "bool";
+            var isDartType =
+                listTypeArumentName == "String" || listTypeArumentName == "int" || listTypeArumentName == "double" || listTypeArumentName == "bool";
 
             // if (field.type.element.name == "dynamic") {
             //   throw new Exception("Class '${schemaClass.name}' has a List<dynamic> type field '${field.displayName}'");
@@ -134,7 +131,7 @@ class RealmObjectGenerator extends Generator {
 
             if (!isDartType && !listTypeArumentName.startsWith("_")) {
               throw new Exception(
-                  "Field ${schemaClass.name}.${field.name} has an inavlid type ${field.type.toString()}. Type parameter name should start with '_' and be a RealmObject schema type");
+                  "Field ${schemaClass.name}.${field.name} has an invalid type ${field.type.toString()}. Type parameter name should start with '_' and be a RealmObject schema type");
             }
 
             if (listTypeArumentName.startsWith("_")) {


### PR DESCRIPTION
there are two fix points. (same typo, two files were fixed)

"has an **inavlid** type List<dynamic>*. Type parameter name should start with '_' and be a RealmObject schema type"
->
"has an **invalid** type List<dynamic>*. Type parameter name should start with '_' and be a RealmObject schema type"

