### PR TITLE
Introduce handle ownership semantics

### DIFF
--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -190,7 +190,7 @@ class ListNotificationsController<T extends Object> extends NotificationsControl
 
   @override
   RealmNotificationTokenHandle subscribe() {
-    return realmCore.subscribeListNotifications(list._handle, this, list.realm.scheduler.handle);
+    return realmCore.subscribeListNotifications(list, this, list.realm.scheduler.handle);
   }
 
   Stream<RealmListChanges<T>> createStream() {

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -199,7 +199,7 @@ class ListNotificationsController<T extends Object> extends NotificationsControl
   }
 
   @override
-  void onChanges(StandaloneHandle changesHandle) {
+  void onChanges(Handle changesHandle) {
     if (changesHandle is! RealmCollectionChangesHandle) {
       throw RealmError("Invalid changes handle. RealmCollectionChangesHandle expected");
     }

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -199,7 +199,7 @@ class ListNotificationsController<T extends Object> extends NotificationsControl
   }
 
   @override
-  void onChanges(Handle changesHandle) {
+  void onChanges(StandaloneHandle changesHandle) {
     if (changesHandle is! RealmCollectionChangesHandle) {
       throw RealmError("Invalid changes handle. RealmCollectionChangesHandle expected");
     }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1163,7 +1163,9 @@ abstract class StandaloneHandle<T extends NativeType> {
     _released = true;
   }
 
-  void release();
+  void release() {
+    _releaseCore();
+  }
 }
 
 abstract class Handle<T extends NativeType> extends StandaloneHandle<T> {
@@ -1185,11 +1187,11 @@ abstract class Handle<T extends NativeType> extends StandaloneHandle<T> {
   }
 }
 
-class SchemaHandle extends Handle<realm_schema> {
+class SchemaHandle extends StandaloneHandle<realm_schema> {
   SchemaHandle._(Pointer<realm_schema> pointer) : super(pointer, 24);
 }
 
-class ConfigHandle extends Handle<realm_config> {
+class ConfigHandle extends StandaloneHandle<realm_config> {
   ConfigHandle._(Pointer<realm_config> pointer) : super(pointer, 512);
 }
 
@@ -1220,7 +1222,7 @@ class RealmHandle extends StandaloneHandle<shared_realm> {
   }
 }
 
-class SchedulerHandle extends Handle<realm_scheduler> {
+class SchedulerHandle extends StandaloneHandle<realm_scheduler> {
   SchedulerHandle._(Pointer<realm_scheduler> pointer) : super(pointer, 24);
 }
 
@@ -1252,35 +1254,35 @@ class RealmNotificationTokenHandle extends Handle<realm_notification_token> {
   RealmNotificationTokenHandle._(Pointer<realm_notification_token> pointer, RealmHandle root) : super(pointer, 32, root: root.getIfUnowned());
 }
 
-class RealmCollectionChangesHandle extends Handle<realm_collection_changes> {
+class RealmCollectionChangesHandle extends StandaloneHandle<realm_collection_changes> {
   RealmCollectionChangesHandle._(Pointer<realm_collection_changes> pointer) : super(pointer, 256);
 }
 
-class RealmObjectChangesHandle extends Handle<realm_object_changes> {
+class RealmObjectChangesHandle extends StandaloneHandle<realm_object_changes> {
   RealmObjectChangesHandle._(Pointer<realm_object_changes> pointer) : super(pointer, 256);
 }
 
-class RealmAppCredentialsHandle extends Handle<realm_app_credentials> {
+class RealmAppCredentialsHandle extends StandaloneHandle<realm_app_credentials> {
   RealmAppCredentialsHandle._(Pointer<realm_app_credentials> pointer) : super(pointer, 16);
 }
 
-class RealmHttpTransportHandle extends Handle<realm_http_transport> {
+class RealmHttpTransportHandle extends StandaloneHandle<realm_http_transport> {
   RealmHttpTransportHandle._(Pointer<realm_http_transport> pointer) : super(pointer, 24);
 }
 
-class AppConfigHandle extends Handle<realm_app_config> {
+class AppConfigHandle extends StandaloneHandle<realm_app_config> {
   AppConfigHandle._(Pointer<realm_app_config> pointer) : super(pointer, 8);
 }
 
-class SyncClientConfigHandle extends Handle<realm_sync_client_config> {
+class SyncClientConfigHandle extends StandaloneHandle<realm_sync_client_config> {
   SyncClientConfigHandle._(Pointer<realm_sync_client_config> pointer) : super(pointer, 8);
 }
 
-class AppHandle extends Handle<realm_app> {
+class AppHandle extends StandaloneHandle<realm_app> {
   AppHandle._(Pointer<realm_app> pointer) : super(pointer, 16);
 }
 
-class UserHandle extends Handle<realm_user> {
+class UserHandle extends StandaloneHandle<realm_user> {
   UserHandle._(Pointer<realm_user> pointer) : super(pointer, 24);
 }
 

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1130,9 +1130,11 @@ class LastError {
 abstract class StandaloneHandle<T extends NativeType> {
   final Pointer<T> _pointer;
   late final Dart_FinalizableHandle _finalizableHandle;
-  bool _released = false;
+  bool _isReleased = false;
 
   bool get isUnowned => _finalizableHandle == nullptr;
+
+  bool get isReleased => _isReleased;
 
   StandaloneHandle(this._pointer, int size) {
     _finalizableHandle = _realmLib.realm_attach_finalizer(this, _pointer.cast(), size);
@@ -1149,7 +1151,7 @@ abstract class StandaloneHandle<T extends NativeType> {
   String toString() => "${_pointer.toString()} value=${_pointer.cast<IntPtr>().value}";
 
   void _releaseCore() {
-    if (_released) {
+    if (_isReleased) {
       return;
     }
 
@@ -1160,7 +1162,7 @@ abstract class StandaloneHandle<T extends NativeType> {
       _realmLib.realm_release(_pointer.cast());
     }
 
-    _released = true;
+    _isReleased = true;
   }
 
   void release() {

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -369,7 +369,7 @@ abstract class NotificationsController {
   RealmNotificationTokenHandle? handle;
 
   RealmNotificationTokenHandle subscribe();
-  void onChanges(Handle changesHandle);
+  void onChanges(StandaloneHandle changesHandle);
   void onError(RealmError error);
 
   void start() {

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -282,7 +282,6 @@ class Scheduler {
   // ignore: constant_identifier_names
   static const dynamic SCHEDULER_FINALIZE_OR_PROCESS_EXIT = 0;
   late final SchedulerHandle handle;
-  bool released = false;
   final RawReceivePort receivePort = RawReceivePort();
 
   Scheduler() {

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -215,7 +215,10 @@ class Realm {
     realmCore.closeRealm(this);
     handle.release();
 
-    _scheduler.stop();
+    if (!_handle.isUnowned) {
+      // Don't stop the scheduler for Realms we didn't create
+      _scheduler.stop();
+    }
   }
 
   /// Checks whether the `Realm` is closed.
@@ -380,7 +383,7 @@ abstract class NotificationsController {
   RealmNotificationTokenHandle? handle;
 
   RealmNotificationTokenHandle subscribe();
-  void onChanges(StandaloneHandle changesHandle);
+  void onChanges(Handle changesHandle);
   void onError(RealmError error);
 
   void start() {

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -352,7 +352,7 @@ class RealmObjectNotificationsController<T extends RealmObject> extends Notifica
   }
 
   @override
-  void onChanges(Handle changesHandle) {
+  void onChanges(StandaloneHandle changesHandle) {
     if (changesHandle is! RealmObjectChangesHandle) {
       throw RealmError("Invalid changes handle. RealmObjectChangesHandle expected");
     }

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -352,7 +352,7 @@ class RealmObjectNotificationsController<T extends RealmObject> extends Notifica
   }
 
   @override
-  void onChanges(StandaloneHandle changesHandle) {
+  void onChanges(Handle changesHandle) {
     if (changesHandle is! RealmObjectChangesHandle) {
       throw RealmError("Invalid changes handle. RealmObjectChangesHandle expected");
     }

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -343,7 +343,7 @@ class RealmObjectNotificationsController<T extends RealmObject> extends Notifica
 
   @override
   RealmNotificationTokenHandle subscribe() {
-    return realmCore.subscribeObjectNotifications(realmObject._handle!, this, realmObject.realm.scheduler.handle);
+    return realmCore.subscribeObjectNotifications(realmObject, this, realmObject.realm.scheduler.handle);
   }
 
   Stream<RealmObjectChanges<T>> createStream() {

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -32,7 +32,7 @@ class RealmResults<T extends RealmObject> extends collection.IterableBase<T> {
 
   /// The Realm instance this collection belongs to.
   final Realm realm;
-   
+
   final _supportsSnapshot = <T>[] is List<RealmObject?>;
 
   RealmResults._(this._handle, this.realm);
@@ -105,7 +105,7 @@ class ResultsNotificationsController<T extends RealmObject> extends Notification
 
   @override
   RealmNotificationTokenHandle subscribe() {
-    return realmCore.subscribeResultsNotifications(results._handle, this, results.realm.scheduler.handle);
+    return realmCore.subscribeResultsNotifications(results, this, results.realm.scheduler.handle);
   }
 
   Stream<RealmResultsChanges<T>> createStream() {

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -114,7 +114,7 @@ class ResultsNotificationsController<T extends RealmObject> extends Notification
   }
 
   @override
-  void onChanges(StandaloneHandle changesHandle) {
+  void onChanges(Handle changesHandle) {
     if (changesHandle is! RealmCollectionChangesHandle) {
       throw RealmError("Invalid changes handle. RealmCollectionChangesHandle expected");
     }

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -114,7 +114,7 @@ class ResultsNotificationsController<T extends RealmObject> extends Notification
   }
 
   @override
-  void onChanges(Handle changesHandle) {
+  void onChanges(StandaloneHandle changesHandle) {
     if (changesHandle is! RealmCollectionChangesHandle) {
       throw RealmError("Invalid changes handle. RealmCollectionChangesHandle expected");
     }

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -76,7 +76,7 @@ Future<void> main([List<String>? args]) async {
     expect(() => getRealm(config), throws<RealmException>("at path '${config.path}' does not exist"));
   });
 
-  test('Configuration readOnly - open existing realm with read-only config', () {
+  test('Configuration readOnly - open existing realm with read-only config', () async {
     Configuration config = Configuration([Car.schema]);
     var realm = getRealm(config);
     realm.close();
@@ -220,7 +220,7 @@ Future<void> main([List<String>? args]) async {
     final realm = getRealm(config);
 
     expect(realm.all<Person>().length, 0);
-  }, skip: 'TODO: fails to delete Realm - https://github.com/realm/realm-core/issues/5363');
+  });
 
   test('Configuration.initialDataCallback with error, invoked on second attempt', () {
     var invoked = false;

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -76,7 +76,7 @@ Future<void> main([List<String>? args]) async {
     expect(() => getRealm(config), throws<RealmException>("at path '${config.path}' does not exist"));
   });
 
-  test('Configuration readOnly - open existing realm with read-only config', () async {
+  test('Configuration readOnly - open existing realm with read-only config', () {
     Configuration config = Configuration([Car.schema]);
     var realm = getRealm(config);
     realm.close();


### PR DESCRIPTION
This is a refactoring of our native handle hierarchy. A summary of the changes:

* Introduces a method to release the native pointer to `Handle<T>`
  * The unowned version of the handle will not attach a native finalizer and the `release` method is a no-op.
* Adds `OwnableHandle<T>` that is owned by a Realm and it's lifetime is at most as long as the lifetime of the parent Realm.
* Modifies all the realm types (list, results, object, query) to inherit from `OwnableHandle` and modifies their ctors to optionally pass in their parent Realm as root in case it's unowned.
* `RealmHandle` cleans up all its children when released.
* Modifies the scheduler not to close its parent realm when freed - I'm not sure why this was the behavior in the first place, but I don't think it was intentional/useful.

There are some deficiencies with the current implementation:
* The `RealmHandle` keeps strong references to all its children. This is less than ideal, but there's no way to avoid it until we get weak references with dart 2.17.
  * This should not be a huge problem because the Realm is explicitly closed as soon as the callback is over.