### PR TITLE
Fix premature realm close on Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ The Realm Flutter package name is `realm`
     var objects = realm.query<Item>("name == 'Special Item'");
     var name = 'John';
     var objects = realm.query<Item>(r'name == $0', [name]]);
+
+    // Close the realm
+    realm.close();
     ```
 
 # Realm Dart SDK 

--- a/example/myapp/bin/myapp.dart
+++ b/example/myapp/bin/myapp.dart
@@ -4,8 +4,7 @@ part 'myapp.g.dart';
 
 @RealmModel()
 class _MyCar {
-  @PrimaryKey()
-  late final String make;
+  late String make;
 }
 
 void main(List<String> arguments) {

--- a/example/myapp/bin/myapp.dart
+++ b/example/myapp/bin/myapp.dart
@@ -7,7 +7,7 @@ class _MyCar {
   late String make;
 }
 
-void main(List<String> arguments) {
+void main(List<String> arguments) async {
   var config = Configuration([MyCar.schema]);
   var realm = Realm(config);
 
@@ -19,10 +19,12 @@ void main(List<String> arguments) {
     car.make = "VW";
     print("The car is ${car.make}");
   });
-
+  await Future<void>.delayed(Duration(seconds: 1));
   var objects = realm.all<MyCar>();
   var indexedCar = objects[0];
   print('The indexedCar is ${indexedCar.make}');
 
+  realm.close();
+  
   print("Done");
 }

--- a/example/myapp/bin/myapp.g.dart
+++ b/example/myapp/bin/myapp.g.dart
@@ -10,7 +10,7 @@ class MyCar extends _MyCar with RealmObject {
   MyCar(
     String make,
   ) {
-    RealmObject.set(this, 'make', make);
+    this.make = make;
   }
 
   MyCar._();
@@ -18,14 +18,14 @@ class MyCar extends _MyCar with RealmObject {
   @override
   String get make => RealmObject.get<String>(this, 'make') as String;
   @override
-  set make(String value) => throw RealmUnsupportedSetError();
+  set make(String value) => RealmObject.set(this, 'make', value);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
     RealmObject.registerFactory(MyCar._);
     return const SchemaObject(MyCar, [
-      SchemaProperty('make', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('make', RealmPropertyType.string),
     ]);
   }
 }

--- a/flutter/realm_flutter/example/lib/main.dart
+++ b/flutter/realm_flutter/example/lib/main.dart
@@ -54,6 +54,8 @@ class _MyAppState extends State<MyApp> {
     var objects = realm.all<Car>();
     var indexedCar = objects[0];
     print("The indexedCar is ${indexedCar.make}");
+    
+    realm.close();
 
     super.initState();
   }

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -20,10 +20,9 @@ import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate';
 
-import 'package:realm_common/realm_common.dart';
-
-import 'results.dart';
+import '../realm.dart' show isFlutterPlatform;
 import 'configuration.dart';
+import 'results.dart';
 import 'realm_object.dart';
 import 'native/realm_core.dart';
 import 'list.dart';
@@ -256,8 +255,10 @@ class _Scheduler {
     final sendPort = receivePort.sendPort;
     handle = realmCore.createScheduler(Isolate.current.hashCode, sendPort.nativePort);
 
-    //We use this to receive a SCHEDULER_FINALIZE_OR_PROCESS_EXIT notification on process exit to close the receivePort or the process with hang.
-    Isolate.spawn(_handler, 2, onExit: sendPort);
+    if (!isFlutterPlatform) {
+      //On Dart we use this to receive a SCHEDULER_FINALIZE_OR_PROCESS_EXIT notification on process exit to close the receivePort or the process with hang.
+      Isolate.spawn(_handler, 2, onExit: sendPort);
+    }
 
     realmCore.setScheduler(config, handle);
   }

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate';
@@ -255,19 +256,12 @@ class _Scheduler {
     final sendPort = receivePort.sendPort;
     handle = realmCore.createScheduler(Isolate.current.hashCode, sendPort.nativePort);
 
-    if (!isFlutterPlatform) {
-      //On Dart we use this to receive a SCHEDULER_FINALIZE_OR_PROCESS_EXIT notification on process exit to close the receivePort or the process with hang.
-      Isolate.spawn(_handler, 2, onExit: sendPort);
-    }
-
     realmCore.setScheduler(config, handle);
   }
 
   void stop() {
     receivePort.close();
   }
-
-  static void _handler(int message) {}
 }
 
 /// @nodoc

--- a/test/realm_test.dart
+++ b/test/realm_test.dart
@@ -200,6 +200,7 @@ Future<void> main([List<String>? args]) async {
     test('Realm can be created', () {
       var config = Configuration([Car.schema]);
       var realm = Realm(config);
+      realm.close();
     });
 
     test('Realm can be closed', () {
@@ -221,6 +222,7 @@ Future<void> main([List<String>? args]) async {
 
       //should not throw exception
       realm = Realm(config);
+      realm.close();
     });
 
     test('Realm is closed', () {
@@ -239,6 +241,7 @@ Future<void> main([List<String>? args]) async {
 
       config = Configuration([Car.schema]);
       realm = Realm(config);
+      realm.close();
     });
 
     test('Realm open with schema superset', () {
@@ -248,6 +251,7 @@ Future<void> main([List<String>? args]) async {
 
       var config1 = Configuration([Person.schema, Car.schema]);
       var realm1 = Realm(config1);
+      realm1.close();
     });
 
     test('Realm open twice with same schema', () async {
@@ -256,6 +260,8 @@ Future<void> main([List<String>? args]) async {
 
       var config1 = Configuration([Person.schema, Car.schema]);
       var realm1 = Realm(config1);
+      realm.close();
+      realm1.close();
     });
 
     test('Realm add throws when no write transaction', () {
@@ -263,6 +269,7 @@ Future<void> main([List<String>? args]) async {
       var realm = Realm(config);
       final car = Car('');
       expect(() => realm.add(car), throws<RealmException>("Wrong transactional state"));
+      realm.close();
     });
 
     test('Realm add object', () {
@@ -272,6 +279,8 @@ Future<void> main([List<String>? args]) async {
       realm.write(() {
         realm.add(Car(''));
       });
+
+      realm.close();
     });
 
     test('Realm add multiple objects', () {
@@ -294,6 +303,8 @@ Future<void> main([List<String>? args]) async {
       for (int i = 0; i < cars.length; ++i) {
         expect(allCars[i].make, cars[i].make);
       }
+
+      realm.close();
     });
 
     test('Realm add object twice does not throw', () {
@@ -308,6 +319,8 @@ Future<void> main([List<String>? args]) async {
         final car1 = realm.add(car);
         expect(car1, equals(car));
       });
+
+      realm.close();
     });
 
     test('Realm adding not configured object throws exception', () {
@@ -315,6 +328,7 @@ Future<void> main([List<String>? args]) async {
       var realm = Realm(config);
 
       expect(() => realm.write(() => realm.add(Person(''))), throws<RealmException>("not configured"));
+      realm.close();
     });
 
     test('Realm add() returns the same object', () {
@@ -328,6 +342,8 @@ Future<void> main([List<String>? args]) async {
       });
 
       expect(addedCar == car, isTrue);
+
+      realm.close();
     });
 
     test('Realm add object transaction rollbacks on exception', () {
@@ -343,6 +359,8 @@ Future<void> main([List<String>? args]) async {
 
       final car = realm.find<Car>("Telsa");
       expect(car, isNull);
+
+      realm.close();
     });
 
     test('Realm adding objects with duplicate primary keys throws', () {
@@ -353,6 +371,8 @@ Future<void> main([List<String>? args]) async {
       final carTwo = Car("Toyota");
       realm.write(() => realm.add(carOne));
       expect(() => realm.write(() => realm.add(carTwo)), throws<RealmException>());
+
+      realm.close();
     });
 
     test('RealmObject get property', () {
@@ -365,6 +385,8 @@ Future<void> main([List<String>? args]) async {
       });
 
       expect(car.make, equals('Tesla'));
+
+      realm.close();
     });
 
     test('RealmObject set property', () {
@@ -383,6 +405,8 @@ Future<void> main([List<String>? args]) async {
           car.make = "Audi"; // setting late final is a runtime error :-/
         });
       }, throws<RealmUnsupportedSetError>());
+
+      realm.close();
     });
 
     test('RealmObject set object type property (link)', () {
@@ -400,6 +424,8 @@ Future<void> main([List<String>? args]) async {
       expect(dog.name, 'MyDog');
       expect(dog.owner, isNotNull);
       expect(dog.owner!.name, 'MyOwner');
+
+      realm.close();
     });
 
     test('RealmObject set property null', () {
@@ -431,6 +457,8 @@ Future<void> main([List<String>? args]) async {
       });
 
       expect(dog.owner, null);
+
+      realm.close();
     });
 
     test('Realm find object by primary key', () {
@@ -441,6 +469,8 @@ Future<void> main([List<String>? args]) async {
 
       final car = realm.find<Car>("Opel");
       expect(car, isNotNull);
+
+      realm.close();
     });
 
     test('Realm find not configured object by primary key throws exception', () {
@@ -448,6 +478,8 @@ Future<void> main([List<String>? args]) async {
       var realm = Realm(config);
 
       expect(() => realm.find<Person>("Me"), throws<RealmException>("not configured"));
+
+      realm.close();
     });
 
     test('Realm find object by primary key default value', () {
@@ -459,6 +491,8 @@ Future<void> main([List<String>? args]) async {
       final car = realm.find<Car>("Tesla");
       expect(car, isNotNull);
       expect(car?.make, equals("Tesla"));
+
+      realm.close();
     });
 
     test('Realm find non existing object by primary key returns null', () {
@@ -469,6 +503,8 @@ Future<void> main([List<String>? args]) async {
 
       final car = realm.find<Car>("NonExistingPrimaryKey");
       expect(car, isNull);
+
+      realm.close();
     });
 
     test('Realm delete object', () {
@@ -485,6 +521,8 @@ Future<void> main([List<String>? args]) async {
 
       var car2 = realm.find<Car>("SomeNewNonExistingValue");
       expect(car2, isNull);
+
+      realm.close();
     });
 
     test('Results.all() should not return null', () {
@@ -493,6 +531,8 @@ Future<void> main([List<String>? args]) async {
 
       final cars = realm.all<Car>();
       expect(cars, isNotNull);
+
+      realm.close();
     });
 
     test('Results length after deletedMany', () {
@@ -516,6 +556,8 @@ Future<void> main([List<String>? args]) async {
       expect(filteredCars.length, 0);
 
       expect(cars.length, 1);
+
+      realm.close();
     });
 
     test('Results length', () {
@@ -533,6 +575,8 @@ Future<void> main([List<String>? args]) async {
 
       final filteredCars = realm.query<Car>('make == "Toyota"');
       expect(filteredCars.length, 1);
+
+      realm.close();
     });
 
     test('Results isEmpty', () {
@@ -550,6 +594,8 @@ Future<void> main([List<String>? args]) async {
       realm.write(() => realm.delete(car));
 
       expect(cars.isEmpty, true);
+
+      realm.close();
     });
 
     test('Results from query isEmpty', () {
@@ -572,6 +618,8 @@ Future<void> main([List<String>? args]) async {
 
       dogs = realm.all<Dog>();
       expect(dogs.isEmpty, false);
+
+      realm.close();
     });
 
     test('Results get by index', () {
@@ -583,6 +631,8 @@ Future<void> main([List<String>? args]) async {
 
       final cars = realm.all<Car>();
       expect(cars[0].make, car.make);
+
+      realm.close();
     });
 
     group('Query and sort tests:', () {
@@ -595,6 +645,8 @@ Future<void> main([List<String>? args]) async {
         final cars = realm.all<Car>().query('make == "Tesla"');
         expect(cars.length, 1);
         expect(cars[0].make, "Tesla");
+
+        realm.close();
       });
 
       test('Query class', () {
@@ -606,6 +658,8 @@ Future<void> main([List<String>? args]) async {
         final cars = realm.query<Car>('make == "Tesla"');
         expect(cars.length, 1);
         expect(cars[0].make, "Tesla");
+
+        realm.close();
       });
 
       test('Query results with parameter', () {
@@ -617,6 +671,8 @@ Future<void> main([List<String>? args]) async {
         final cars = realm.all<Car>().query(r'make == $0', ['Tesla']);
         expect(cars.length, 1);
         expect(cars[0].make, "Tesla");
+
+        realm.close();
       });
 
       test('Query results with multiple parameters', () {
@@ -638,6 +694,8 @@ Future<void> main([List<String>? args]) async {
         final filteredTeams = realm.all<Team>().query(r'$0 IN players AND name BEGINSWITH $1', [x, 'A']);
         expect(filteredTeams.length, 1);
         expect(filteredTeams, [t1]);
+
+        realm.close();
       });
 
       test('Query class with parameter', () {
@@ -649,6 +707,8 @@ Future<void> main([List<String>? args]) async {
         final cars = realm.query<Car>(r'make == $0', ['Tesla']);
         expect(cars.length, 1);
         expect(cars[0].make, "Tesla");
+
+        realm.close();
       });
 
       test('Query class with multiple parameters', () {
@@ -680,6 +740,8 @@ Future<void> main([List<String>? args]) async {
         final filteredTeams = realm.query<Team>(r'$0 IN players AND name BEGINSWITH $1', [x, 'A']);
         expect(filteredTeams.length, 1);
         expect(filteredTeams[0].name, "A1");
+
+        realm.close();
       });
 
       test('Query results with no arguments throws', () {
@@ -687,6 +749,8 @@ Future<void> main([List<String>? args]) async {
         var realm = Realm(config);
         realm.write(() => realm.add(Car("Audi")));
         expect(() => realm.all<Car>().query(r'make == $0'), throws<RealmException>("no arguments are provided"));
+
+        realm.close();
       });
 
       test('Query results with wrong argument types (int for string) throws', () {
@@ -694,6 +758,7 @@ Future<void> main([List<String>? args]) async {
         var realm = Realm(config);
         realm.write(() => realm.add(Car("Audi")));
         expect(() => realm.all<Car>().query(r'make == $0', [1]), throws<RealmException>("Unsupported comparison between type"));
+        realm.close();
       });
 
       test('Query results with wrong argument types (bool for int) throws ', () {
@@ -701,6 +766,7 @@ Future<void> main([List<String>? args]) async {
         var realm = Realm(config);
         realm.write(() => realm.add(Dog("Foxi")));
         expect(() => realm.all<Dog>().query(r'age == $0', [true]), throws<RealmException>("Unsupported comparison between type"));
+        realm.close();
       });
 
       test('Sort result', () {
@@ -717,6 +783,7 @@ Future<void> main([List<String>? args]) async {
         final resultNames = result.map((p) => p.name).toList();
         final sortedNames = [...resultNames]..sort();
         expect(resultNames, sortedNames);
+        realm.close();
       });
 
       test('Sort order preserved under db ops', () {
@@ -749,6 +816,7 @@ Future<void> main([List<String>? args]) async {
 
         expect(result, isNot(orderedEquals(snapshot)));
         expect(result, containsAllInOrder(snapshot));
+        realm.close();
       });
     });
     test('Lists create object with a list property', () {
@@ -763,6 +831,7 @@ Future<void> main([List<String>? args]) async {
       expect(teams[0].name, "Ferrari");
       expect(teams[0].players, isNotNull);
       expect(teams[0].players.length, 0);
+      realm.close();
     });
 
     test('RealmObject add with list properties', () {
@@ -787,6 +856,7 @@ Future<void> main([List<String>? args]) async {
       expect(teams[0].scores[0], 1);
       expect(teams[0].scores[1], 2);
       expect(teams[0].scores[2], 3);
+      realm.close();
     });
 
     test('Lists get set', () {
@@ -815,6 +885,7 @@ Future<void> main([List<String>? args]) async {
       expect(players[0].name, "Michael");
       expect(players[1].name, "Sebastian");
       expect(players[2].name, "Kimi");
+      realm.close();
     });
 
     test('Lists get invalid index throws exception', () {
@@ -829,6 +900,7 @@ Future<void> main([List<String>? args]) async {
 
       expect(() => players[-1], throws<RealmException>("Index out of range"));
       expect(() => players[800], throws<RealmException>());
+      realm.close();
     });
 
     test('Lists set invalid index throws', () {
@@ -843,6 +915,7 @@ Future<void> main([List<String>? args]) async {
 
       expect(() => realm.write(() => players[-1] = Person('')), throws<RealmException>("Index out of range"));
       expect(() => realm.write(() => players[800] = Person('')), throws<RealmException>());
+      realm.close();
     });
 
     test('List clear items from list', () {
@@ -880,6 +953,7 @@ Future<void> main([List<String>? args]) async {
       //Ensure that players objects still exist in realm detached from the team
       final allPlayers = realm.all<Person>();
       expect(allPlayers.length, 3);
+      realm.close();
     });
 
     test('List clear - same list related to two objects', () {
@@ -923,6 +997,7 @@ Future<void> main([List<String>? args]) async {
       //Ensure players still exist in realm
       final players = realm.all<Person>();
       expect(players.length, 3);
+      realm.close();
     });
 
     test('List clear - same item added to two lists', () {
@@ -963,6 +1038,7 @@ Future<void> main([List<String>? args]) async {
       //Ensure the player still exists in realm
       final allPlayers = realm.all<Person>();
       expect(allPlayers.length, 1);
+      realm.close();
     });
 
     test('List clear in closed realm - expected exception', () {
@@ -999,6 +1075,7 @@ Future<void> main([List<String>? args]) async {
       //Ensure that the team is still related to the player
       expect(teams.length, 1);
       expect(teams[0].players.length, 1);
+      realm.close();
     });
 
     test('Realm.deleteMany from iterable', () {
@@ -1025,6 +1102,7 @@ Future<void> main([List<String>? args]) async {
       //Ensure both teams are deleted and only teamTwo has left
       expect(teams.length, 1);
       expect(teams[0].name, teamTwo.name);
+      realm.close();
     });
 
     test('Realm.deleteMany from realm list', () {
@@ -1056,6 +1134,7 @@ Future<void> main([List<String>? args]) async {
       //Reload all persons from realm and ensure they are deleted
       final allPersons = realm.all<Person>();
       expect(allPersons.length, 0);
+      realm.close();
     });
 
     test('Realm.deleteMany from list referenced by two objects', () {
@@ -1094,6 +1173,7 @@ Future<void> main([List<String>? args]) async {
       //Reload all persons from realm and ensure they are deleted
       final allPersons = realm.all<Person>();
       expect(allPersons.length, 0);
+      realm.close();
     });
 
     test('Realm.deleteMany from results', () {
@@ -1117,6 +1197,7 @@ Future<void> main([List<String>? args]) async {
       //Reload teams from realm and ensure they are deleted
       teams = realm.all<Team>();
       expect(teams.length, 0);
+      realm.close();
     });
 
     test('Realm.deleteMany from list after realm is closed', () {
@@ -1152,6 +1233,7 @@ Future<void> main([List<String>? args]) async {
       realm = Realm(config);
       final allPersons = realm.all<Person>();
       expect(allPersons.length, 3);
+      realm.close();
     });
 
     test('Results iteration test', () {
@@ -1176,6 +1258,7 @@ Future<void> main([List<String>? args]) async {
 
       //Ensure list size is the same like teams collection size
       expect(list.length, teams.length);
+      realm.close();
     });
 
     test('Realm existsSync', () {
@@ -1183,6 +1266,7 @@ Future<void> main([List<String>? args]) async {
       expect(Realm.existsSync(config.path), false);
       var realm = Realm(config);
       expect(Realm.existsSync(config.path), true);
+      realm.close();
     });
 
     test('Realm exists', () async {
@@ -1190,6 +1274,7 @@ Future<void> main([List<String>? args]) async {
       expect(await Realm.exists(config.path), false);
       var realm = Realm(config);
       expect(await Realm.exists(config.path), true);
+      realm.close();
     });
 
     test('Realm deleteRealm succeeds', () {
@@ -1211,6 +1296,7 @@ Future<void> main([List<String>? args]) async {
 
       expect(File(config.path).existsSync(), true);
       expect(Directory("${config.path}.management").existsSync(), true);
+      realm.close();
     });
 
     test('Equals', () {
@@ -1237,6 +1323,7 @@ Future<void> main([List<String>? args]) async {
       final read = realm.query<Person>("name == 'Kasper'");
 
       expect(read, [person]);
+      realm.close();
     });
   });
   group('Cycle referenced objects tests:', () {
@@ -1289,6 +1376,7 @@ Future<void> main([List<String>? args]) async {
       expect(mainSchools[0].branches.length, 2);
       expect(mainSchools[0].students.length, 3);
       expect(mainSchools[0].branches[0].students.length + mainSchools[0].branches[1].students.length, 3);
+      realm.close();
     });
   });
 }


### PR DESCRIPTION
Fixes premature realm close in Flutter
Also update example to not include primarykeys to support multiple re-runs