### PR TITLE
Language should just be 'dart'

### DIFF
--- a/lib/src/cli/metrics/metrics.dart
+++ b/lib/src/cli/metrics/metrics.dart
@@ -43,7 +43,7 @@ Future<Metrics> generateMetrics({
       distinctId: distinctId,
       token: 'ce0fac19508f6c8f20066d345d360fd0',
       binding: 'dart',
-      language: 'dart ${Platform.version.takeUntil(' ')}',
+      language: 'dart',
       framework: framework,
       frameworkVersion: frameworkVersion,
       hostOsType: Platform.operatingSystem,


### PR DESCRIPTION
Don't report language version in language field, ie. report 'dart', not 'dart 2.14.0'
