### PR TITLE
Add string-based access API for RealmObject

### DIFF
--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -29,7 +29,7 @@ import 'results.dart';
 /// added to or deleted from the collection or from the Realm.
 ///
 /// {@category Realm}
-abstract class RealmList<T extends Object> with RealmEntity implements List<T> {
+abstract class RealmList<T extends Object?> with RealmEntity implements List<T> {
   late final RealmObjectMetadata? _metadata;
 
   /// Gets a value indicating whether this collection is still valid to use.
@@ -43,7 +43,7 @@ abstract class RealmList<T extends Object> with RealmEntity implements List<T> {
   factory RealmList(Iterable<T> items) => UnmanagedRealmList(items);
 }
 
-class ManagedRealmList<T extends Object> extends collection.ListBase<T> with RealmEntity implements RealmList<T> {
+class ManagedRealmList<T extends Object?> extends collection.ListBase<T> with RealmEntity implements RealmList<T> {
   final RealmListHandle _handle;
 
   @override
@@ -96,7 +96,7 @@ class ManagedRealmList<T extends Object> extends collection.ListBase<T> with Rea
   bool get isValid => realmCore.listIsValid(this);
 }
 
-class UnmanagedRealmList<T extends Object> extends collection.ListBase<T> with RealmEntity implements RealmList<T> {
+class UnmanagedRealmList<T extends Object?> extends collection.ListBase<T> with RealmEntity implements RealmList<T> {
   final _unmanaged = <T?>[]; // use T? for length=
 
   UnmanagedRealmList([Iterable<T>? items]) {
@@ -155,12 +155,12 @@ extension RealmListOfObject<T extends RealmObject> on RealmList<T> {
 }
 
 /// @nodoc
-extension RealmListInternal<T extends Object> on RealmList<T> {
+extension RealmListInternal<T extends Object?> on RealmList<T> {
   ManagedRealmList<T> asManaged() => this is ManagedRealmList<T> ? this as ManagedRealmList<T> : throw RealmStateError('$this is not managed');
 
   RealmListHandle get handle => asManaged()._handle;
 
-  static RealmList<T> create<T extends Object>(RealmListHandle handle, Realm realm, RealmObjectMetadata? metadata) => RealmList<T>._(handle, realm, metadata);
+  static RealmList<T> create<T extends Object?>(RealmListHandle handle, Realm realm, RealmObjectMetadata? metadata) => RealmList<T>._(handle, realm, metadata);
 
   static void setValue(RealmListHandle handle, Realm realm, int index, Object? value) {
     if (index < 0) {

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -339,7 +339,9 @@ class _RealmCore {
         final property = propertiesPtr.elementAt(i);
         final propertyName = property.ref.name.toDartString()!;
         final objectType = property.ref.link_target.toDartString(treatEmptyAsNull: true);
-        final propertyMeta = RealmPropertyMetadata(property.ref.key, objectType, RealmCollectionType.values.elementAt(property.ref.collection_type));
+        final isNullable = property.ref.flags & realm_property_flags.RLM_PROPERTY_NULLABLE != 0;
+        final propertyMeta = RealmPropertyMetadata(property.ref.key, objectType, RealmPropertyType.values.elementAt(property.ref.type), isNullable,
+            RealmCollectionType.values.elementAt(property.ref.collection_type));
         result[propertyName] = propertyMeta;
       }
       return result;

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -329,7 +329,7 @@ extension RealmInternal on Realm {
     return RealmObjectInternal.create(type, this, handle, accessor);
   }
 
-  RealmList<T> createList<T extends Object>(RealmListHandle handle, RealmObjectMetadata? metadata) {
+  RealmList<T> createList<T extends Object?>(RealmListHandle handle, RealmObjectMetadata? metadata) {
     return RealmListInternal.create(handle, this, metadata);
   }
 

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -330,7 +330,7 @@ extension RealmInternal on Realm {
   }
 
   RealmList<T> createList<T extends Object?>(RealmListHandle handle, RealmObjectMetadata? metadata) {
-    return RealmListInternal.create(handle, this, metadata);
+    return RealmListInternal.create<T>(handle, this, metadata);
   }
 
   List<String> getPropertyNames(Type type, List<int> propertyKeys) {

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -400,7 +400,11 @@ class DynamicRealmObject {
   }
 
   List<T> getList<T extends Object>(String name) {
-    _validatePropertyType<T>(name, RealmCollectionType.list, false);
+    final prop = _validatePropertyType<T>(name, RealmCollectionType.list, false);
+    if (T == Object && prop?.propertyType == RealmPropertyType.object) {
+      return RealmObject.get<RealmObject>(_obj, name) as List<T>;
+    }
+
     return RealmObject.get<T>(_obj, name) as List<T>;
   }
 

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -205,7 +205,7 @@ mixin RealmObject on RealmEntity {
   RealmObjectHandle? _handle;
   RealmAccessor _accessor = RealmValuesAccessor();
   static final Map<Type, RealmObject Function()> _factories = <Type, RealmObject Function()>{
-    RealmObject: () => DynamicRealmObject._(),
+    RealmObject: () => ConcreteRealmObject._(),
   };
 
   /// @nodoc
@@ -267,6 +267,8 @@ mixin RealmObject on RealmEntity {
     final controller = RealmObjectNotificationsController<T>(object);
     return controller.createStream();
   }
+
+  late final DynamicRealmObject dynamic = DynamicRealmObject._(this);
 }
 
 /// @nodoc
@@ -369,6 +371,18 @@ class RealmObjectNotificationsController<T extends RealmObject> extends Notifica
 }
 
 /// @nodoc
-class DynamicRealmObject with RealmEntity, RealmObject {
-  DynamicRealmObject._();
+class ConcreteRealmObject with RealmEntity, RealmObject {
+  ConcreteRealmObject._();
+}
+
+class DynamicRealmObject {
+  final RealmObject _obj;
+
+  DynamicRealmObject._(this._obj);
+
+  T get<T extends Object>(String name) => RealmObject.get<T>(_obj, name) as T;
+
+  T? getNullable<T extends Object>(String name) => RealmObject.get<T>(_obj, name) as T?;
+
+  List<T> getList<T extends Object>(String name) => RealmObject.get<T>(_obj, name) as List<T>;
 }

--- a/test/dynamic_realm_test.dart
+++ b/test/dynamic_realm_test.dart
@@ -19,7 +19,6 @@
 // ignore_for_file: unused_local_variable, avoid_relative_lib_imports
 
 import 'dart:io';
-import 'dart:math';
 import 'package:test/test.dart' hide test, throws;
 import '../lib/realm.dart';
 
@@ -70,8 +69,92 @@ Future<void> main([List<String>? args]) async {
     expect(dynamic1, same(dynamic2));
   });
 
+  final date = DateTime.now().toUtc();
+  final objectId = ObjectId();
+  final uuid = Uuid.v4();
+
+  AllTypes _getPopulatedAllTypes() => AllTypes('abc', true, date, -123.456, objectId, uuid, -987,
+      nullableStringProp: 'def',
+      nullableBoolProp: true,
+      nullableDateProp: date,
+      nullableDoubleProp: -123.456,
+      nullableObjectIdProp: objectId,
+      nullableUuidProp: uuid,
+      nullableIntProp: 123);
+
+  AllTypes _getEmptyAllTypes() => AllTypes('', false, DateTime(0).toUtc(), 0, objectId, uuid, 0);
+
+  AllCollections _getPopulatedAllCollections() => AllCollections(
+      strings: ['abc', 'def'],
+      bools: [true, false],
+      dates: [date, DateTime(0).toUtc()],
+      doubles: [-123.456, 555.666],
+      objectIds: [objectId, objectId],
+      uuids: [uuid, uuid],
+      ints: [-987, 123]);
+
+  void _validateDynamic(RealmObject actual, AllTypes expected) {
+    expect(actual.dynamic.get<String>('stringProp'), expected.stringProp);
+    expect(actual.dynamic.get('stringProp'), expected.stringProp);
+    expect(actual.dynamic.getNullable<String>('nullableStringProp'), expected.nullableStringProp);
+    expect(actual.dynamic.getNullable('nullableStringProp'), expected.nullableStringProp);
+
+    expect(actual.dynamic.get<bool>('boolProp'), expected.boolProp);
+    expect(actual.dynamic.get('boolProp'), expected.boolProp);
+    expect(actual.dynamic.getNullable<bool>('nullableBoolProp'), expected.nullableBoolProp);
+    expect(actual.dynamic.getNullable('nullableBoolProp'), expected.nullableBoolProp);
+
+    expect(actual.dynamic.get<DateTime>('dateProp'), expected.dateProp);
+    expect(actual.dynamic.get('dateProp'), expected.dateProp);
+    expect(actual.dynamic.getNullable<DateTime>('nullableDateProp'), expected.nullableDateProp);
+    expect(actual.dynamic.getNullable('nullableDateProp'), expected.nullableDateProp);
+
+    expect(actual.dynamic.get<double>('doubleProp'), expected.doubleProp);
+    expect(actual.dynamic.get('doubleProp'), expected.doubleProp);
+    expect(actual.dynamic.getNullable<double>('nullableDoubleProp'), expected.nullableDoubleProp);
+    expect(actual.dynamic.getNullable('nullableDoubleProp'), expected.nullableDoubleProp);
+
+    expect(actual.dynamic.get<ObjectId>('objectIdProp'), expected.objectIdProp);
+    expect(actual.dynamic.get('objectIdProp'), expected.objectIdProp);
+    expect(actual.dynamic.getNullable<ObjectId>('nullableObjectIdProp'), expected.nullableObjectIdProp);
+    expect(actual.dynamic.getNullable('nullableObjectIdProp'), expected.nullableObjectIdProp);
+
+    expect(actual.dynamic.get<Uuid>('uuidProp'), expected.uuidProp);
+    expect(actual.dynamic.get('uuidProp'), expected.uuidProp);
+    expect(actual.dynamic.getNullable<Uuid>('nullableUuidProp'), expected.nullableUuidProp);
+    expect(actual.dynamic.getNullable('nullableUuidProp'), expected.nullableUuidProp);
+
+    expect(actual.dynamic.get<int>('intProp'), expected.intProp);
+    expect(actual.dynamic.get('intProp'), expected.intProp);
+    expect(actual.dynamic.getNullable<int>('nullableIntProp'), expected.nullableIntProp);
+    expect(actual.dynamic.getNullable('nullableIntProp'), expected.nullableIntProp);
+  }
+
+  void _validateDynamicLists(RealmObject actual, AllCollections expected) {
+    expect(actual.dynamic.getList<String>('strings'), expected.strings);
+    expect(actual.dynamic.getList('strings'), expected.strings);
+
+    expect(actual.dynamic.getList<bool>('bools'), expected.bools);
+    expect(actual.dynamic.getList('bools'), expected.bools);
+
+    expect(actual.dynamic.getList<DateTime>('dates'), expected.dates);
+    expect(actual.dynamic.getList('dates'), expected.dates);
+
+    expect(actual.dynamic.getList<double>('doubles'), expected.doubles);
+    expect(actual.dynamic.getList('doubles'), expected.doubles);
+
+    expect(actual.dynamic.getList<ObjectId>('objectIds'), expected.objectIds);
+    expect(actual.dynamic.getList('objectIds'), expected.objectIds);
+
+    expect(actual.dynamic.getList<Uuid>('uuids'), expected.uuids);
+    expect(actual.dynamic.getList('uuids'), expected.uuids);
+
+    expect(actual.dynamic.getList<int>('ints'), expected.ints);
+    expect(actual.dynamic.getList('ints'), expected.ints);
+  }
+
   for (var isDynamic in [true, false]) {
-    Realm getDynamicRealm(Realm original) {
+    Realm _getDynamicRealm(Realm original) {
       if (isDynamic) {
         original.close();
         return getRealm(Configuration([]));
@@ -85,7 +168,7 @@ Future<void> main([List<String>? args]) async {
         final config = Configuration([Car.schema]);
         final staticRealm = getRealm(config);
 
-        final realm = getDynamicRealm(staticRealm);
+        final realm = _getDynamicRealm(staticRealm);
         final allCars = realm.dynamic.all(Car.schema.name);
         expect(allCars.length, 0);
       });
@@ -97,7 +180,7 @@ Future<void> main([List<String>? args]) async {
           staticRealm.add(Car('Honda'));
         });
 
-        final realm = getDynamicRealm(staticRealm);
+        final realm = _getDynamicRealm(staticRealm);
         final allCars = realm.dynamic.all(Car.schema.name);
         expect(allCars.length, 1);
 
@@ -109,7 +192,7 @@ Future<void> main([List<String>? args]) async {
         final config = Configuration([Car.schema]);
         final staticRealm = getRealm(config);
 
-        final dynamicRealm = getDynamicRealm(staticRealm);
+        final dynamicRealm = _getDynamicRealm(staticRealm);
 
         expect(() => dynamicRealm.dynamic.all('i-dont-exist'), throws<RealmException>("Object type i-dont-exist not configured in the current Realm's schema"));
       });
@@ -133,15 +216,15 @@ Future<void> main([List<String>? args]) async {
           obj1.list.addAll([obj1, obj2, obj3]);
         });
 
-        final dynamicRealm = getDynamicRealm(staticRealm);
+        final dynamicRealm = _getDynamicRealm(staticRealm);
 
         final objects = dynamicRealm.dynamic.all(LinksClass.schema.name);
         final obj1 = objects.singleWhere((o) => o.dynamic.get<Uuid>('id') == id1);
         final obj2 = objects.singleWhere((o) => o.dynamic.get<Uuid>('id') == id2);
         final obj3 = objects.singleWhere((o) => o.dynamic.get<Uuid>('id') == id3);
 
-        expect(obj1.dynamic.get<RealmObject>('link'), obj2);
-        expect(obj2.dynamic.get<RealmObject>('link'), obj3);
+        expect(obj1.dynamic.getNullable<RealmObject>('link'), obj2);
+        expect(obj2.dynamic.getNullable<RealmObject>('link'), obj3);
 
         final list = obj1.dynamic.getList<RealmObject>('list');
 
@@ -161,7 +244,7 @@ Future<void> main([List<String>? args]) async {
           staticRealm.add(Car('Toyota'));
         });
 
-        final dynamicRealm = getDynamicRealm(staticRealm);
+        final dynamicRealm = _getDynamicRealm(staticRealm);
 
         final carsWithH = dynamicRealm.dynamic.all(Car.schema.name).query('make BEGINSWITH "H"');
         expect(carsWithH.length, 2);
@@ -176,7 +259,7 @@ Future<void> main([List<String>? args]) async {
           staticRealm.add(Car('Hyundai'));
         });
 
-        final dynamicRealm = getDynamicRealm(staticRealm);
+        final dynamicRealm = _getDynamicRealm(staticRealm);
 
         final car = dynamicRealm.dynamic.find(Car.schema.name, 'Honda');
         expect(car, isNotNull);
@@ -190,17 +273,166 @@ Future<void> main([List<String>? args]) async {
         final config = Configuration([Car.schema]);
         final staticRealm = getRealm(config);
 
-        final dynamicRealm = getDynamicRealm(staticRealm);
+        final dynamicRealm = _getDynamicRealm(staticRealm);
 
         expect(() => dynamicRealm.dynamic.find('i-dont-exist', 'i-dont-exist'),
             throws<RealmException>("Object type i-dont-exist not configured in the current Realm's schema"));
       });
     });
 
-    group('RealmObject.dynamic when isDynamic=$isDynamic', () {});
+    group('Realm.dynamic when isDynamic=$isDynamic', () {
+      test('get can get all property types', () {
+        final config = Configuration([AllTypes.schema]);
+        final staticRealm = getRealm(config);
+
+        staticRealm.write(() {
+          staticRealm.add(_getPopulatedAllTypes());
+          staticRealm.add(_getEmptyAllTypes());
+        });
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+        final objects = dynamicRealm.dynamic.all(AllTypes.schema.name);
+
+        final obj1 = objects.singleWhere((o) => o.dynamic.get<String>('stringProp') == 'abc');
+        final obj2 = objects.singleWhere((o) => o.dynamic.get<String>('stringProp') == '');
+
+        _validateDynamic(obj1, _getPopulatedAllTypes());
+        _validateDynamic(obj2, _getEmptyAllTypes());
+      });
+
+      test('get fails with non-existent property', () {
+        final config = Configuration([AllTypes.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(_getEmptyAllTypes());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllTypes.schema.name).single;
+        expect(() => obj.dynamic.get('i-dont-exist'), throws<RealmException>("Property 'i-dont-exist' does not exist on class 'AllTypes'"));
+        expect(() => obj.dynamic.getNullable('i-dont-exist'), throws<RealmException>("Property 'i-dont-exist' does not exist on class 'AllTypes'"));
+      });
+
+      test('get fails with wrong type', () {
+        final config = Configuration([AllTypes.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(_getEmptyAllTypes());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllTypes.schema.name).single;
+
+        expect(
+            () => obj.dynamic.get<int>('stringProp'),
+            throws<RealmException>(
+                "Property 'stringProp' on class 'AllTypes' is not the correct type. Expected 'RealmPropertyType.int', got 'RealmPropertyType.string'."));
+
+        expect(
+            () => obj.dynamic.getNullable<int>('nullableStringProp'),
+            throws<RealmException>(
+                "Property 'nullableStringProp' on class 'AllTypes' is not the correct type. Expected 'RealmPropertyType.int', got 'RealmPropertyType.string'."));
+
+        expect(() => obj.dynamic.get<int>('nullableIntProp'),
+            throws<RealmException>("Property 'nullableIntProp' on class 'AllTypes' is nullable but the wrong method was used to access it."));
+
+        expect(() => obj.dynamic.getNullable<int>('intProp'),
+            throws<RealmException>("Property 'intProp' on class 'AllTypes' is required but the wrong method was used to access it."));
+      });
+
+      test('get fails on collections', () {
+        final config = Configuration([AllCollections.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(AllCollections());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllCollections.schema.name).single;
+        expect(
+            () => obj.dynamic.get<String>('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
+
+        expect(
+            () => obj.dynamic.get('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
+
+        expect(
+            () => obj.dynamic.getNullable<String>('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
+
+        expect(
+            () => obj.dynamic.getNullable('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
+      });
+
+      test('getList can get all list types', () {
+        final config = Configuration([AllCollections.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(_getPopulatedAllCollections());
+          staticRealm.add(AllCollections());
+        });
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+        final objects = dynamicRealm.dynamic.all(AllCollections.schema.name);
+        final obj1 = objects.singleWhere((element) => element.dynamic.getList('strings').isNotEmpty);
+        final obj2 = objects.singleWhere((element) => element.dynamic.getList('strings').isEmpty);
+
+        _validateDynamicLists(obj1, _getPopulatedAllCollections());
+        _validateDynamicLists(obj2, AllCollections());
+      });
+
+      test('getList fails with non-existent property', () {
+        final config = Configuration([AllCollections.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(AllCollections());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllCollections.schema.name).single;
+        expect(() => obj.dynamic.getList('i-dont-exist'), throws<RealmException>("Property 'i-dont-exist' does not exist on class 'AllCollections'"));
+      });
+
+      test('getList fails with wrong type', () {
+        final config = Configuration([AllCollections.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(AllCollections());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllCollections.schema.name).single;
+
+        expect(
+            () => obj.dynamic.getList<int>('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is not the correct type. Expected 'RealmPropertyType.int', got 'RealmPropertyType.string'"));
+      });
+
+      test('getList fails on non-collection properties', () {
+        final config = Configuration([AllTypes.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(_getEmptyAllTypes());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllTypes.schema.name).single;
+        expect(
+            () => obj.dynamic.getList('intProp'),
+            throws<RealmException>(
+                "Property 'intProp' on class 'AllTypes' is 'RealmCollectionType.none' but the method used to access it expected 'RealmCollectionType.list'."));
+      });
+    });
   }
 
-  test('RealmObject.dynamic.get can get all property types', () {
+  test('RealmObject.dynamic.get when static can get all property types', () {
     final config = Configuration([AllTypes.schema]);
     final staticRealm = getRealm(config);
 
@@ -209,51 +441,27 @@ Future<void> main([List<String>? args]) async {
     final date = DateTime.now();
 
     staticRealm.write(() {
-      staticRealm.add(AllTypes('abc', true, date, 123.456, objectId, uuid, 123));
-      staticRealm.add(AllTypes('', false, DateTime(0), 0, objectId, uuid, 0,
-          nullableStringProp: 'def',
-          nullableBoolProp: true,
-          nullableDateProp: date,
-          nullableDoubleProp: 999.999,
-          nullableObjectIdProp: objectId,
-          nullableUuidProp: uuid));
+      staticRealm.add(_getPopulatedAllTypes());
+      staticRealm.add(_getEmptyAllTypes());
     });
 
     for (var obj in staticRealm.all<AllTypes>()) {
-      expect(obj.dynamic.get<String>('stringProp'), obj.stringProp);
-      expect(obj.dynamic.get('stringProp'), obj.stringProp);
-      expect(obj.dynamic.getNullable<String>('nullableStringProp'), obj.nullableStringProp);
-      expect(obj.dynamic.getNullable('nullableStringProp'), obj.nullableStringProp);
+      _validateDynamic(obj, obj);
+    }
+  });
 
-      expect(obj.dynamic.get<bool>('boolProp'), obj.boolProp);
-      expect(obj.dynamic.get('boolProp'), obj.boolProp);
-      expect(obj.dynamic.getNullable<bool>('nullableBoolProp'), obj.nullableBoolProp);
-      expect(obj.dynamic.getNullable('nullableBoolProp'), obj.nullableBoolProp);
+  test('RealmObject.dynamic.getList when static can get all list types', () {
+    final config = Configuration([AllCollections.schema]);
+    final realm = getRealm(config);
 
-      expect(obj.dynamic.get<DateTime>('dateProp'), obj.dateProp);
-      expect(obj.dynamic.get('dateProp'), obj.dateProp);
-      expect(obj.dynamic.getNullable<DateTime>('nullableDateProp'), obj.nullableDateProp);
-      expect(obj.dynamic.getNullable('nullableDateProp'), obj.nullableDateProp);
+    realm.write(() {
+      realm.add(_getPopulatedAllCollections());
 
-      expect(obj.dynamic.get<double>('doubleProp'), obj.doubleProp);
-      expect(obj.dynamic.get('doubleProp'), obj.doubleProp);
-      expect(obj.dynamic.getNullable<double>('nullableDoubleProp'), obj.nullableDoubleProp);
-      expect(obj.dynamic.getNullable('nullableDoubleProp'), obj.nullableDoubleProp);
+      realm.add(AllCollections());
+    });
 
-      expect(obj.dynamic.get<ObjectId>('objectIdProp'), obj.objectIdProp);
-      expect(obj.dynamic.get('objectIdProp'), obj.objectIdProp);
-      expect(obj.dynamic.getNullable<ObjectId>('nullableObjectIdProp'), obj.nullableObjectIdProp);
-      expect(obj.dynamic.getNullable('nullableObjectIdProp'), obj.nullableObjectIdProp);
-
-      expect(obj.dynamic.get<Uuid>('uuidProp'), obj.uuidProp);
-      expect(obj.dynamic.get('uuidProp'), obj.uuidProp);
-      expect(obj.dynamic.getNullable<Uuid>('nullableUuidProp'), obj.nullableUuidProp);
-      expect(obj.dynamic.getNullable('nullableUuidProp'), obj.nullableUuidProp);
-
-      expect(obj.dynamic.get<int>('intProp'), obj.intProp);
-      expect(obj.dynamic.get('intProp'), obj.intProp);
-      expect(obj.dynamic.getNullable<int>('nullableIntProp'), obj.nullableIntProp);
-      expect(obj.dynamic.getNullable('nullableIntProp'), obj.nullableIntProp);
+    for (final obj in realm.all<AllCollections>()) {
+      _validateDynamicLists(obj, obj);
     }
   });
 }

--- a/test/dynamic_realm_test.dart
+++ b/test/dynamic_realm_test.dart
@@ -96,38 +96,39 @@ Future<void> main([List<String>? args]) async {
   void _validateDynamic(RealmObject actual, AllTypes expected) {
     expect(actual.dynamic.get<String>('stringProp'), expected.stringProp);
     expect(actual.dynamic.get('stringProp'), expected.stringProp);
-    expect(actual.dynamic.getNullable<String>('nullableStringProp'), expected.nullableStringProp);
-    expect(actual.dynamic.getNullable('nullableStringProp'), expected.nullableStringProp);
+
+    expect(actual.dynamic.get<String?>('nullableStringProp'), expected.nullableStringProp);
+    expect(actual.dynamic.get('nullableStringProp'), expected.nullableStringProp);
 
     expect(actual.dynamic.get<bool>('boolProp'), expected.boolProp);
     expect(actual.dynamic.get('boolProp'), expected.boolProp);
-    expect(actual.dynamic.getNullable<bool>('nullableBoolProp'), expected.nullableBoolProp);
-    expect(actual.dynamic.getNullable('nullableBoolProp'), expected.nullableBoolProp);
+    expect(actual.dynamic.get<bool?>('nullableBoolProp'), expected.nullableBoolProp);
+    expect(actual.dynamic.get('nullableBoolProp'), expected.nullableBoolProp);
 
     expect(actual.dynamic.get<DateTime>('dateProp'), expected.dateProp);
     expect(actual.dynamic.get('dateProp'), expected.dateProp);
-    expect(actual.dynamic.getNullable<DateTime>('nullableDateProp'), expected.nullableDateProp);
-    expect(actual.dynamic.getNullable('nullableDateProp'), expected.nullableDateProp);
+    expect(actual.dynamic.get<DateTime?>('nullableDateProp'), expected.nullableDateProp);
+    expect(actual.dynamic.get('nullableDateProp'), expected.nullableDateProp);
 
     expect(actual.dynamic.get<double>('doubleProp'), expected.doubleProp);
     expect(actual.dynamic.get('doubleProp'), expected.doubleProp);
-    expect(actual.dynamic.getNullable<double>('nullableDoubleProp'), expected.nullableDoubleProp);
-    expect(actual.dynamic.getNullable('nullableDoubleProp'), expected.nullableDoubleProp);
+    expect(actual.dynamic.get<double?>('nullableDoubleProp'), expected.nullableDoubleProp);
+    expect(actual.dynamic.get('nullableDoubleProp'), expected.nullableDoubleProp);
 
     expect(actual.dynamic.get<ObjectId>('objectIdProp'), expected.objectIdProp);
     expect(actual.dynamic.get('objectIdProp'), expected.objectIdProp);
-    expect(actual.dynamic.getNullable<ObjectId>('nullableObjectIdProp'), expected.nullableObjectIdProp);
-    expect(actual.dynamic.getNullable('nullableObjectIdProp'), expected.nullableObjectIdProp);
+    expect(actual.dynamic.get<ObjectId?>('nullableObjectIdProp'), expected.nullableObjectIdProp);
+    expect(actual.dynamic.get('nullableObjectIdProp'), expected.nullableObjectIdProp);
 
     expect(actual.dynamic.get<Uuid>('uuidProp'), expected.uuidProp);
     expect(actual.dynamic.get('uuidProp'), expected.uuidProp);
-    expect(actual.dynamic.getNullable<Uuid>('nullableUuidProp'), expected.nullableUuidProp);
-    expect(actual.dynamic.getNullable('nullableUuidProp'), expected.nullableUuidProp);
+    expect(actual.dynamic.get<Uuid?>('nullableUuidProp'), expected.nullableUuidProp);
+    expect(actual.dynamic.get('nullableUuidProp'), expected.nullableUuidProp);
 
     expect(actual.dynamic.get<int>('intProp'), expected.intProp);
     expect(actual.dynamic.get('intProp'), expected.intProp);
-    expect(actual.dynamic.getNullable<int>('nullableIntProp'), expected.nullableIntProp);
-    expect(actual.dynamic.getNullable('nullableIntProp'), expected.nullableIntProp);
+    expect(actual.dynamic.get<int?>('nullableIntProp'), expected.nullableIntProp);
+    expect(actual.dynamic.get('nullableIntProp'), expected.nullableIntProp);
   }
 
   void _validateDynamicLists(RealmObject actual, AllCollections expected) {
@@ -223,8 +224,8 @@ Future<void> main([List<String>? args]) async {
         final obj2 = objects.singleWhere((o) => o.dynamic.get<Uuid>('id') == id2);
         final obj3 = objects.singleWhere((o) => o.dynamic.get<Uuid>('id') == id3);
 
-        expect(obj1.dynamic.getNullable<RealmObject>('link'), obj2);
-        expect(obj2.dynamic.getNullable<RealmObject>('link'), obj3);
+        expect(obj1.dynamic.get<RealmObject?>('link'), obj2);
+        expect(obj2.dynamic.get<RealmObject?>('link'), obj3);
 
         final list = obj1.dynamic.getList<RealmObject>('list');
 
@@ -317,12 +318,12 @@ Future<void> main([List<String>? args]) async {
         final obj1 = dynamicRealm.dynamic.find(LinksClass.schema.name, uuid1)!;
         final obj2 = dynamicRealm.dynamic.find(LinksClass.schema.name, uuid2)!;
 
-        expect(obj1.dynamic.getNullable<RealmObject>('link'), isNull);
-        expect(obj1.dynamic.getNullable('link'), isNull);
+        expect(obj1.dynamic.get<RealmObject?>('link'), isNull);
+        expect(obj1.dynamic.get('link'), isNull);
 
-        expect(obj2.dynamic.getNullable<RealmObject>('link'), obj1);
-        expect(obj2.dynamic.getNullable('link'), obj1);
-        expect(obj2.dynamic.getNullable<RealmObject>('link')?.dynamic.get<Uuid>('id'), uuid1);
+        expect(obj2.dynamic.get<RealmObject?>('link'), obj1);
+        expect(obj2.dynamic.get('link'), obj1);
+        expect(obj2.dynamic.get<RealmObject?>('link')?.dynamic.get<Uuid>('id'), uuid1);
       });
 
       test('fails with non-existent property', () {
@@ -335,7 +336,6 @@ Future<void> main([List<String>? args]) async {
 
         final obj = dynamicRealm.dynamic.all(AllTypes.schema.name).single;
         expect(() => obj.dynamic.get('i-dont-exist'), throws<RealmException>("Property 'i-dont-exist' does not exist on class 'AllTypes'"));
-        expect(() => obj.dynamic.getNullable('i-dont-exist'), throws<RealmException>("Property 'i-dont-exist' does not exist on class 'AllTypes'"));
       });
 
       test('fails with wrong type', () {
@@ -354,15 +354,15 @@ Future<void> main([List<String>? args]) async {
                 "Property 'stringProp' on class 'AllTypes' is not the correct type. Expected 'RealmPropertyType.int', got 'RealmPropertyType.string'."));
 
         expect(
-            () => obj.dynamic.getNullable<int>('nullableStringProp'),
+            () => obj.dynamic.get<int?>('nullableStringProp'),
             throws<RealmException>(
                 "Property 'nullableStringProp' on class 'AllTypes' is not the correct type. Expected 'RealmPropertyType.int', got 'RealmPropertyType.string'."));
 
         expect(() => obj.dynamic.get<int>('nullableIntProp'),
-            throws<RealmException>("Property 'nullableIntProp' on class 'AllTypes' is nullable but the wrong method was used to access it."));
+            throws<RealmException>("Property 'nullableIntProp' on class 'AllTypes' is nullable but the generic argument passed to get<T> is int."));
 
-        expect(() => obj.dynamic.getNullable<int>('intProp'),
-            throws<RealmException>("Property 'intProp' on class 'AllTypes' is required but the wrong method was used to access it."));
+        expect(() => obj.dynamic.get<int?>('intProp'),
+            throws<RealmException>("Property 'intProp' on class 'AllTypes' is required but the generic argument passed to get<T> is int?."));
       });
 
       test('fails on collection properties', () {
@@ -385,12 +385,7 @@ Future<void> main([List<String>? args]) async {
                 "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
 
         expect(
-            () => obj.dynamic.getNullable<String>('strings'),
-            throws<RealmException>(
-                "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
-
-        expect(
-            () => obj.dynamic.getNullable('strings'),
+            () => obj.dynamic.get<String?>('strings'),
             throws<RealmException>(
                 "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
       });
@@ -532,12 +527,12 @@ Future<void> main([List<String>? args]) async {
     final obj1 = realm.find<LinksClass>(uuid1)!;
     final obj2 = realm.find<LinksClass>(uuid2)!;
 
-    expect(obj1.dynamic.getNullable<RealmObject>('link'), isNull);
-    expect(obj1.dynamic.getNullable('link'), isNull);
+    expect(obj1.dynamic.get<RealmObject?>('link'), isNull);
+    expect(obj1.dynamic.get('link'), isNull);
 
-    expect(obj2.dynamic.getNullable<RealmObject>('link'), obj1);
-    expect(obj2.dynamic.getNullable('link'), obj1);
-    expect(obj2.dynamic.getNullable<RealmObject>('link')?.dynamic.get<Uuid>('id'), uuid1);
+    expect(obj2.dynamic.get<RealmObject?>('link'), obj1);
+    expect(obj2.dynamic.get('link'), obj1);
+    expect(obj2.dynamic.get<RealmObject?>('link')?.dynamic.get<Uuid>('id'), uuid1);
   });
 
   test('RealmObject.dynamic.getList when static can get links', () {

--- a/test/dynamic_realm_test.dart
+++ b/test/dynamic_realm_test.dart
@@ -516,4 +516,50 @@ Future<void> main([List<String>? args]) async {
       _validateDynamicLists(obj, obj);
     }
   });
+
+  test('RealmObject.dynamic.get when static can get links', () {
+    final config = Configuration([LinksClass.schema]);
+    final realm = getRealm(config);
+
+    final uuid1 = Uuid.v4();
+    final uuid2 = Uuid.v4();
+
+    realm.write(() {
+      final obj1 = realm.add(LinksClass(uuid1));
+      realm.add(LinksClass(uuid2, link: obj1));
+    });
+
+    final obj1 = realm.find<LinksClass>(uuid1)!;
+    final obj2 = realm.find<LinksClass>(uuid2)!;
+
+    expect(obj1.dynamic.getNullable<RealmObject>('link'), isNull);
+    expect(obj1.dynamic.getNullable('link'), isNull);
+
+    expect(obj2.dynamic.getNullable<RealmObject>('link'), obj1);
+    expect(obj2.dynamic.getNullable('link'), obj1);
+    expect(obj2.dynamic.getNullable<RealmObject>('link')?.dynamic.get<Uuid>('id'), uuid1);
+  });
+
+  test('RealmObject.dynamic.getList when static can get links', () {
+    final config = Configuration([LinksClass.schema]);
+    final realm = getRealm(config);
+
+    final uuid1 = Uuid.v4();
+    final uuid2 = Uuid.v4();
+
+    realm.write(() {
+      final obj1 = realm.add(LinksClass(uuid1));
+      realm.add(LinksClass(uuid2, list: [obj1, obj1]));
+    });
+
+    final obj1 = realm.find<LinksClass>(uuid1)!;
+    final obj2 = realm.find<LinksClass>(uuid2)!;
+
+    expect(obj1.dynamic.getList<RealmObject>('list'), isEmpty);
+    expect(obj1.dynamic.getList('list'), isEmpty);
+
+    expect(obj2.dynamic.getList<RealmObject>('list'), [obj1, obj1]);
+    expect(obj2.dynamic.getList('list'), [obj1, obj1]);
+    expect(obj2.dynamic.getList<RealmObject>('list')[0].dynamic.get<Uuid>('id'), uuid1);
+  });
 }

--- a/test/dynamic_realm_test.dart
+++ b/test/dynamic_realm_test.dart
@@ -96,7 +96,6 @@ Future<void> main([List<String>? args]) async {
   void _validateDynamic(RealmObject actual, AllTypes expected) {
     expect(actual.dynamic.get<String>('stringProp'), expected.stringProp);
     expect(actual.dynamic.get('stringProp'), expected.stringProp);
-
     expect(actual.dynamic.get<String?>('nullableStringProp'), expected.nullableStringProp);
     expect(actual.dynamic.get('nullableStringProp'), expected.nullableStringProp);
 
@@ -129,6 +128,22 @@ Future<void> main([List<String>? args]) async {
     expect(actual.dynamic.get('intProp'), expected.intProp);
     expect(actual.dynamic.get<int?>('nullableIntProp'), expected.nullableIntProp);
     expect(actual.dynamic.get('nullableIntProp'), expected.nullableIntProp);
+
+    dynamic actualDynamic = actual;
+    expect(actualDynamic.stringProp, expected.stringProp);
+    expect(actualDynamic.nullableStringProp, expected.nullableStringProp);
+    expect(actualDynamic.boolProp, expected.boolProp);
+    expect(actualDynamic.nullableBoolProp, expected.nullableBoolProp);
+    expect(actualDynamic.dateProp, expected.dateProp);
+    expect(actualDynamic.nullableDateProp, expected.nullableDateProp);
+    expect(actualDynamic.doubleProp, expected.doubleProp);
+    expect(actualDynamic.nullableDoubleProp, expected.nullableDoubleProp);
+    expect(actualDynamic.objectIdProp, expected.objectIdProp);
+    expect(actualDynamic.nullableObjectIdProp, expected.nullableObjectIdProp);
+    expect(actualDynamic.uuidProp, expected.uuidProp);
+    expect(actualDynamic.nullableUuidProp, expected.nullableUuidProp);
+    expect(actualDynamic.intProp, expected.intProp);
+    expect(actualDynamic.nullableIntProp, expected.nullableIntProp);
   }
 
   void _validateDynamicLists(RealmObject actual, AllCollections expected) {
@@ -152,6 +167,15 @@ Future<void> main([List<String>? args]) async {
 
     expect(actual.dynamic.getList<int>('ints'), expected.ints);
     expect(actual.dynamic.getList('ints'), expected.ints);
+
+    dynamic actualDynamic = actual;
+    expect(actualDynamic.strings, expected.strings);
+    expect(actualDynamic.bools, expected.bools);
+    expect(actualDynamic.dates, expected.dates);
+    expect(actualDynamic.doubles, expected.doubles);
+    expect(actualDynamic.objectIds, expected.objectIds);
+    expect(actualDynamic.uuids, expected.uuids);
+    expect(actualDynamic.ints, expected.ints);
   }
 
   for (var isDynamic in [true, false]) {


### PR DESCRIPTION
Adds a string-based API to read properties of a RealmObject. Right now we only support reading as that's required to get migrations working, but it can be extended in the future to also support setting.


The API is the following:

```dart
final obj = realm.dynamic.find("Foo", 123);

// Get simple primitive
final str = obj.dynamic.get<String>("stringProp");

// Get another object
final bar = obj.dynamic.get<RealmObject>("bar");
final barString = bar.dynamic.get<String>("stringProp");

// Get a list of objects
final bars = obj.dynamic.getList<RealmObject>("bars");

// Iterate the list as normal
for (final bar in bars) {
  print(bar.dynamic.get<DateTime>("dateProp");
}
```

Part of https://github.com/realm/realm-dart/issues/70.