### PR TITLE
find should take object

### DIFF
--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -167,7 +167,7 @@ class Realm {
 
   bool get isClosed => realmCore.isRealmClosed(this);
 
-  T? find<T extends RealmObject>(String primaryKey) {
+  T? find<T extends RealmObject>(Object primaryKey) {
     RealmMetadata metadata = _getMetadata(T);
 
     final handle = realmCore.find(this, metadata.class_.key, primaryKey);


### PR DESCRIPTION
This fixes `realm.find<T>(String primaryKey)` to take object instead `realm.find<T>(Object primaryKey)`