### PR TITLE
Fix write inside write rollback; expose Realm.isInTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 * Support result value from write transaction callbacks ([#294](https://github.com/realm/realm-dart/pull/294/))
+* Added a property `Realm.isInTransaction` that indicates whether the Realm instance has an open write transaction associated with it.
 
 ### Fixed
-* None
+* Fixed an issue that would result in the wrong transaction being rolled back if you start a write transaction inside a write transaction. (Issue [#442](https://github.com/realm/realm-dart/issues/442))
 
 ### Compatibility
 * Dart ^2.15 on Windows, MacOS and Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Added a property `Realm.isInTransaction` that indicates whether the Realm instance has an open write transaction associated with it.
 
 ### Fixed
-* Fixed an issue that would result in the wrong transaction being rolled back if you start a write transaction inside a write transaction. (Issue [#442](https://github.com/realm/realm-dart/issues/442))
+* Fixed an issue that would result in the wrong transaction being rolled back if you start a write transaction inside a write transaction. ([#442](https://github.com/realm/realm-dart/issues/442))
 
 ### Compatibility
 * Dart ^2.15 on Windows, MacOS and Linux

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -70,7 +70,7 @@ class Realm {
       _scheduler.stop();
       rethrow;
     }
-    _config.isInUse = true;    
+    _config.isInUse = true;
   }
 
   /// Deletes all files associated with a `Realm` located at given [path]
@@ -164,22 +164,22 @@ class Realm {
     }
   }
 
-  bool get _isInTransaction => realmCore.getIsWritable(this);
+  /// Checks whether the `Realm` is in write transaction.
+  bool get isInTransaction => realmCore.getIsWritable(this);
 
   /// Synchronously calls the provided callback inside a write transaction.
   ///
   /// If no exception is thrown from within the callback, the transaction will be committed.
   /// It is more efficient to update several properties or even create multiple objects in a single write transaction.
   T write<T>(T Function() writeCallback) {
+    final transaction = Transaction._(this);
+
     try {
-      realmCore.beginWrite(this);
       T result = writeCallback();
-      realmCore.commitWrite(this);
+      transaction.commit();
       return result;
     } catch (e) {
-      if (_isInTransaction) {
-        realmCore.rollbackWrite(this);
-      }
+      transaction.rollback();
       rethrow;
     }
   }
@@ -277,6 +277,34 @@ class Scheduler {
 
   void stop() {
     receivePort.close();
+  }
+}
+
+/// @nodoc
+class Transaction {
+  Realm? _realm;
+
+  Transaction._(Realm realm) {
+    _realm = realm;
+    realmCore.beginWrite(realm);
+  }
+
+  void commit() {
+    if (_realm == null) {
+      throw RealmException('Transaction was already closed. Cannot commit');
+    }
+
+    realmCore.commitWrite(_realm!);
+    _realm = null;
+  }
+
+  void rollback() {
+    if (_realm == null) {
+      throw RealmException('Transaction was already closed. Cannot rollback');
+    }
+
+    realmCore.rollbackWrite(_realm!);
+    _realm = null;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-dart/issues/442

The `Transaction` class is currently undocumented as we don't have explicit `beginWrite` method. We may introduce it at a later point, especially once we get async writes.

I made `isInTransaction` public because it's quite useful when you are calling methods from inside your write transaction. Since starting a second transaction will throw, we should expose a mechanism for developers to guard against it. Example:

```dart

void markComplete(Task task) {
  if (task.realm.isInTransaction) {
    task.isComplete = true;
  } else {
    task.realm.write(() {
      task.isComplete = true;
    });
  }
}
```