### PR TITLE
Fix shouldCompact callback

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -119,7 +119,7 @@ class Configuration {
   /// add some initial data that your app needs. The function will not execute for existing
   /// Realms, even if all objects in the Realm are deleted.
   final Function(Realm realm)? initialDataCallback;
-  
+
   /// The function called when opening a Realm for the first time
   /// during the life of a process to determine if it should be compacted
   /// before being returned to the user.
@@ -128,7 +128,7 @@ class Configuration {
   /// [usedSize] - The total bytes used by data in the file.
   /// It returns true to indicate that an attempt to compact the file should be made.
   /// The compaction will be skipped if another process is currently accessing the realm file.
-  final Function(int totalSize, int usedSize)? shouldCompactCallback;
+  final bool Function(int totalSize, int usedSize)? shouldCompactCallback;
 }
 
 /// A collection of properties describing the underlying schema of a [RealmObject].

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -195,11 +195,10 @@ class _RealmCore {
   static int should_compact_callback(Pointer<Void> userdata, int totalSize, int usedSize) {
     final Configuration? config = userdata.toObject();
     if (config == null) {
-      return 0;
+      return FALSE;
     }
-    config.shouldCompactCallback!(totalSize, usedSize);
 
-    return 1;
+    return config.shouldCompactCallback!(totalSize, usedSize) ? TRUE : FALSE;
   }
 
   SchedulerHandle createScheduler(int isolateId, int sendPort) {

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -358,13 +358,13 @@ Future<void> main([List<String>? args]) async {
   _addDummyData(Realm realm) {
     for (var i = 0; i < dummyDataSize; i++) {
       realm.write(() {
-        realm.add(Person('Very long and space consuming name $i'));
+        realm.add(Person('Very long and space consuming name $i that goes on forever and ever and ever. This should take a whole lot of space!'));
       });
     }
 
     var rand = Random();
     var people = realm.all<Person>();
-    for (var i = 0; i < dummyDataSize / 2; i++) {
+    for (var i = 0; i < 3 * dummyDataSize / 4; i++) {
       realm.write(() {
         final toDelete = people[rand.nextInt(people.length)];
         realm.delete(toDelete);
@@ -400,7 +400,7 @@ Future<void> main([List<String>? args]) async {
         expect(newSize, oldSize);
       }
 
-      expect(compactedRealm.all<Person>().length, dummyDataSize / 2);
+      expect(compactedRealm.all<Person>().length, dummyDataSize / 4);
     });
   }
 }

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -18,6 +18,7 @@
 
 // ignore_for_file: unused_local_variable
 import 'dart:io';
+import 'dart:math';
 import 'package:test/test.dart' hide test, throws;
 import '../lib/realm.dart';
 import 'test.dart';
@@ -298,18 +299,108 @@ Future<void> main([List<String>? args]) async {
     expect(callbackEx, isNotNull);
     expect(callbackEx.toString(), contains('The Realm is already in a write transaction'));
   });
-  
-  test('Configuration - do not compact on open realm', () {
+
+  test('Configuration.shouldCompact can return false', () {
+    var invoked = false;
     var config = Configuration([Dog.schema, Person.schema], shouldCompactCallback: (totalSize, usedSize) {
+      invoked = true;
       return false;
     });
+
     final realm = getRealm(config);
+    expect(invoked, true);
   });
 
-  test('Configuration - compact on open realm', () {
+  test('Configuration.shouldCompact invoked on every open', () {
+    var invoked = 0;
     var config = Configuration([Dog.schema, Person.schema], shouldCompactCallback: (totalSize, usedSize) {
+      invoked++;
+      return false;
+    });
+
+    final realm = getRealm(config);
+    expect(invoked, 1);
+    realm.close();
+
+    // Try to open the realm again - we should see the callback get invoked.
+    getRealm(config);
+    expect(invoked, 2);
+  });
+
+  test('Configuration.shouldCompact not invoked if a Realm is still open', () {
+    var invoked = 0;
+    var config = Configuration([Dog.schema, Person.schema], shouldCompactCallback: (totalSize, usedSize) {
+      invoked++;
+      return false;
+    });
+
+    final realm = getRealm(config);
+    expect(invoked, 1);
+
+    // Try to open the Realm again - callback should not be invoked because the first Realm
+    // is still open
+    getRealm(config);
+    expect(invoked, 1);
+  });
+
+  test('Configuration.shouldCompact can return true', () {
+    var invoked = false;
+    var config = Configuration([Dog.schema, Person.schema], shouldCompactCallback: (totalSize, usedSize) {
+      invoked = true;
       return totalSize > 0;
     });
+
     final realm = getRealm(config);
+    expect(invoked, true);
   });
+
+  const dummyDataSize = 100;
+  _addDummyData(Realm realm) {
+    for (var i = 0; i < dummyDataSize; i++) {
+      realm.write(() {
+        realm.add(Person('Very long and space consuming name $i'));
+      });
+    }
+
+    var rand = Random();
+    var people = realm.all<Person>();
+    for (var i = 0; i < dummyDataSize / 2; i++) {
+      realm.write(() {
+        final toDelete = people[rand.nextInt(people.length)];
+        realm.delete(toDelete);
+      });
+    }
+  }
+
+  for (var shouldCompact in [true, false]) {
+    test('Configuration.shouldCompact when return $shouldCompact triggers compaction', () {
+      var config = Configuration([Person.schema]);
+
+      final populateRealm = Realm(config);
+      _addDummyData(populateRealm);
+      populateRealm.close();
+
+      final oldSize = File(config.path).lengthSync();
+      var projectedNewSize = 0;
+
+      config = Configuration([Person.schema], shouldCompactCallback: (totalSize, usedSize) {
+        projectedNewSize = usedSize;
+        return shouldCompact;
+      });
+
+      final compactedRealm = getRealm(config);
+      final newSize = File(config.path).lengthSync();
+
+      if (shouldCompact) {
+        expect(newSize, lessThan(oldSize));
+
+        // Space occupied should be less than twice the data size
+        expect(newSize, lessThan(2 * projectedNewSize));
+      } else {
+        expect(newSize, oldSize);
+      }
+
+      expect(compactedRealm.all<Person>().length, dummyDataSize / 2);
+    });
+  }
 }

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -358,13 +358,13 @@ Future<void> main([List<String>? args]) async {
   _addDummyData(Realm realm) {
     for (var i = 0; i < dummyDataSize; i++) {
       realm.write(() {
-        realm.add(Person('Very long and space consuming name $i that goes on forever and ever and ever. This should take a whole lot of space!'));
+        realm.add(Person(generateRandomString(1000)));
       });
     }
 
     var rand = Random();
     var people = realm.all<Person>();
-    for (var i = 0; i < 3 * dummyDataSize / 4; i++) {
+    for (var i = 0; i < dummyDataSize / 2; i++) {
       realm.write(() {
         final toDelete = people[rand.nextInt(people.length)];
         realm.delete(toDelete);
@@ -400,7 +400,7 @@ Future<void> main([List<String>? args]) async {
         expect(newSize, oldSize);
       }
 
-      expect(compactedRealm.all<Person>().length, dummyDataSize / 4);
+      expect(compactedRealm.all<Person>().length, dummyDataSize / 2);
     });
   }
 }


### PR DESCRIPTION
Adds a return value to the should compact callback as it was previously void and the Realm was indiscriminately compacted regardless of what the user returned. Additionally, adds more comprehensive tests for the feature.