### PR TITLE
Use dart specific C api for notification callbacks

### DIFF
--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -6052,6 +6052,38 @@ class RealmLibrary {
   late final _dart_get_thread_id _get_thread_id =
       _get_thread_id_ptr.asFunction<_dart_get_thread_id>();
 
+  /// Subscribe for notifications of changes to a realm results collection.
+  ///
+  /// @param results The realm results to subscribe to.
+  /// @param userdata A handle to dart object that will be passed to the callback.
+  /// @param on_change The callback to invoke, if the realm results changes.
+  /// @return A notification token that can be released to unsubscribe.
+  ///
+  /// This is a dart specific wrapper for realm_results_add_notification_callback.
+  ffi.Pointer<realm_notification_token>
+      realm_dart_results_add_notification_callback(
+    ffi.Pointer<realm_results> results,
+    Object userdata,
+    ffi.Pointer<ffi.NativeFunction<realm_dart_on_collection_change_func_t>>
+        on_change,
+    ffi.Pointer<realm_scheduler> scheduler,
+  ) {
+    return _realm_dart_results_add_notification_callback(
+      results,
+      userdata,
+      on_change,
+      scheduler,
+    );
+  }
+
+  late final _realm_dart_results_add_notification_callback_ptr = _lookup<
+          ffi.NativeFunction<_c_realm_dart_results_add_notification_callback>>(
+      'realm_dart_results_add_notification_callback');
+  late final _dart_realm_dart_results_add_notification_callback
+      _realm_dart_results_add_notification_callback =
+      _realm_dart_results_add_notification_callback_ptr
+          .asFunction<_dart_realm_dart_results_add_notification_callback>();
+
   ffi.Pointer<ffi.Int8> realm_dart_get_files_path() {
     return _realm_dart_get_files_path();
   }
@@ -10080,6 +10112,29 @@ typedef _dart_realm_dart_scheduler_invoke = void Function(
 typedef _c_get_thread_id = ffi.Uint64 Function();
 
 typedef _dart_get_thread_id = int Function();
+
+typedef realm_dart_on_collection_change_func_t = ffi.Void Function(
+  ffi.Handle,
+  ffi.Pointer<realm_collection_changes>,
+);
+
+typedef _c_realm_dart_results_add_notification_callback
+    = ffi.Pointer<realm_notification_token> Function(
+  ffi.Pointer<realm_results> results,
+  ffi.Handle userdata,
+  ffi.Pointer<ffi.NativeFunction<realm_dart_on_collection_change_func_t>>
+      on_change,
+  ffi.Pointer<realm_scheduler> scheduler,
+);
+
+typedef _dart_realm_dart_results_add_notification_callback
+    = ffi.Pointer<realm_notification_token> Function(
+  ffi.Pointer<realm_results> results,
+  Object userdata,
+  ffi.Pointer<ffi.NativeFunction<realm_dart_on_collection_change_func_t>>
+      on_change,
+  ffi.Pointer<realm_scheduler> scheduler,
+);
 
 typedef _c_realm_dart_get_files_path = ffi.Pointer<ffi.Int8> Function();
 

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -6084,6 +6084,38 @@ class RealmLibrary {
       _realm_dart_results_add_notification_callback_ptr
           .asFunction<_dart_realm_dart_results_add_notification_callback>();
 
+  /// Subscribe for notifications of changes to a realm list collection.
+  ///
+  /// @param list The realm list to subscribe to.
+  /// @param userdata A handle to dart object that will be passed to the callback.
+  /// @param on_change The callback to invoke, if the realm list changes.
+  /// @return A notification token that can be released to unsubscribe.
+  ///
+  /// This is a dart specific wrapper for realm_list_add_notification_callback.
+  ffi.Pointer<realm_notification_token>
+      realm_dart_list_add_notification_callback(
+    ffi.Pointer<realm_list> list,
+    Object userdata,
+    ffi.Pointer<ffi.NativeFunction<realm_dart_on_collection_change_func_t>>
+        on_change,
+    ffi.Pointer<realm_scheduler> scheduler,
+  ) {
+    return _realm_dart_list_add_notification_callback(
+      list,
+      userdata,
+      on_change,
+      scheduler,
+    );
+  }
+
+  late final _realm_dart_list_add_notification_callback_ptr =
+      _lookup<ffi.NativeFunction<_c_realm_dart_list_add_notification_callback>>(
+          'realm_dart_list_add_notification_callback');
+  late final _dart_realm_dart_list_add_notification_callback
+      _realm_dart_list_add_notification_callback =
+      _realm_dart_list_add_notification_callback_ptr
+          .asFunction<_dart_realm_dart_list_add_notification_callback>();
+
   ffi.Pointer<ffi.Int8> realm_dart_get_files_path() {
     return _realm_dart_get_files_path();
   }
@@ -10130,6 +10162,24 @@ typedef _c_realm_dart_results_add_notification_callback
 typedef _dart_realm_dart_results_add_notification_callback
     = ffi.Pointer<realm_notification_token> Function(
   ffi.Pointer<realm_results> results,
+  Object userdata,
+  ffi.Pointer<ffi.NativeFunction<realm_dart_on_collection_change_func_t>>
+      on_change,
+  ffi.Pointer<realm_scheduler> scheduler,
+);
+
+typedef _c_realm_dart_list_add_notification_callback
+    = ffi.Pointer<realm_notification_token> Function(
+  ffi.Pointer<realm_list> list,
+  ffi.Handle userdata,
+  ffi.Pointer<ffi.NativeFunction<realm_dart_on_collection_change_func_t>>
+      on_change,
+  ffi.Pointer<realm_scheduler> scheduler,
+);
+
+typedef _dart_realm_dart_list_add_notification_callback
+    = ffi.Pointer<realm_notification_token> Function(
+  ffi.Pointer<realm_list> list,
   Object userdata,
   ffi.Pointer<ffi.NativeFunction<realm_dart_on_collection_change_func_t>>
       on_change,

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -21,6 +21,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi';
+import 'dart:ffi' as ffi show Handle;
 import 'dart:typed_data';
 
 // Hide StringUtf8Pointer.toNativeUtf8 and StringUtf16Pointer since these allows to sliently allocating memory. Use toUtf8Ptr instead
@@ -62,7 +63,6 @@ class _RealmCore {
   factory _RealmCore() {
     return _instance ??= _RealmCore._();
   }
-  //
 
   String get libraryVersion => _realmLib.realm_get_library_version().cast<Utf8>().toDartString();
 
@@ -482,28 +482,18 @@ class _RealmCore {
   }
 
   Stream<RealmCollectionChanges> resultsChanges(RealmResults results, SchedulerHandle scheduler) {
-    late StreamController<RealmCollectionChanges> controller;
-
-    void callback(Pointer<Void> data) {
-      final changes = RealmCollectionChanges(
-        RealmCollectionChangesHandle._(_realmLib.realm_clone(data).cast()),
+    return buildStream(
+      (Pointer<realm_collection_changes> data) => RealmCollectionChanges(
+        RealmCollectionChangesHandle._(_realmLib.realm_clone(data.cast()).cast()),
         results.realm,
-      );
-      controller.add(changes);
-    }
-
-    controller = _constructRealmNotificationStreamController(
-        (userData, callback, free, error) => _realmLib.realm_results_add_notification_callback(
-              results.handle._pointer,
-              userData,
-              free,
-              callback.cast(),
-              error,
-              scheduler._pointer,
-            ),
-        callback);
-
-    return controller.stream;
+      ),
+      (userdata) => RealmNotificationTokenHandle._(_realmLib.realm_dart_results_add_notification_callback(
+        results.handle._pointer,
+        userdata,
+        realmCollectionChangesTrampoline,
+        scheduler._pointer,
+      )),
+    );
   }
 
   Stream<RealmCollectionChanges> listChanges(RealmList list, SchedulerHandle scheduler) {
@@ -671,7 +661,7 @@ class RealmQueryHandle extends Handle<realm_query> {
 }
 
 class RealmNotificationTokenHandle extends Handle<realm_notification_token> {
-  RealmNotificationTokenHandle._(Pointer<realm_notification_token> pointer) : super(pointer, 1 << 24); // TODO: What should gc hint be?
+  RealmNotificationTokenHandle._(Pointer<realm_notification_token> pointer) : super(pointer, 1 << 28); // TODO: What should gc hint be?
 }
 
 class RealmCollectionChangesHandle extends Handle<realm_collection_changes> {
@@ -795,4 +785,52 @@ extension _realm_value_t_ex on Pointer<realm_value_t> {
         throw RealmException("realm_value_type ${ref.type} not supported");
     }
   }
+}
+
+final realmCollectionChangesTrampoline = Pointer.fromFunction<Void Function(ffi.Handle, Pointer<realm_collection_changes>)>(_realmCollectionChangesTrampoline);
+
+// The compiler is too dumb to use trampoline<realm_collection_changes> with ffi directly
+void _realmCollectionChangesTrampoline(Object? userdata, Pointer<realm_collection_changes> changes) => 
+  trampoline(userdata, changes);
+
+void trampoline<T extends NativeType>(Object? userdata, Pointer<T> changes) {
+  // Cannot check for null on the native side, since _DL version of Dart_IsNull doesn't exist :-/
+  if (userdata != null) {
+    final callback = userdata as void Function(Pointer<T>);
+    callback(changes);
+  }
+}
+
+Stream<T> buildStream<T, U extends NativeType, TokenT extends Handle>(
+  T Function(U) convert,
+  TokenT Function(Object userdata) subscribe,
+) {
+  late StreamController<T> controller;
+
+  void onChange(U data) {
+    final changes = convert(data);
+    controller.add(changes);
+  }
+
+  TokenT? token;
+  void start() {
+    token ??= subscribe(onChange);
+  }
+
+  void stop() {
+    final t = token;
+    if (t != null) {
+      t.releaseEarly();
+      token = null;
+    }
+  }
+
+  controller = StreamController<T>(
+    onListen: start,
+    onPause: stop,
+    onResume: start,
+    onCancel: stop,
+  );
+
+  return controller.stream;
 }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -497,28 +497,18 @@ class _RealmCore {
   }
 
   Stream<RealmCollectionChanges> listChanges(RealmList list, SchedulerHandle scheduler) {
-    late StreamController<RealmCollectionChanges> controller;
-
-    void callback(Pointer<Void> data) {
-      final changes = RealmCollectionChanges(
-        RealmCollectionChangesHandle._(_realmLib.realm_clone(data).cast()),
+    return buildStream(
+      (Pointer<realm_collection_changes> data) => RealmCollectionChanges(
+        RealmCollectionChangesHandle._(_realmLib.realm_clone(data.cast()).cast()),
         list.realm,
-      );
-      controller.add(changes);
-    }
-
-    controller = _constructRealmNotificationStreamController(
-        (userData, callback, free, error) => _realmLib.realm_list_add_notification_callback(
-              list.handle._pointer,
-              userData,
-              free,
-              callback.cast(),
-              error,
-              scheduler._pointer,
-            ),
-        callback);
-
-    return controller.stream;
+      ),
+      (userdata) => RealmNotificationTokenHandle._(_realmLib.realm_dart_list_add_notification_callback(
+        list.handle._pointer,
+        userdata,
+        realmCollectionChangesTrampoline,
+        scheduler._pointer,
+      )),
+    );
   }
 
   RealmLinkHandle _getObjectAsLink(RealmObject object) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,14 @@
 set(SOURCES
      realm_dart.cpp
      realm_dart_scheduler.cpp
+     realm_dart_collections.cpp
      dart-include/dart_api_dl.c
 )
 
 set(HEADERS
     realm_dart.h
     realm_dart_scheduler.h
+    realm_dart_collections.h
     realm-core/src/realm.h
 )
 

--- a/src/realm_dart_collections.cpp
+++ b/src/realm_dart_collections.cpp
@@ -100,3 +100,18 @@ realm_dart_results_add_notification_callback(realm_results_t *results,
                                                    nullptr, // on_error never called by realm core 6+
                                                    scheduler);
 }
+
+RLM_API realm_notification_token_t *
+realm_dart_list_add_notification_callback(realm_list_t *list,
+                                          Dart_Handle userdata,
+                                          realm_dart_on_collection_change_func_t on_change,
+                                          realm_scheduler_t *scheduler)
+{
+    auto callback = new Callback{userdata, on_change};
+    return realm_list_add_notification_callback(list,
+                                                callback,
+                                                free_,
+                                                on_change_,
+                                                nullptr, // on_error never called by realm core 6+
+                                                scheduler);
+}

--- a/src/realm_dart_collections.cpp
+++ b/src/realm_dart_collections.cpp
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "realm.h"
+#include "dart_api_dl.h"
+#include "realm_dart_collections.h"
+
+struct Scope
+{
+    Scope()
+    {
+        Dart_EnterScope_DL();
+    }
+    ~Scope()
+    {
+        Dart_ExitScope_DL();
+    }
+};
+
+class Callback
+{
+    Dart_WeakPersistentHandle handle_;
+    realm_dart_on_collection_change_func_t callback_;
+
+    static void finalize_(void *isolate_callback_data, void *peer)
+    {
+        auto &callback = *reinterpret_cast<Callback *>(peer);
+        callback.drop_handle();
+    }
+
+    void drop_handle()
+    {
+        if (handle_ != nullptr)
+        {
+            Dart_DeleteWeakPersistentHandle_DL(handle_);
+            handle_ = nullptr;
+        }
+    }
+
+public:
+    Callback(Dart_Handle handle, realm_dart_on_collection_change_func_t callback)
+        : handle_(Dart_NewWeakPersistentHandle_DL(handle, this, 1 << 24, finalize_)), callback_(callback) {}
+
+    ~Callback()
+    {
+        drop_handle();
+    }
+
+    void operator()(const realm_collection_changes_t *changes)
+    {
+        if (handle_ != nullptr)
+        {
+            Scope s; // ensure we can create handles
+            auto h = Dart_HandleFromWeakPersistent_DL(handle_);
+            // Note Dart_IsNull(h) is not exposed in DL, so we cannot check.
+            // Hence the callback has to be prepared for this eventuality.
+            callback_(h, changes);
+        }
+    }
+};
+
+void on_change_(void *userdata, const realm_collection_changes_t *changes)
+{
+    auto &callback = *reinterpret_cast<Callback *>(userdata);
+    callback(changes);
+}
+
+void free_(void *userdata)
+{
+    auto callback = reinterpret_cast<Callback *>(userdata);
+    delete callback;
+}
+
+RLM_API realm_notification_token_t *
+realm_dart_results_add_notification_callback(realm_results_t *results,
+                                             Dart_Handle userdata,
+                                             realm_dart_on_collection_change_func_t on_change,
+                                             realm_scheduler_t *scheduler)
+{
+    auto callback = new Callback{userdata, on_change};
+    return realm_results_add_notification_callback(results,
+                                                   callback,
+                                                   free_,
+                                                   on_change_,
+                                                   nullptr, // on_error never called by realm core 6+
+                                                   scheduler);
+}

--- a/src/realm_dart_collections.h
+++ b/src/realm_dart_collections.h
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_DART_COLLECTIONS_H
+#define REALM_DART_COLLECTIONS_H
+
+#include "realm.h"
+#include "dart_api_dl.h"
+
+typedef void (*realm_dart_on_collection_change_func_t)(Dart_Handle userdata, const realm_collection_changes_t *);
+
+/**
+ * Subscribe for notifications of changes to a realm results collection.
+ *
+ * @param results The realm results to subscribe to.
+ * @param userdata A handle to dart object that will be passed to the callback.
+ * @param on_change The callback to invoke, if the realm results changes.
+ * @return A notification token that can be released to unsubscribe.
+ *
+ * This is a dart specific wrapper for realm_results_add_notification_callback.
+ */
+RLM_API realm_notification_token_t *
+realm_dart_results_add_notification_callback(realm_results_t *results,
+                                             Dart_Handle userdata,
+                                             realm_dart_on_collection_change_func_t on_change,
+                                             realm_scheduler_t *scheduler);
+
+#endif // REALM_DART_COLLECTIONS_H

--- a/src/realm_dart_collections.h
+++ b/src/realm_dart_collections.h
@@ -40,4 +40,20 @@ realm_dart_results_add_notification_callback(realm_results_t *results,
                                              realm_dart_on_collection_change_func_t on_change,
                                              realm_scheduler_t *scheduler);
 
+/**
+ * Subscribe for notifications of changes to a realm list collection.
+ *
+ * @param list The realm list to subscribe to.
+ * @param userdata A handle to dart object that will be passed to the callback.
+ * @param on_change The callback to invoke, if the realm list changes.
+ * @return A notification token that can be released to unsubscribe.
+ *
+ * This is a dart specific wrapper for realm_list_add_notification_callback.
+ */
+RLM_API realm_notification_token_t *
+realm_dart_list_add_notification_callback(realm_list_t *list,
+                                          Dart_Handle userdata,
+                                          realm_dart_on_collection_change_func_t on_change,
+                                          realm_scheduler_t *scheduler);
+
 #endif // REALM_DART_COLLECTIONS_H


### PR DESCRIPTION
This has the advantage of not needing the static map in CallbackBridge, and hence no extra cleanup is needed dart side.

Another advantage is that we don't have to wait for dart side WeakReference in 2.17, since we can use the native side Dart_WeakPersistentHandle that already exists.

The extra C/C++ code is fairly negligible.