### PR TITLE
line 38 causes error with CMAKE<3.19

### DIFF
--- a/flutter/realm_flutter/windows/CMakeLists.txt
+++ b/flutter/realm_flutter/windows/CMakeLists.txt
@@ -35,7 +35,7 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 execute_process(COMMAND "${FLUTTER_ROOT}\\bin\\flutter.bat" "pub" "run" "realm" "install" "--target-os-type" "windows" "--package-name" "realm" #"--debug"
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
-  COMMAND_ERROR_IS_FATAL ANY
+  # COMMAND_ERROR_IS_FATAL ANY
 )
 message(STATUS "cmd output: ${output}")
 message(STATUS "cmd result: ${result}")


### PR DESCRIPTION
COMMAND_ERROR_IS_FATAL, found on line 38, causes an error with CMAKE version < 3.19
See https://cmake.org/cmake/help/v3.18/command/execute_process.html compared to https://cmake.org/cmake/help/v3.19/command/execute_process.html
Since it has already been commented out on line 49, commenting it out on line 38 too could be an idea for solving the issue.
Alternatively the user should be asked to update CMAKE