### PR TITLE
RealmList.clear

### DIFF
--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -80,7 +80,11 @@ class RealmList<T extends Object> extends collection.ListBase<T> {
 
   @override
   void clear() {
-    throw UnimplementedError();
+    try {
+      realmCore.clear(this);
+    } on Exception catch (e) {
+      throw RealmException("Error deleting all items. Error: $e");
+    }
   }
 }
 

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -82,8 +82,8 @@ class RealmList<T extends Object> extends collection.ListBase<T> {
   void clear() {
     try {
       realmCore.clear(this);
-    } on Exception catch (e) {
-      throw RealmException("Error deleting all items. Error: $e");
+    } catch (e) {
+      throw RealmException("Error clearing items from collection. Error: $e");
     }
   }
 }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -385,7 +385,8 @@ class _RealmCore {
   }
 
   void clear(RealmList list) {
-    _realmLib.invokeGetBool(() => _realmLib.realm_list_remove_all(list.handle._pointer));
+    _realmLib
+        .invokeGetBool(() => _realmLib.realm_list_clear(list.handle._pointer));
   }
 }
 

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -384,6 +384,9 @@ class _RealmCore {
     });
   }
 
+  void clear(RealmList list) {
+    _realmLib.invokeGetBool(() => _realmLib.realm_list_remove_all(list.handle._pointer));
+  }
 }
 
 class LastError {

--- a/test/realm_test.dart
+++ b/test/realm_test.dart
@@ -552,5 +552,34 @@ Future<void> main([List<String>? args]) async {
       expect(() => realm.write(() => players[-1] = Person()), throws<RealmException>("Index out of range"));
       expect(() => realm.write(() => players[800] = Person()), throws<RealmException>());
     });
+
+     test('Lists clear objects', () {
+      var config = Configuration([Team.schema, Person.schema]);
+      var realm = Realm(config);
+
+      final team = Team()..name = "Team";
+      realm.write(() => realm.add(team));
+      final teams = realm.all<Team>();
+      expect(teams.length, 1);
+      final players = teams[0].players;
+      expect(players, isNotNull);
+      expect(players.length, 0);
+
+      realm.write(() => players.addAll([
+            Person()..name = "Michael Schumacher",
+            Person()..name = "Sebastian Vettel",
+            Person()..name = "Kimi Räikkönen"
+          ]));
+
+      expect(players.length, 3);
+      realm.write(() => players.clear());
+
+      expect(players.length, 0);
+      expect(teams[0].players.length, 0);
+
+      final allPersons = realm.all<Person>();
+      expect(allPersons.length, 0);
+      expect(allPersons.length, 0);     
+    });
   });
 }


### PR DESCRIPTION
RealmList.Clear implemented. Clears collection objects relations but not the objects themselves. (#58)