### PR TITLE
use macos 10.15 for gh actions

### DIFF
--- a/.github/workflows/realm-flutter-android.yml
+++ b/.github/workflows/realm-flutter-android.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   CI:
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
       - name: Checkout

--- a/.github/workflows/realm-flutter-ios.yml
+++ b/.github/workflows/realm-flutter-ios.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   CI:
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Seems like macos-latest switched to 11 and Android CI started to fail sporadically. Previously on Mac 10.15 it was running deterministically so use that one instead