### PR TITLE
Add new workflows for prepare/publish release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,15 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+env:
+  REALM_CI: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          submodules: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,24 @@
+name: Publish Release
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Environment to publish packages to
+        options:
+        - public
+        - internal
+      dry-run:
+        type: boolean
+        description: Run the workflow without actually uploading packages
+env:
+  REALM_CI: true
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment == 'public' && 'Production' || 'Staging' }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: false


### PR DESCRIPTION
This is only needed so that the workflows end up in `master`. The actual implementation will follow later.