### PR TITLE
CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS is not needed on windows and just ex…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,6 @@ if(REALM_BUILD_CORE_FROM_SOURCE)
 endif()
 
 target_compile_definitions(RealmFFIStatic PUBLIC -DRealm_EXPORTS)
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 target_link_libraries(realm_dart RealmFFIStatic)
 


### PR DESCRIPTION
…plodes the number of exports