### PR TITLE
use macos 10.15 for gh actions

### DIFF
--- a/.github/workflows/realm-flutter-android.yml
+++ b/.github/workflows/realm-flutter-android.yml
@@ -64,12 +64,12 @@ jobs:
       - name: Run tests on Android Emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
-            force-avd-creation: false
-            disable-animations: true
-            emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-            api-level: 29
-            ndk: 21.0.6113669
-            arch: x86
-            cmake: 3.10.2.4988404
-            script: flutter drive --target=test_driver/app.dart --dart-define=testName="Realm version"
-            working-directory: ./flutter/realm_flutter/tests
+          force-avd-creation: false
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          api-level: 29
+          ndk: 21.0.6113669
+          arch: x86
+          cmake: 3.10.2.4988404
+          script: flutter drive --target=test_driver/app.dart --dart-define=testName="Realm version"
+          working-directory: ./flutter/realm_flutter/tests

--- a/.github/workflows/realm-flutter-android.yml
+++ b/.github/workflows/realm-flutter-android.yml
@@ -32,7 +32,7 @@ jobs:
           ./../scripts/build-android.sh
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v1.5.3
         with:
           flutter-version: '2.5.0'
 

--- a/.github/workflows/realm-flutter-android.yml
+++ b/.github/workflows/realm-flutter-android.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v1
         with:
-          flutter-version: '2.5.x'
+          flutter-version: '2.5.0'
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/realm-flutter-android.yml
+++ b/.github/workflows/realm-flutter-android.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   CI:
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
       - name: Checkout

--- a/.github/workflows/realm-flutter-ios.yml
+++ b/.github/workflows/realm-flutter-ios.yml
@@ -24,7 +24,9 @@ jobs:
           submodules: 'recursive'
 
       - name: get-ccache-id
-        run: echo "CCACHE_ID=os:${{ runner.OS }} build:ios realm-core-commit-hash:$(git submodule status src/realm-core | cut -c 1-41)" >> $GITHUB_ENV
+        run: |
+              echo "CCACHE_ID=os:${{ runner.OS }} build:ios realm-core-commit-hash $(git submodule status src/realm-core | cut -c 1-41)" >> $GITHUB_ENV
+              echo "using ccache-id:$(git submodule status src/realm-core | cut -c 1-41)"
 
       - name: install ccache
         uses: hendrikmuhs/ccache-action@v1  

--- a/.github/workflows/realm-flutter-ios.yml
+++ b/.github/workflows/realm-flutter-ios.yml
@@ -24,12 +24,10 @@ jobs:
           submodules: 'recursive'
 
       - name: get-ccache-id
-        run: |
-              echo "CCACHE_ID=os:${{ runner.OS }} build:ios realm-core-commit-hash $(git submodule status src/realm-core | cut -c 1-41)" >> $GITHUB_ENV
-              echo "using ccache-id:$(git submodule status src/realm-core | cut -c 1-41)"
+        run: echo "CCACHE_ID=os:${{ runner.OS }} build:ios realm-core commit hash $(git submodule status src/realm-core | cut -c 1-41)" >> $GITHUB_ENV
 
       - name: install ccache
-        uses: hendrikmuhs/ccache-action@v1  
+        uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ env.CCACHE_ID }}
 
@@ -40,7 +38,7 @@ jobs:
 
       - name: Build Realm Flutter for iOS
         run: |
-          ./scripts/build-ios.sh simulator
+              ./scripts/build-ios.sh simulator
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v1

--- a/.github/workflows/realm-flutter-ios.yml
+++ b/.github/workflows/realm-flutter-ios.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: 'recursive'
 
       - name: get-ccache-id
-        run: echo "CCACHE_ID=${{ runner.OS }} $(git submodule status src/realm-core)" >> $GITHUB_ENV
+        run: echo "CCACHE_ID=os:${{ runner.OS }} build:ios realm-core-commit-hash:$(git submodule status src/realm-core | cut -c 1-41)" >> $GITHUB_ENV
 
       - name: install ccache
         uses: hendrikmuhs/ccache-action@v1  

--- a/.github/workflows/realm-flutter-ios.yml
+++ b/.github/workflows/realm-flutter-ios.yml
@@ -41,7 +41,7 @@ jobs:
               ./scripts/build-ios.sh simulator
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v1.5.3
         with:
           flutter-version: '2.5.0'
     

--- a/.github/workflows/realm-flutter-ios.yml
+++ b/.github/workflows/realm-flutter-ios.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   CI:
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Seems like macos-latest switched to 11 and Android CI started to fail sporadically. Previously on Mac 10.15 it was running deterministically so use that one instead