### PR TITLE
Support realm object generation by default

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -10,4 +10,12 @@ targets:
           - lib/src/cli/metrics/metrics.dart
       realm_generator|realm_object_builder:
         generate_for:
-          - test/**.dart
+          include:
+builders:
+  realm_generator:
+    import: "package:realm_generator/realm_generator.dart"
+    builder_factories: ["generateRealmObjects"]
+    build_extensions: { ".dart": ["realm_objects.g.part"] }
+    auto_apply: dependents
+    build_to: cache
+    applies_builders: ["source_gen|combining_builder"]

--- a/example/myapp/build.yaml
+++ b/example/myapp/build.yaml
@@ -1,7 +1,0 @@
-targets:
-    $default:
-        builders:
-            realm_generator|realm_object_builder:
-                enabled: true
-                generate_for:
-                    - bin/*.dart 

--- a/example/myapp/pubspec.yaml
+++ b/example/myapp/pubspec.yaml
@@ -12,4 +12,3 @@ dependencies:
 
 dev_dependencies:
   lints: ^1.0.1
-  build_runner: ^2.1.2

--- a/flutter/realm_flutter/build.yaml
+++ b/flutter/realm_flutter/build.yaml
@@ -10,4 +10,12 @@ targets:
           - lib/src/cli/metrics/metrics.dart
       realm_generator|realm_object_builder:
         generate_for:
-          - test/**.dart
+          include:
+builders:
+  realm_generator:
+    import: "package:realm_generator/realm_generator.dart"
+    builder_factories: ["generateRealmObjects"]
+    build_extensions: { ".dart": ["realm_objects.g.part"] }
+    auto_apply: dependents
+    build_to: cache
+    applies_builders: ["source_gen|combining_builder"]

--- a/flutter/realm_flutter/example/pubspec.yaml
+++ b/flutter/realm_flutter/example/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.4
-  build_runner: ^2.1.2
+  build_runner: ^2.1.0
 
 flutter:
   uses-material-design: true

--- a/flutter/realm_flutter/pubspec.yaml
+++ b/flutter/realm_flutter/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   realm_generator: 
     path: ../../generator
   tar: 0.5.0
+  build_runner: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/flutter/realm_flutter/pubspec.yaml
+++ b/flutter/realm_flutter/pubspec.yaml
@@ -37,7 +37,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   build_cli: ^2.1.3
-  build_runner: ^2.1.2
   json_serializable: ^6.1.0
   lints: ^1.0.1
   test: ^1.20.1

--- a/lib/src/cli/generate/options.g.dart
+++ b/lib/src/cli/generate/options.g.dart
@@ -13,12 +13,13 @@ Options _$parseOptionsResult(ArgResults result) => Options()
 ArgParser _$populateOptionsParser(ArgParser parser) => parser
   ..addFlag(
     'clean',
-    help: "Same as running 'dart run build_runner clean'",
+    help:
+        "Optional. Cleans generator caches. Same as running 'dart run build_runner clean'",
   )
   ..addFlag(
     'watch',
     help:
-        "Same as running 'dart run build_runner watch --delete-conflicting-outputs'",
+        "Optional. Watches for changes and generates RealmObjects classes on the background. Same as running 'dart run build_runner watch --delete-conflicting-outputs'",
   );
 
 final _$parserForOptions = _$populateOptionsParser(ArgParser());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,10 +28,10 @@ dependencies:
   realm_generator: 
     path: ./generator
   tar: 0.5.0
+  build_runner: ^2.1.0
 
 dev_dependencies:
   build_cli: ^2.1.3
-  build_runner: ^2.1.2
   json_serializable: ^6.1.0
   lints: ^1.0.1
   test: ^1.14.3


### PR DESCRIPTION
This enables realm object generation after realm package is added to user project.
include build.yaml for realm_dart and realm package
removes dart example  build.yaml
leaves build.yaml for flutter example as an example for customized build.yaml
move build_runner as a dependency

This substitutes #211 