### PR TITLE
add support for objectId

### DIFF
--- a/common/lib/realm_common.dart
+++ b/common/lib/realm_common.dart
@@ -18,3 +18,5 @@
 
 export 'src/realm_common_base.dart';
 export 'src/realm_types.dart';
+
+export 'package:objectid/objectid.dart' show ObjectId;

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -18,6 +18,7 @@
 
 import 'dart:ffi';
 import 'dart:typed_data';
+import 'package:objectid/objectid.dart';
 
 /// All supported `Realm` property types.
 /// {@category Configuration}
@@ -79,9 +80,6 @@ class RealmStateError extends StateError implements RealmError {
 
 /// @nodoc
 class Uuid {} // TODO!
-
-/// @nodoc
-class ObjectId {} // TODO!
 
 /// @nodoc
 class Decimal128 {} // TODO!

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -12,5 +12,8 @@ issue_tracker: https://github.com/realm/realm-dart/issues
 environment:
   sdk: '>=2.15.0 <3.0.0'
 
+dependencies: 
+  objectid: ^2.1.0
+
 dev_dependencies:
   lints: ^1.0.1

--- a/generator/lib/src/dart_type_ex.dart
+++ b/generator/lib/src/dart_type_ex.dart
@@ -23,8 +23,6 @@ import 'package:realm_common/realm_common.dart';
 import 'package:realm_generator/src/pseudo_type.dart';
 import 'package:source_gen/source_gen.dart';
 
-import 'element.dart';
-import 'error.dart';
 import 'session.dart';
 import 'type_checkers.dart';
 

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -83,7 +83,6 @@ extension FieldElementEx on FieldElement {
           type.isDartCoreMap ||
           type.isRealmAny ||
           type.isExactly<Decimal128>() ||
-          type.isExactly<ObjectId>() ||
           type.isExactly<Uuid>()) {
         throw RealmInvalidGenerationSourceError(
           'Field type not supported yet',
@@ -146,11 +145,7 @@ extension FieldElementEx on FieldElement {
 
       // Validate indexes
       if ((primaryKey != null || indexed != null) &&
-          (![
-                RealmPropertyType.string,
-                RealmPropertyType.int,
-              ].contains(type.realmType) ||
-              type.isRealmCollection)) {
+          (![RealmPropertyType.string, RealmPropertyType.int, RealmPropertyType.objectid].contains(type.realmType) || type.isRealmCollection)) {
         final file = span!.file;
         final annotation = (primaryKey ?? indexed)!.annotation;
 

--- a/generator/test/good_test.dart
+++ b/generator/test/good_test.dart
@@ -2,9 +2,9 @@ import 'test_util.dart';
 
 void main() {
   const directory = 'test/good_test_data';
-  getListOfTestFiles(directory).forEach((inputFile, outputFile) {
+  getListOfTestFiles(directory).forEach((inputFile, expectedFile) {
     executeTest(getTestName(inputFile), () async {
-      await generatorTestBuilder(directory, inputFile, outputFile);
+      await generatorTestBuilder(directory, inputFile, expectedFile);
     });
   });
 }

--- a/generator/test/good_test_data/all_types.dart
+++ b/generator/test/good_test_data/all_types.dart
@@ -30,4 +30,15 @@ class _Bar {
 
   @Indexed()
   String? anOptionalString;
+
+  late ObjectId objectId;
+}
+
+@RealmModel()
+class _PrimitiveTypes {
+  late String stringProp;
+  late bool boolProp;
+  late DateTime dateProp;
+  late double doubleProp;
+  late ObjectId objectIdProp;
 }

--- a/generator/test/good_test_data/all_types.expected
+++ b/generator/test/good_test_data/all_types.expected
@@ -1,0 +1,221 @@
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class Fooo extends _Foo with RealmEntity, RealmObject {
+  static var _defaultsSet = false;
+
+  Fooo({
+    int x = 0,
+  }) {
+    if (!_defaultsSet) {
+      _defaultsSet = RealmObject.setDefaults<Fooo>({
+        'x': 0,
+      });
+    }
+    RealmObject.set(this, 'x', x);
+  }
+
+  Fooo._();
+
+  @override
+  int get x => RealmObject.get<int>(this, 'x') as int;
+  @override
+  set x(int value) => RealmObject.set(this, 'x', value);
+
+  @override
+  Stream<RealmObjectChanges<Fooo>> get changes =>
+      RealmObject.getChanges<Fooo>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(Fooo._);
+    return const SchemaObject(Fooo, [
+      SchemaProperty('x', RealmPropertyType.int),
+    ]);
+  }
+}
+
+class Bar extends _Bar with RealmEntity, RealmObject {
+  static var _defaultsSet = false;
+
+  Bar(
+    String id,
+    bool aBool,
+    bool another,
+    ObjectId objectId, {
+    Uint8List data = Uint8List(16),
+    DateTime timestamp = DateTime.now(),
+    double aDouble = 0.0,
+    Foo? foo,
+    String? anOptionalString,
+    Iterable<int> list = const [],
+  }) {
+    if (!_defaultsSet) {
+      _defaultsSet = RealmObject.setDefaults<Bar>({
+        'data': Uint8List(16),
+        'timestamp': DateTime.now(),
+        'aDouble': 0.0,
+      });
+    }
+    RealmObject.set(this, 'id', id);
+    RealmObject.set(this, 'aBool', aBool);
+    RealmObject.set(this, 'another', another);
+    RealmObject.set(this, 'data', data);
+    RealmObject.set(this, 'timestamp', timestamp);
+    RealmObject.set(this, 'aDouble', aDouble);
+    RealmObject.set(this, 'foo', foo);
+    RealmObject.set(this, 'anOptionalString', anOptionalString);
+    RealmObject.set(this, 'objectId', objectId);
+    RealmObject.set<RealmList<int>>(this, 'list', RealmList<int>(list));
+  }
+
+  Bar._();
+
+  @override
+  String get id => RealmObject.get<String>(this, 'id') as String;
+  @override
+  set id(String value) => throw RealmUnsupportedSetError();
+
+  @override
+  bool get aBool => RealmObject.get<bool>(this, 'aBool') as bool;
+  @override
+  set aBool(bool value) => RealmObject.set(this, 'aBool', value);
+
+  @override
+  bool get another => RealmObject.get<bool>(this, 'another') as bool;
+  @override
+  set another(bool value) => RealmObject.set(this, 'another', value);
+
+  @override
+  Uint8List get data => RealmObject.get<Uint8List>(this, 'data') as Uint8List;
+  @override
+  set data(Uint8List value) => RealmObject.set(this, 'data', value);
+
+  @override
+  DateTime get timestamp =>
+      RealmObject.get<DateTime>(this, 'tidspunkt') as DateTime;
+  @override
+  set timestamp(DateTime value) => RealmObject.set(this, 'tidspunkt', value);
+
+  @override
+  double get aDouble => RealmObject.get<double>(this, 'aDouble') as double;
+  @override
+  set aDouble(double value) => RealmObject.set(this, 'aDouble', value);
+
+  @override
+  Foo? get foo => RealmObject.get<Foo>(this, 'foo') as Foo?;
+  @override
+  set foo(covariant Foo? value) => RealmObject.set(this, 'foo', value);
+
+  @override
+  RealmList<int> get list =>
+      RealmObject.get<int>(this, 'list') as RealmList<int>;
+  @override
+  set list(covariant RealmList<int> value) => throw RealmUnsupportedSetError();
+
+  @override
+  String? get anOptionalString =>
+      RealmObject.get<String>(this, 'anOptionalString') as String?;
+  @override
+  set anOptionalString(String? value) =>
+      RealmObject.set(this, 'anOptionalString', value);
+
+  @override
+  ObjectId get objectId =>
+      RealmObject.get<ObjectId>(this, 'objectId') as ObjectId;
+  @override
+  set objectId(ObjectId value) => RealmObject.set(this, 'objectId', value);
+
+  @override
+  Stream<RealmObjectChanges<Bar>> get changes =>
+      RealmObject.getChanges<Bar>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(Bar._);
+    return const SchemaObject(Bar, [
+      SchemaProperty('id', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('aBool', RealmPropertyType.bool),
+      SchemaProperty('another', RealmPropertyType.bool),
+      SchemaProperty('data', RealmPropertyType.binary),
+      SchemaProperty('tidspunkt', RealmPropertyType.timestamp,
+          mapTo: 'tidspunkt'),
+      SchemaProperty('aDouble', RealmPropertyType.double),
+      SchemaProperty('foo', RealmPropertyType.object,
+          optional: true, linkTarget: 'Foo'),
+      SchemaProperty('list', RealmPropertyType.int,
+          collectionType: RealmCollectionType.list),
+      SchemaProperty('anOptionalString', RealmPropertyType.string,
+          optional: true),
+      SchemaProperty('objectId', RealmPropertyType.objectid),
+    ]);
+  }
+}
+
+class PrimitiveTypes extends _PrimitiveTypes with RealmEntity, RealmObject {
+  PrimitiveTypes(
+    String stringProp,
+    bool boolProp,
+    DateTime dateProp,
+    double doubleProp,
+    ObjectId objectIdProp,
+  ) {
+    RealmObject.set(this, 'stringProp', stringProp);
+    RealmObject.set(this, 'boolProp', boolProp);
+    RealmObject.set(this, 'dateProp', dateProp);
+    RealmObject.set(this, 'doubleProp', doubleProp);
+    RealmObject.set(this, 'objectIdProp', objectIdProp);
+  }
+
+  PrimitiveTypes._();
+
+  @override
+  String get stringProp =>
+      RealmObject.get<String>(this, 'stringProp') as String;
+  @override
+  set stringProp(String value) => RealmObject.set(this, 'stringProp', value);
+
+  @override
+  bool get boolProp => RealmObject.get<bool>(this, 'boolProp') as bool;
+  @override
+  set boolProp(bool value) => RealmObject.set(this, 'boolProp', value);
+
+  @override
+  DateTime get dateProp =>
+      RealmObject.get<DateTime>(this, 'dateProp') as DateTime;
+  @override
+  set dateProp(DateTime value) => RealmObject.set(this, 'dateProp', value);
+
+  @override
+  double get doubleProp =>
+      RealmObject.get<double>(this, 'doubleProp') as double;
+  @override
+  set doubleProp(double value) => RealmObject.set(this, 'doubleProp', value);
+
+  @override
+  ObjectId get objectIdProp =>
+      RealmObject.get<ObjectId>(this, 'objectIdProp') as ObjectId;
+  @override
+  set objectIdProp(ObjectId value) =>
+      RealmObject.set(this, 'objectIdProp', value);
+
+  @override
+  Stream<RealmObjectChanges<PrimitiveTypes>> get changes =>
+      RealmObject.getChanges<PrimitiveTypes>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(PrimitiveTypes._);
+    return const SchemaObject(PrimitiveTypes, [
+      SchemaProperty('stringProp', RealmPropertyType.string),
+      SchemaProperty('boolProp', RealmPropertyType.bool),
+      SchemaProperty('dateProp', RealmPropertyType.timestamp),
+      SchemaProperty('doubleProp', RealmPropertyType.double),
+      SchemaProperty('objectIdProp', RealmPropertyType.objectid),
+    ]);
+  }
+}

--- a/generator/test/good_test_data/primary_key.dart
+++ b/generator/test/good_test_data/primary_key.dart
@@ -1,0 +1,18 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel()
+class _IntPK {
+  @PrimaryKey()
+  late int id;
+}
+@RealmModel()
+class _StringPK {
+  @PrimaryKey()
+  late String id;
+}
+
+@RealmModel()
+class _ObjectIdPK {
+  @PrimaryKey()
+  late ObjectId id;
+}

--- a/generator/test/good_test_data/primary_key.expected
+++ b/generator/test/good_test_data/primary_key.expected
@@ -1,0 +1,87 @@
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class IntPK extends _IntPK with RealmEntity, RealmObject {
+  IntPK(
+    int id,
+  ) {
+    RealmObject.set(this, 'id', id);
+  }
+
+  IntPK._();
+
+  @override
+  int get id => RealmObject.get<int>(this, 'id') as int;
+  @override
+  set id(int value) => throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<IntPK>> get changes =>
+      RealmObject.getChanges<IntPK>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(IntPK._);
+    return const SchemaObject(IntPK, [
+      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+    ]);
+  }
+}
+
+class StringPK extends _StringPK with RealmEntity, RealmObject {
+  StringPK(
+    String id,
+  ) {
+    RealmObject.set(this, 'id', id);
+  }
+
+  StringPK._();
+
+  @override
+  String get id => RealmObject.get<String>(this, 'id') as String;
+  @override
+  set id(String value) => throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<StringPK>> get changes =>
+      RealmObject.getChanges<StringPK>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(StringPK._);
+    return const SchemaObject(StringPK, [
+      SchemaProperty('id', RealmPropertyType.string, primaryKey: true),
+    ]);
+  }
+}
+
+class ObjectIdPK extends _ObjectIdPK with RealmEntity, RealmObject {
+  ObjectIdPK(
+    ObjectId id,
+  ) {
+    RealmObject.set(this, 'id', id);
+  }
+
+  ObjectIdPK._();
+
+  @override
+  ObjectId get id => RealmObject.get<ObjectId>(this, 'id') as ObjectId;
+  @override
+  set id(ObjectId value) => throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<ObjectIdPK>> get changes =>
+      RealmObject.getChanges<ObjectIdPK>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(ObjectIdPK._);
+    return const SchemaObject(ObjectIdPK, [
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
+    ]);
+  }
+}

--- a/generator/test/test_util.dart
+++ b/generator/test/test_util.dart
@@ -49,7 +49,6 @@ class LinesEqualsMatcher extends Matcher {
   @override
   // ignore: strict_raw_type
   bool matches(dynamic actual, Map matchState) {
-    try{
     final actualValue = utf8.decode(actual as List<int>);
     final actualLines = actualValue.split("\n");
 
@@ -71,11 +70,6 @@ class LinesEqualsMatcher extends Matcher {
     }
 
     return true;
-    }
-    catch (_) {
-      print("fali");
-      return false;
-    }
   }
 
   @override

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -32,7 +32,7 @@ import 'results.dart';
 // always expose with `show` to explicitly control the public API surface
 export 'application.dart' show ApplicationConfiguration, MetadataPersistenceMode;
 export 'package:realm_common/realm_common.dart'
-    show Ignored, Indexed, MapTo, PrimaryKey, RealmError, RealmModel, RealmUnsupportedSetError, RealmStateError, RealmCollectionType, RealmPropertyType;
+    show Ignored, Indexed, MapTo, PrimaryKey, RealmError, RealmModel, RealmUnsupportedSetError, RealmStateError, RealmCollectionType, RealmPropertyType, ObjectId;
 export "configuration.dart" show Configuration, RealmSchema, SchemaObject;
 export 'list.dart' show RealmList, RealmListOfObject, RealmListChanges;
 export 'realm_object.dart' show RealmEntity, RealmException, RealmObject, RealmObjectChanges;

--- a/test/realm_object_test.g.dart
+++ b/test/realm_object_test.g.dart
@@ -1,0 +1,92 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'realm_object_test.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class ObjectIdPrimaryKey extends _ObjectIdPrimaryKey
+    with RealmEntity, RealmObject {
+  ObjectIdPrimaryKey(
+    ObjectId id,
+  ) {
+    RealmObject.set(this, 'id', id);
+  }
+
+  ObjectIdPrimaryKey._();
+
+  @override
+  ObjectId get id => RealmObject.get<ObjectId>(this, 'id') as ObjectId;
+  @override
+  set id(ObjectId value) => throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<ObjectIdPrimaryKey>> get changes =>
+      RealmObject.getChanges<ObjectIdPrimaryKey>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(ObjectIdPrimaryKey._);
+    return const SchemaObject(ObjectIdPrimaryKey, [
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
+    ]);
+  }
+}
+
+class IntPrimaryKey extends _IntPrimaryKey with RealmEntity, RealmObject {
+  IntPrimaryKey(
+    int id,
+  ) {
+    RealmObject.set(this, 'id', id);
+  }
+
+  IntPrimaryKey._();
+
+  @override
+  int get id => RealmObject.get<int>(this, 'id') as int;
+  @override
+  set id(int value) => throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<IntPrimaryKey>> get changes =>
+      RealmObject.getChanges<IntPrimaryKey>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(IntPrimaryKey._);
+    return const SchemaObject(IntPrimaryKey, [
+      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+    ]);
+  }
+}
+
+class StringPrimaryKey extends _StringPrimaryKey with RealmEntity, RealmObject {
+  StringPrimaryKey(
+    String id,
+  ) {
+    RealmObject.set(this, 'id', id);
+  }
+
+  StringPrimaryKey._();
+
+  @override
+  String get id => RealmObject.get<String>(this, 'id') as String;
+  @override
+  set id(String value) => throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<StringPrimaryKey>> get changes =>
+      RealmObject.getChanges<StringPrimaryKey>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(StringPrimaryKey._);
+    return const SchemaObject(StringPrimaryKey, [
+      SchemaProperty('id', RealmPropertyType.string, primaryKey: true),
+    ]);
+  }
+}


### PR DESCRIPTION
support objectId
use custom line by line matcher for generator tests
this supersedes https://github.com/realm/realm-dart/pull/460
fixes #461  