### PR TITLE
Prepare a workflow for publishing releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,18 +59,18 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
+        if: ${{ !contains(github.head_ref, 'release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/linux/**
           key: binaries-linux-${{hashFiles('./src/**')}}
 
       - name: Setup Ninja
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Build Realm for Linux
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: ./scripts/build-linux.sh
 
       - name: Store artifacts
@@ -187,26 +187,26 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
+        if: ${{ !contains(github.head_ref, 'release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/macos/**
           key: binaries-macos-${{hashFiles('./src/**')}}
 
       - name: Install ccache
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ccache-macos
 
       - name: Enable ccache
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: |
           echo "/usr/lib/ccache" >> $GITHUB_PATH
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 
       - name: Build Realm for macOS
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: ./scripts/build-macos.sh
 
       - name: Store artifacts
@@ -288,7 +288,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: false
-      
+
       - uses: realm/ci-actions/mdb-realm/deployApps@fac1d6958f03d71de743305ce3ab27594efbe7b7
         id: deploy-mdb-apps
         with:
@@ -298,12 +298,12 @@ jobs:
           apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
           privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
           differentiator: dart-windows
-      
+
       - name : Setup Dart SDK
         uses: dart-lang/setup-dart@main
         with:
           sdk: stable
-      
+
       - name: Deploy Apps
         run: |
           dart run realm_dart deploy-apps \
@@ -325,7 +325,7 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
+        if: ${{ !contains(github.head_ref, 'release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/windows/**
@@ -340,7 +340,7 @@ jobs:
           cache-restore-keys: vcpkg-windows-x64
 
       - name: Build Realm for Windows
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: scripts\build.bat
 
       - name: Store artifacts
@@ -349,7 +349,7 @@ jobs:
           name: librealm-windows
           path: binary/windows/**
           retention-days: 1
-  
+
   cleanup-windows:
     runs-on: ubuntu-latest
     name: Cleanup Windows
@@ -451,26 +451,26 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
+        if: ${{ !contains(github.head_ref, 'release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/ios/**
           key: binaries-ios-${{hashFiles('./src/**')}}
 
       - name: Install ccache
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ccache-ios
 
       - name: Enable ccache
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: |
           echo "/usr/lib/ccache" >> $GITHUB_PATH
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 
       - name: Build Realm for iOS
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         # TODO: paralellize build to build for all architectures
         run: ./scripts/build-ios.sh simulator
 
@@ -536,7 +536,7 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
+        if: ${{ !contains(github.head_ref, 'release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/android/**
@@ -547,7 +547,7 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Build Realm for Android
-        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         # TODO: parallelize build for all architectures
         run: |
           export ANDROID_NDK=$ANDROID_NDK_HOME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,18 +59,18 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'release/') }}
+        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/linux/**
           key: binaries-linux-${{hashFiles('./src/**')}}
 
       - name: Setup Ninja
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Build Realm for Linux
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: ./scripts/build-linux.sh
 
       - name: Store artifacts
@@ -187,26 +187,26 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'release/') }}
+        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/macos/**
           key: binaries-macos-${{hashFiles('./src/**')}}
 
       - name: Install ccache
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ccache-macos
 
       - name: Enable ccache
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: |
           echo "/usr/lib/ccache" >> $GITHUB_PATH
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 
       - name: Build Realm for macOS
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: ./scripts/build-macos.sh
 
       - name: Store artifacts
@@ -325,7 +325,7 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'release/') }}
+        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/windows/**
@@ -340,7 +340,7 @@ jobs:
           cache-restore-keys: vcpkg-windows-x64
 
       - name: Build Realm for Windows
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: scripts\build.bat
 
       - name: Store artifacts
@@ -451,26 +451,26 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'release/') }}
+        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/ios/**
           key: binaries-ios-${{hashFiles('./src/**')}}
 
       - name: Install ccache
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ccache-ios
 
       - name: Enable ccache
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         run: |
           echo "/usr/lib/ccache" >> $GITHUB_PATH
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 
       - name: Build Realm for iOS
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         # TODO: paralellize build to build for all architectures
         run: ./scripts/build-ios.sh simulator
 
@@ -536,7 +536,7 @@ jobs:
 
       - name: Check cache
         id: check-cache
-        if: ${{ !contains(github.head_ref, 'release/') }}
+        if: ${{ !contains(github.head_ref, 'todo-update-me-to-release/') }}
         uses: actions/cache@v3
         with:
           path: ./binary/android/**
@@ -547,7 +547,7 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Build Realm for Android
-        if: ${{ contains(github.head_ref, 'release/') || steps.check-cache.outputs.cache-hit != 'true' }}
+        if: ${{ contains(github.head_ref, 'todo-update-me-to-release/') || steps.check-cache.outputs.cache-hit != 'true' }}
         # TODO: parallelize build for all architectures
         run: |
           export ANDROID_NDK=$ANDROID_NDK_HOME

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,31 +16,33 @@ jobs:
 
       - name: Update Changelog
         id: update-changelog
-        uses: realm/ci-actions/update-changelog@dac063f8ebd86c201590d07536d6f56f86f66ba9
+        uses: realm/ci-actions/update-changelog@2258c53d191c9a483c0b56216a0b66ccdbb35895
         with:
           changelog: ${{ github.workspace }}/CHANGELOG.md
+          version-suffix: '+alpha'
+
 
       - name: Update pubspec.yaml
         uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
         with:
           find: 'version: .*'
-          replace: 'version: ${{ steps.update-changelog.outputs.new-version }}+alpha'
-          include: '**/pubspec.yaml'
+          replace: 'version: ${{ steps.update-changelog.outputs.new-version }}'
+          include: '**pubspec.yaml'
 
       - name: Update realm.podspec
         uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
         with:
           find: "  s.version(\\s+)= '[^']*'"
-          replace: "  s.version$1= '${{ steps.update-changelog.outputs.new-version }}+alpha'"
-          include: '**/realm.podspec'
+          replace: "  s.version$1= '${{ steps.update-changelog.outputs.new-version }}'"
+          include: '**realm.podspec'
 
       - name: Update realm_core.libraryVersion
         id: update-library-version
         uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
         with:
           find: "  String get libraryVersion => '[^']*';"
-          replace: "  String get libraryVersion => '${{ steps.update-changelog.outputs.new-version }}+alpha';"
-          include: '**/realm_core.dart'
+          replace: "  String get libraryVersion => '${{ steps.update-changelog.outputs.new-version }}';"
+          include: '**realm_core.dart'
 
       - name: Make sure we updated libraryVersion
         run: |
@@ -52,8 +54,9 @@ jobs:
       - name: Create Release PR
         uses: peter-evans/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad #! 3.10.1
         with:
-          branch: release/${{ steps.update-changelog.outputs.new-version }}
-          base: master
+          # TODO: move to release/master
+          branch: test-release/${{ steps.update-changelog.outputs.new-version }}
+          base: test-master
           title: Prepare for ${{ steps.update-changelog.outputs.new-version }}
           draft: false
           body: An automated PR for next release.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -54,9 +54,8 @@ jobs:
       - name: Create Release PR
         uses: peter-evans/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad #! 3.10.1
         with:
-          # TODO: move to release/master
-          branch: test-release/${{ steps.update-changelog.outputs.new-version }}
-          base: test-master
+          branch: release/${{ steps.update-changelog.outputs.new-version }}
+          base: master
           title: Prepare for ${{ steps.update-changelog.outputs.new-version }}
           draft: false
           body: An automated PR for next release.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Update Changelog
         id: update-changelog
-        uses: realm/ci-actions/update-changelog@2258c53d191c9a483c0b56216a0b66ccdbb35895
+        uses: realm/ci-actions/update-changelog@92b1c91f266809c4374947b8846c09c9049b6f3d
         with:
           changelog: ${{ github.workspace }}/CHANGELOG.md
           version-suffix: '+alpha'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
-        submodules: recursive
+        submodules: false
 
     - name: Read version
       id: get-version
@@ -103,6 +103,7 @@ jobs:
     - name: Cleanup binary symlinks
       run: |
         rm -rf flutter/realm_flutter/android/src/main/cpp/lib
+        rm flutter/realm_flutter/ios/src
         rm flutter/realm_flutter/ios/realm_dart.xcframework
         rm flutter/realm_flutter/linux/binary
         rm flutter/realm_flutter/windows/binary

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
-        submodules: false
+        submodules: recursive
 
     - name: Read version
       id: get-version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,8 +27,6 @@ jobs:
       run: |
         pkgVersion=$(sed -ne "s/^version: \(.*\)/\1/p" pubspec.yaml)
         pkgSuffix="${{ github.event.inputs.environment != 'Production' && format('-{0}', github.sha) || '' }}"
-        echo $pkgVersion
-        echo $pkgSuffix
         echo "::set-output name=version::$pkgVersion$pkgSuffix"
       shell: bash
 
@@ -197,21 +195,6 @@ jobs:
         dart pub publish --dry-run --directory realm || true
       working-directory: release/${{ needs.prepare-packages.outputs.version }}
 
-    # - name: Configure Docs Credentials
-    #   uses: aws-actions/configure-aws-credentials@v1
-    #   with:
-    #     aws-access-key-id: ${{ secrets.DOCS_S3_ACCESS_KEY }}
-    #     aws-secret-access-key: ${{ secrets.DOCS_S3_SECRET_KEY }}
-    #     aws-region: us-east-2
-    # - name: Upload docs
-    #   run: |
-    #     Expand-Archive -Path Realm/packages/Docs.zip/Docs.zip -DestinationPath Realm/packages
-    #     $versions = "${{ steps.get-version.outputs.version }}", "latest"
-    #     Foreach ($ver in $versions)
-    #     {
-    #       aws s3 sync --acl public-read "${{ github.workspace }}\Realm\packages\_site" s3://realm-sdks/realm-sdks/dotnet/$ver/
-    #     }
-
     - name: Find Release PR
       uses: juliangruber/find-pull-request-action@f9f7484f8237cf8485e5ab826e542ba5dd9e9c6e
       id: find-pull-request
@@ -236,49 +219,6 @@ jobs:
         tag: ${{ needs.prepare-packages.outputs.version }}
         token: ${{ secrets.REALM_CI_PAT }}
         draft: true
-
-    # - name: Update Changelog
-    #   run: |
-    #     echo "## vNext (TBD)
-
-    #     ### Enhancements
-    #     * None
-
-    #     ### Fixed
-    #     * None
-
-    #     ### Compatibility
-    #     * Realm Studio: 11.0.0 or later.
-
-    #     ### Internal
-    #     * Using Core x.y.z.
-    #     " | cat - CHANGELOG.md >> temp
-    #     mv temp CHANGELOG.md
-
-    # - name: git status
-    #   run: |
-    #     git status
-
-    # - name: Create vNext PR
-    #   id: vnext-pr
-    #   uses: peter-evans/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad
-    #   with:
-    #     branch: prepare-vnext
-    #     # TODO: update to master
-    #     base: test-master
-    #     title: Prepare for vNext
-    #     draft: false
-    #     body: Update Changelog for vNext
-    #     commit-message: Prepare for vNext
-    #     token: ${{ secrets.REALM_CI_PAT }}
-    #     delete-branch: true
-
-    # - name: Merge Pull Request
-    #   uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
-    #   with:
-    #     github-token: ${{ secrets.REALM_CI_PAT }}
-    #     number: ${{ steps.vnext-pr.outputs.pull-request-number }}
-    #     method: squash
 
     - name: 'Post to #realm-releases'
       uses: realm/ci-actions/release-to-slack@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,7 +51,7 @@ jobs:
 
         for directory in binary/*; do
           targetFile="release/${directory#*-}.tar.gz"
-          dart run realm_dart archive --source-dir "${{ github.workspace }}/binary/$directory" --output-file "${{ github.workspace }}/$targetFile"
+          dart run realm_dart archive --source-dir "${{ github.workspace }}/$directory" --output-file "${{ github.workspace }}/$targetFile"
         done
 
     - name: Update realm_* path dependencies (Production)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -82,7 +82,6 @@ jobs:
         replace: 'version: ${{ steps.get-version.outputs.version }}'
         include: '**pubspec.yaml'
 
-
     - name: Remove pubspec.yaml/publish_to:none
       uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
       with:
@@ -168,7 +167,7 @@ jobs:
     if: ${{ github.event.inputs.environment == 'Production' }}
     environment:
       name: 'Production'
-      url: ${{ steps.upload-to-s3.outputs.url }}
+      url: https://pub.dev/packages/realm/versions/${{ needs.prepare-packages.outputs.version }}
     name: Publish release
     needs:
     - prepare-packages

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,14 +47,12 @@ jobs:
     # as the artifact name - i.e. librealm-linux, etc.
     - name: Archive binaries
       run: |
-        for directory in binary/*; do
-          targetDir="binary/${directory#*-}"
-          mv "$directory" "$targetDir"
-          dart run realm_dart archive --source-dir "${{ github.workspace }}/$targetDir"
-        done
+        mkdir -p release
 
-        mkdir -p release/${{ steps.get-version.outputs.version }}
-        mv binary/*.tar.gz release/${{ steps.get-version.outputs.version }}
+        for directory in binary/*; do
+          targetFile="release/${directory#*-}.tar.gz"
+          dart run realm_dart archive --source-dir "${{ github.workspace }}/binary/directory" --output-file "${{ github.workspace }}/$targetFile"
+        done
 
     - name: Update realm_* path dependencies (Production)
       uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
@@ -89,17 +87,17 @@ jobs:
 
     - name: Package common
       run: |
-        cp -Lr ../../common .
+        cp -Lr ../common .
         cd common
         dart pub publish --dry-run || true
-      working-directory: release/${{ steps.get-version.outputs.version }}
+      working-directory: release
 
     - name: Package generator
       run: |
-        cp -Lr ../../generator .
+        cp -Lr ../generator .
         cd generator
         dart pub publish --dry-run || true
-      working-directory: release/${{ steps.get-version.outputs.version }}
+      working-directory: release
 
     # realm_flutter has symlinks to native binaries which should not be packaged
     - name: Cleanup binary symlinks
@@ -113,26 +111,26 @@ jobs:
 
     - name: Package realm (flutter)
       run: |
-        cp -Lr ../../flutter/realm_flutter realm
+        cp -Lr ../flutter/realm_flutter realm
         cd realm
         dart pub publish --dry-run || true
-      working-directory: release/${{ steps.get-version.outputs.version }}
+      working-directory: release
 
     - name: Package realm_dart
       run: |
         mkdir realm_dart
-        cp -Lr ../../bin ../../example ../../lib ../../test realm_dart
-        rsync -vt ../../* realm_dart/
+        cp -Lr ../bin ../example ../lib ../test realm_dart
+        rsync -vt ../* realm_dart/
         cd realm_dart
         dart pub publish --dry-run || true
-      working-directory: release/${{ steps.get-version.outputs.version }}
+      working-directory: release
 
     - name: Extract Changelog
       run: |
-        $match = Get-Content ../../CHANGELOG.md -Raw | select-string -pattern "(?ms)^(?<latestVersionChanges>.+?)(?=(\n|\r\n)## )"
+        $match = Get-Content ../CHANGELOG.md -Raw | select-string -pattern "(?ms)^(?<latestVersionChanges>.+?)(?=(\n|\r\n)## )"
         $latestChanges = $match.Matches[0].Groups["latestVersionChanges"].Value;
         $latestChanges | Out-File ExtractedChangelog.md
-      working-directory: release/${{ steps.get-version.outputs.version }}
+      working-directory: release
       shell: pwsh
 
     - name: Upload release folder
@@ -158,7 +156,7 @@ jobs:
         s3_folder="static.realm.io/downloads/dart/${{ steps.get-version.outputs.version }}"
         aws s3 sync --acl public-read . "s3://$s3_folder"
         echo "::set-output name=url::https://$s3_folder/packages.tar.gz"
-      working-directory: release/${{ steps.get-version.outputs.version }}
+      working-directory: release
 
   publish-packages:
     runs-on: ubuntu-latest
@@ -193,7 +191,7 @@ jobs:
         dart pub publish --dry-run --directory generator || true
         dart pub publish --dry-run --directory realm_dart || true
         dart pub publish --dry-run --directory realm || true
-      working-directory: release/${{ needs.prepare-packages.outputs.version }}
+      working-directory: release
 
     - name: Find Release PR
       uses: juliangruber/find-pull-request-action@f9f7484f8237cf8485e5ab826e542ba5dd9e9c6e
@@ -211,8 +209,8 @@ jobs:
     - name: Publish Github Release
       uses: ncipollo/release-action@10c84d509b28aae3903113151bfd832314964f2e
       with:
-        artifacts: release/${{ needs.prepare-packages.outputs.version }}/*.tar.gz
-        bodyFile: release/${{ needs.prepare-packages.outputs.version }}/ExtractedChangelog.md
+        artifacts: release/*.tar.gz
+        bodyFile: release/ExtractedChangelog.md
         name: ${{ needs.prepare-packages.outputs.version }}
         # TODO: move to master
         commit: test-master
@@ -220,10 +218,11 @@ jobs:
         token: ${{ secrets.REALM_CI_PAT }}
         draft: true
 
-    - name: 'Post to #realm-releases'
-      uses: realm/ci-actions/release-to-slack@v3
-      with:
-        changelog: release/${{ needs.prepare-packages.outputs.version }}/ExtractedChangelog.md
-        sdk: dart
-        webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
-        version: ${{ needs.prepare-packages.outputs.version }}
+    # TODO: reenable
+    # - name: 'Post to #realm-releases'
+    #   uses: realm/ci-actions/release-to-slack@v3
+    #   with:
+    #     changelog: release/ExtractedChangelog.md
+    #     sdk: dart
+    #     webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
+    #     version: ${{ needs.prepare-packages.outputs.version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -185,13 +185,12 @@ jobs:
       with:
         sdk: stable
 
-    # TODO: remove --dry-run
     - name: Publish packages to pub.dev
       run: |
-        dart pub publish --dry-run --directory common || true
-        dart pub publish --dry-run --directory generator || true
-        dart pub publish --dry-run --directory realm_dart || true
-        dart pub publish --dry-run --directory realm || true
+        dart pub publish --directory common || true
+        dart pub publish --directory generator || true
+        dart pub publish --directory realm_dart || true
+        dart pub publish --directory realm || true
       working-directory: release
 
     - name: Find Release PR
@@ -213,17 +212,15 @@ jobs:
         artifacts: release/*.tar.gz
         bodyFile: release/ExtractedChangelog.md
         name: ${{ needs.prepare-packages.outputs.version }}
-        # TODO: move to master
-        commit: test-master
+        commit: master
         tag: ${{ needs.prepare-packages.outputs.version }}
         token: ${{ secrets.REALM_CI_PAT }}
-        draft: true
+        draft: false
 
-    # TODO: reenable
-    # - name: 'Post to #realm-releases'
-    #   uses: realm/ci-actions/release-to-slack@v3
-    #   with:
-    #     changelog: release/ExtractedChangelog.md
-    #     sdk: dart
-    #     webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
-    #     version: ${{ needs.prepare-packages.outputs.version }}
+    - name: 'Post to #realm-releases'
+      uses: realm/ci-actions/release-to-slack@v3
+      with:
+        changelog: release/ExtractedChangelog.md
+        sdk: dart
+        webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
+        version: ${{ needs.prepare-packages.outputs.version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Cleanup binary symlinks
       run: |
         rm -rf flutter/realm_flutter/android/src/main/cpp/lib
-        rm flutter/realm_flutter/ios/realm_flutter_ios.xcframework
+        rm flutter/realm_flutter/ios/realm_dart.xcframework
         rm flutter/realm_flutter/linux/binary
         rm flutter/realm_flutter/windows/binary
         rm flutter/realm_flutter/macos/librealm_dart.dylib

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,22 +3,288 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        type: choice
+        type: environment
+        required: true
         description: Environment to publish packages to
-        options:
-        - public
-        - internal
-      dry-run:
-        type: boolean
-        description: Run the workflow without actually uploading packages
-env:
-  REALM_CI: true
 jobs:
-  main:
+  prepare-packages:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment == 'public' && 'Production' || 'Staging' }}
+    environment:
+      name: Staging
+      url: ${{ steps.upload-to-s3.outputs.url }}
+    name: Prepare packages
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
         submodules: false
+
+    - name: Read version
+      id: get-version
+      run: |
+        pkgVersion=$(sed -ne "s/^version: \(.*\)/\1/p" pubspec.yaml)
+        pkgSuffix="${{ github.event.inputs.environment != 'Production' && format('-{0}', github.sha) || '' }}"
+        echo $pkgVersion
+        echo $pkgSuffix
+        echo "::set-output name=version::$pkgVersion$pkgSuffix"
+      shell: bash
+
+    - name : Setup Dart SDK
+      uses: dart-lang/setup-dart@main
+      with:
+        sdk: stable
+
+    - name: Download all artifacts
+      uses: dawidd6/action-download-artifact@d0f291cf39bd21965ea9c4c6e210fc355c3844ed
+      with:
+        workflow: ci.yml
+        commit: ${{ github.sha }}
+        path: ${{ github.workspace }}/binary/
+        workflow_conclusion: completed
+
+    # The rename is necessary because action-download-artifact will put things in a folder named the same
+    # as the artifact name - i.e. librealm-linux, etc.
+    - name: Archive binaries
+      run: |
+        for directory in binary/*; do
+          targetDir="binary/${directory#*-}"
+          mv "$directory" "$targetDir"
+          dart run realm_dart archive --source-dir "${{ github.workspace }}/$targetDir"
+        done
+
+        mkdir -p release/${{ steps.get-version.outputs.version }}
+        mv binary/*.tar.gz release/${{ steps.get-version.outputs.version }}
+
+    - name: Update realm_* path dependencies (Production)
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
+      if: ${{ github.event.inputs.environment == 'Production' }}
+      with:
+        find: "  realm_(common|generator):(\\n|\\r\\n)    path:.*"
+        replace: "  realm_$1: ${{ steps.get-version.outputs.version }}"
+        include: "**pubspec.yaml"
+
+    - name: Update realm_* path dependencies (Staging)
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
+      if: ${{ github.event.inputs.environment != 'Production' }}
+      with:
+        find: "  realm_(common|generator):(\\n|\\r\\n)    path:.*"
+        replace: "  realm_$1:\n    path: ../$1"
+        include: "**pubspec.yaml"
+
+    - name: Update pubspec.yaml version (Staging)
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
+      if: ${{ github.event.inputs.environment != 'Production' }}
+      with:
+        find: 'version: .*'
+        replace: 'version: ${{ steps.get-version.outputs.version }}'
+        include: '**pubspec.yaml'
+
+
+    - name: Remove pubspec.yaml/publish_to:none
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
+      with:
+        find: "publish_to: none(\\n|\\r\\n)"
+        replace: " "
+        include: "**pubspec.yaml"
+
+    - name: Package common
+      run: |
+        cp -Lr ../../common .
+        cd common
+        dart pub publish --dry-run || true
+      working-directory: release/${{ steps.get-version.outputs.version }}
+
+    - name: Package generator
+      run: |
+        cp -Lr ../../generator .
+        cd generator
+        dart pub publish --dry-run || true
+      working-directory: release/${{ steps.get-version.outputs.version }}
+
+    # realm_flutter has symlinks to native binaries which should not be packaged
+    - name: Cleanup binary symlinks
+      run: |
+        rm -rf flutter/realm_flutter/android/src/main/cpp/lib
+        rm flutter/realm_flutter/ios/realm_flutter_ios.xcframework
+        rm flutter/realm_flutter/linux/binary
+        rm flutter/realm_flutter/windows/binary
+        rm flutter/realm_flutter/macos/librealm_dart.dylib
+        rm example/binary
+
+    - name: Package realm (flutter)
+      run: |
+        cp -Lr ../../flutter/realm_flutter realm
+        cd realm
+        dart pub publish --dry-run || true
+      working-directory: release/${{ steps.get-version.outputs.version }}
+
+    - name: Package realm_dart
+      run: |
+        mkdir realm_dart
+        cp -Lr ../../bin ../../example ../../lib ../../test realm_dart
+        rsync -vt ../../* realm_dart/
+        cd realm_dart
+        dart pub publish --dry-run || true
+      working-directory: release/${{ steps.get-version.outputs.version }}
+
+    - name: Extract Changelog
+      run: |
+        $match = Get-Content ../../CHANGELOG.md -Raw | select-string -pattern "(?ms)^(?<latestVersionChanges>.+?)(?=(\n|\r\n)## )"
+        $latestChanges = $match.Matches[0].Groups["latestVersionChanges"].Value;
+        $latestChanges | Out-File ExtractedChangelog.md
+      working-directory: release/${{ steps.get-version.outputs.version }}
+      shell: pwsh
+
+    - name: Upload release folder
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-bundle
+        path: release/**
+        retention-days: 30
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY }}
+        aws-region: us-east-1
+
+    - name: Upload release folder to S3
+      id: upload-to-s3
+      run: |
+        tar -zcvf packages.tar.gz common generator realm_dart realm ExtractedChangelog.md
+        rm -rf common generator realm_dart realm ExtractedChangelog.md
+
+        s3_folder="static.realm.io/downloads/dart/${{ steps.get-version.outputs.version }}"
+        aws s3 sync --acl public-read . "s3://$s3_folder"
+        echo "::set-output name=url::https://$s3_folder/packages.tar.gz"
+      working-directory: release/${{ steps.get-version.outputs.version }}
+
+  publish-packages:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.environment == 'Production' }}
+    environment:
+      name: 'Production'
+      url: ${{ steps.upload-to-s3.outputs.url }}
+    name: Publish release
+    needs:
+    - prepare-packages
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+
+    - name: Download release folder
+      uses: actions/download-artifact@v2
+      with:
+        name: release-bundle
+        path: release
+
+    - name : Setup Dart SDK
+      uses: dart-lang/setup-dart@main
+      with:
+        sdk: stable
+
+    # TODO: remove --dry-run
+    - name: Publish packages to pub.dev
+      run: |
+        dart pub publish --dry-run --directory common || true
+        dart pub publish --dry-run --directory generator || true
+        dart pub publish --dry-run --directory realm_dart || true
+        dart pub publish --dry-run --directory realm || true
+      working-directory: release/${{ needs.prepare-packages.outputs.version }}
+
+    # - name: Configure Docs Credentials
+    #   uses: aws-actions/configure-aws-credentials@v1
+    #   with:
+    #     aws-access-key-id: ${{ secrets.DOCS_S3_ACCESS_KEY }}
+    #     aws-secret-access-key: ${{ secrets.DOCS_S3_SECRET_KEY }}
+    #     aws-region: us-east-2
+    # - name: Upload docs
+    #   run: |
+    #     Expand-Archive -Path Realm/packages/Docs.zip/Docs.zip -DestinationPath Realm/packages
+    #     $versions = "${{ steps.get-version.outputs.version }}", "latest"
+    #     Foreach ($ver in $versions)
+    #     {
+    #       aws s3 sync --acl public-read "${{ github.workspace }}\Realm\packages\_site" s3://realm-sdks/realm-sdks/dotnet/$ver/
+    #     }
+
+    - name: Find Release PR
+      uses: juliangruber/find-pull-request-action@f9f7484f8237cf8485e5ab826e542ba5dd9e9c6e
+      id: find-pull-request
+      with:
+        branch: ${{ github.ref }}
+
+    - name: Merge Pull Request
+      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
+      with:
+        github-token: ${{ secrets.REALM_CI_PAT }}
+        number: ${{ steps.find-pull-request.outputs.number }}
+        method: squash
+
+    - name: Publish Github Release
+      uses: ncipollo/release-action@10c84d509b28aae3903113151bfd832314964f2e
+      with:
+        artifacts: release/${{ needs.prepare-packages.outputs.version }}/*.tar.gz
+        bodyFile: release/${{ needs.prepare-packages.outputs.version }}/ExtractedChangelog.md
+        name: ${{ needs.prepare-packages.outputs.version }}
+        # TODO: move to master
+        commit: test-master
+        tag: ${{ needs.prepare-packages.outputs.version }}
+        token: ${{ secrets.REALM_CI_PAT }}
+        draft: true
+
+    # - name: Update Changelog
+    #   run: |
+    #     echo "## vNext (TBD)
+
+    #     ### Enhancements
+    #     * None
+
+    #     ### Fixed
+    #     * None
+
+    #     ### Compatibility
+    #     * Realm Studio: 11.0.0 or later.
+
+    #     ### Internal
+    #     * Using Core x.y.z.
+    #     " | cat - CHANGELOG.md >> temp
+    #     mv temp CHANGELOG.md
+
+    # - name: git status
+    #   run: |
+    #     git status
+
+    # - name: Create vNext PR
+    #   id: vnext-pr
+    #   uses: peter-evans/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad
+    #   with:
+    #     branch: prepare-vnext
+    #     # TODO: update to master
+    #     base: test-master
+    #     title: Prepare for vNext
+    #     draft: false
+    #     body: Update Changelog for vNext
+    #     commit-message: Prepare for vNext
+    #     token: ${{ secrets.REALM_CI_PAT }}
+    #     delete-branch: true
+
+    # - name: Merge Pull Request
+    #   uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
+    #   with:
+    #     github-token: ${{ secrets.REALM_CI_PAT }}
+    #     number: ${{ steps.vnext-pr.outputs.pull-request-number }}
+    #     method: squash
+
+    - name: 'Post to #realm-releases'
+      uses: realm/ci-actions/release-to-slack@v3
+      with:
+        changelog: release/${{ needs.prepare-packages.outputs.version }}/ExtractedChangelog.md
+        sdk: dart
+        webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
+        version: ${{ needs.prepare-packages.outputs.version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,7 +51,7 @@ jobs:
 
         for directory in binary/*; do
           targetFile="release/${directory#*-}.tar.gz"
-          dart run realm_dart archive --source-dir "${{ github.workspace }}/binary/directory" --output-file "${{ github.workspace }}/$targetFile"
+          dart run realm_dart archive --source-dir "${{ github.workspace }}/binary/$directory" --output-file "${{ github.workspace }}/$targetFile"
         done
 
     - name: Update realm_* path dependencies (Production)

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ flutter/realm_flutter/.gradle/
 # Ignore example pubspec.lock since the example always reference the local package
 example/pubspec.lock
 /generator/coverage/
+release/

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -1,5 +1,5 @@
 name: realm_common
-description: >- 
+description: >-
              Hosts the common code shared between realm, realm_dart and realm_generator packages.
              This package is part of the official Realm Flutter and Realm Dart SDKs.
 
@@ -9,10 +9,12 @@ homepage: https://www.realm.io
 repository: https://github.com/realm/realm-dart
 issue_tracker: https://github.com/realm/realm-dart/issues
 
+publish_to: none
+
 environment:
   sdk: '>=2.15.0 <3.0.0'
 
-dependencies: 
+dependencies:
   objectid: ^2.1.0
   sane_uuid: ^1.0.0-alpha.4
 

--- a/flutter/realm_flutter/linux/CMakeLists.txt
+++ b/flutter/realm_flutter/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.10)
 
 set(PROJECT_NAME "realm")
 project(${PROJECT_NAME} LANGUAGES CXX)
@@ -37,7 +37,7 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 execute_process(COMMAND "${FLUTTER_ROOT}/bin/flutter" "pub" "run" "realm" "install" "--target-os-type" "linux" "--package-name" "realm" #"--debug"
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
-  COMMAND_ERROR_IS_FATAL ANY
+  # COMMAND_ERROR_IS_FATAL ANY
 )
 message(STATUS "cmd output: ${output}")
 message(STATUS "cmd result: ${result}")

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: realm_generator
-description: >- 
+description: >-
              Generates RealmObject classes from Realm data model classes.
              This package is part of the official Realm Flutter and Realm Dart SDKs.
 
@@ -27,4 +27,4 @@ dependencies:
 dev_dependencies:
   build_test: ^2.1.4
   lints: ^1.0.1
-
+  test: ^1.14.3

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -28,3 +28,4 @@ dev_dependencies:
   build_test: ^2.1.4
   lints: ^1.0.1
   test: ^1.14.3
+  path: ^1.0.0

--- a/generator/test/test_util.dart
+++ b/generator/test/test_util.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'dart:async';
 import 'dart:convert';
-import 'package:analyzer/file_system/overlay_file_system.dart';
 import 'package:path/path.dart' as _path;
 import 'package:dart_style/dart_style.dart';
 import 'package:build_test/build_test.dart';
@@ -32,7 +31,7 @@ Future<dynamic> generatorTestBuilder(String directoryName, String inputFileName,
 Future<Map<String, Object>> getInputFileAsset(String inputFilePath) async {
   var key = 'pkg|$inputFilePath';
   String inputContent = await readFileAsDartFormattedString(inputFilePath);
-  return {key: inputContent };
+  return {key: inputContent};
 }
 
 /// A special equality matcher for strings.
@@ -59,12 +58,12 @@ class LinesEqualsMatcher extends Matcher {
 
     for (var i = 0; i < expectedLines.length - 1; i++) {
       if (i >= actualLines.length) {
-        matchState["Error"] = "Difference at line ${i+1}. \nExpected: ${expectedLines[i]}.\n  Actual: empty";
+        matchState["Error"] = "Difference at line ${i + 1}. \nExpected: ${expectedLines[i]}.\n  Actual: empty";
         return false;
       }
 
       if (expectedLines[i] != actualLines[i]) {
-        matchState["Error"] = "Difference at line ${i+1}. \nExpected: ${expectedLines[i]}.\n  Actual: ${actualLines[i]}";
+        matchState["Error"] = "Difference at line ${i + 1}. \nExpected: ${expectedLines[i]}.\n  Actual: ${actualLines[i]}";
         return false;
       }
     }

--- a/lib/src/cli/archive/archive_command.dart
+++ b/lib/src/cli/archive/archive_command.dart
@@ -48,7 +48,7 @@ class ArchiveCommand extends Command<void> {
     }
 
     if (options.outputFile == null) {
-      abort('output-file option not specified');
+      abort("output-file option not specified");
     }
 
     final archive = Archive();

--- a/lib/src/cli/archive/archive_command.dart
+++ b/lib/src/cli/archive/archive_command.dart
@@ -47,12 +47,10 @@ class ArchiveCommand extends Command<void> {
       abort("source-dir option not specified");
     }
 
-    if (options.outputFile == null) {
-      abort("output-file option not specified");
-    }
+    final outputFile = options.outputFile ?? '${options.sourceDir}.tar.gz';
 
     final archive = Archive();
-    archive.archive(Directory(options.sourceDir!), File(options.outputFile!));
+    archive.archive(Directory(options.sourceDir!), File(outputFile));
   }
 
   void abort(String error) {

--- a/lib/src/cli/archive/archive_command.dart
+++ b/lib/src/cli/archive/archive_command.dart
@@ -47,10 +47,12 @@ class ArchiveCommand extends Command<void> {
       abort("source-dir option not specified");
     }
 
-    final outputFile = options.outputFile ?? '${options.sourceDir}.tar.gz';
+    if (options.outputFile == null) {
+      abort('output-file option not specified');
+    }
 
     final archive = Archive();
-    archive.archive(Directory(options.sourceDir!), File(outputFile));
+    archive.archive(Directory(options.sourceDir!), File(options.outputFile!));
   }
 
   void abort(String error) {

--- a/lib/src/cli/install/install_command.dart
+++ b/lib/src/cli/install/install_command.dart
@@ -169,6 +169,11 @@ class InstallCommand extends Command<void> {
     final realmPackagePath = await _getRealmPackagePath();
     final realmPubspec = await _parseRealmPubspec(realmPackagePath);
 
+    if (realmPubspec.publishTo == 'none') {
+      print("Referencing $_packageName@${realmPubspec.version} which hasn't been published. Skipping download.");
+      return;
+    }
+
     final binaryPath = Directory(_getBinaryPath(path.dirname(realmPackagePath)));
     final archiveName = "${_options.targetOsType!.name}.tar.gz";
     await _downloadAndExtractBinaries(binaryPath, realmPubspec, archiveName);

--- a/lib/src/cli/install/install_command.dart
+++ b/lib/src/cli/install/install_command.dart
@@ -60,7 +60,7 @@ class InstallCommand extends Command<void> {
         case TargetOsType.macos:
           return path.join(realmPackagePath, "macos");
         case TargetOsType.linux:
-          return path.join(realmPackagePath, "linux", "binary");
+          return path.join(realmPackagePath, "linux", "binary", "linux");
         case TargetOsType.windows:
           return path.join(realmPackagePath, "windows", "binary", "windows");
         default:

--- a/lib/src/cli/install/install_command.dart
+++ b/lib/src/cli/install/install_command.dart
@@ -99,6 +99,9 @@ class InstallCommand extends Command<void> {
     }
 
     final destinationFile = File(path.join(Directory.systemTemp.absolute.path, "realm-binary", archiveName));
+    if (!await destinationFile.parent.exists()) {
+      await destinationFile.parent.create(recursive: true);
+    }
 
     print("Downloading Realm binaries for $_packageName@${realmPubspec.version} to ${destinationFile.absolute.path}");
     final client = HttpClient();

--- a/lib/src/cli/install/install_command.dart
+++ b/lib/src/cli/install/install_command.dart
@@ -44,38 +44,34 @@ class InstallCommand extends Command<void> {
 
   bool get isFlutter => options.packageName == "realm";
   bool get isDart => options.packageName == "realm_dart";
-  bool get isTargetAndroid => options.targetOsType == TargetOsType.android;
-  bool get isTargetiOS => options.targetOsType == TargetOsType.ios;
-  bool get isTargetMacOS => options.targetOsType == TargetOsType.macos;
-  bool get isTargetWindows => options.targetOsType == TargetOsType.windows;
-  bool get isTargetLinux => options.targetOsType == TargetOsType.linux;
   bool get debug => options.debug ?? false;
 
   InstallCommand() {
     populateOptionsParser(argParser);
   }
 
-  Future<bool> skipInstall() async {
-    if (debug) {
-      print("Debug flag set. Continuing Realm install command execution");
-      return false;
+  String _getBinaryPath(String realmPackagePath) {
+    if (isFlutter) {
+      switch (options.targetOsType) {
+        case TargetOsType.android:
+          return path.join(realmPackagePath, "android", "src", "main", "cpp", "lib");
+        case TargetOsType.ios:
+          return path.join(realmPackagePath, "ios");
+        case TargetOsType.macos:
+          return path.join(realmPackagePath, "macos");
+        case TargetOsType.linux:
+          return path.join(realmPackagePath, "linux", "binary");
+        case TargetOsType.windows:
+          return path.join(realmPackagePath, "windows", "binary", "windows");
+        default:
+          throw Exception("Unsupported target OS type for Flutter: ${options.targetOsType}");
+      }
     }
 
-    var pubspecFile = await File("pubspec.yaml").readAsString();
-    final projectPubspec = Pubspec.parse(pubspecFile);
-    if (projectPubspec.name == "realm" || projectPubspec.name == "realm_dart" || projectPubspec.name == packageName) {
-      return true;
-    }
-
-    const realmPackages = <String>{"realm", "realm_dart", "realm_common", "realm_generator"};
-    isPathDependency(MapEntry<String, Dependency> entry) => (realmPackages.contains(entry.key) && entry.value is PathDependency);
-
-    bool hasPathDependency = projectPubspec.dependencies.entries.any(isPathDependency);
-    hasPathDependency = hasPathDependency || projectPubspec.dependencyOverrides.entries.any(isPathDependency);
-    return hasPathDependency;
+    return path.join(Directory.current.absolute.path, 'binary', options.targetOsType!.name);
   }
 
-  Future<bool> skipDownload(String binariesPath, String expectedVersion) async {
+  Future<bool> _skipDownload(String binariesPath, String expectedVersion) async {
     final versionsFile = File(path.join(binariesPath, versionFileName));
 
     if (!await versionsFile.exists()) {
@@ -89,21 +85,20 @@ class InstallCommand extends Command<void> {
     return expectedVersion == existingVersion;
   }
 
-  Future<void> downloadAndExtractAndroidBinaries(String realmPackagePath, Pubspec realmPubspec) async {
-    var destinationDir = Directory(path.join(path.dirname(realmPackagePath), "android", "src", "main", "cpp", "lib"));
-    if (await skipDownload(destinationDir.absolute.path, realmPubspec.version.toString())) {
+  Future<void> _downloadAndExtractBinaries(Directory destinationDir, Pubspec realmPubspec, String archiveName) async {
+    if (await _skipDownload(destinationDir.absolute.path, realmPubspec.version.toString())) {
       return;
     }
 
-    var archiveName = "android.tar.gz";
-    final destinationFile = File(path.join(destinationDir.absolute.path, archiveName));
     if (!await destinationDir.exists()) {
       await destinationDir.create(recursive: true);
     }
 
+    final destinationFile = File(path.join(Directory.systemTemp.absolute.path, "realm-binary", archiveName));
+
     print("Downloading Realm binaries for $packageName@${realmPubspec.version} to ${destinationFile.absolute.path}");
     final client = HttpClient();
-    var url = 'https://github.com/realm/realm-dart/releases/download/${realmPubspec.version}/$archiveName';
+    var url = 'https://static.realm.io/downloads/dart/${realmPubspec.version}/$archiveName';
     if (debug) {
       url = 'http://localhost:8000/$archiveName';
     }
@@ -124,220 +119,11 @@ class InstallCommand extends Command<void> {
     final archive = Archive();
     await archive.extract(destinationFile, destinationDir);
 
-    await saveVersionFile(destinationDir, realmPubspec);
-  }
-
-  Future<void> downloadAndExtractiOSBinaries(String realmPackagePath, Pubspec realmPubspec) async {
-    var destinationDir = Directory(path.join(path.dirname(realmPackagePath), "ios"));
-    if (await skipDownload(destinationDir.absolute.path, realmPubspec.version.toString())) {
-      return;
-    }
-
-    var archiveName = "ios.tar.gz";
-    final destinationFile = File(path.join(destinationDir.absolute.path, archiveName));
-    if (!await destinationDir.exists()) {
-      await destinationDir.create(recursive: true);
-    }
-
-    print("Downloading Realm binaries for $packageName@${realmPubspec.version} to ${destinationFile.absolute.path}");
-    final client = HttpClient();
-    try {
-      var url = 'https://github.com/realm/realm-dart/releases/download/${realmPubspec.version}/$archiveName';
-      if (debug) {
-        url = 'http://localhost:8000/$archiveName';
-      }
-      final request = await HttpClient().getUrl(Uri.parse(url));
-      final response = await request.close();
-      if (response.statusCode >= 400) {
-        throw Exception("Error downloading Realm binaries from $url. Error code: ${response.statusCode}");
-      }
-      await response.pipe(destinationFile.openWrite());
-    }
-    //TODO: This does not handle download errors.
-     finally {
-      client.close(force: true);
-    }
-
-    print("Extracting Realm binaries to ${destinationDir.absolute.path}");
-    final archive = Archive();
-    await archive.extract(destinationFile, destinationDir);
-
-    await saveVersionFile(destinationDir, realmPubspec);
-  }
-
-  Future<void> downloadAndExtractMacOSFlutterBinaries(String realmPackagePath, Pubspec realmPubspec) async {
-    var destinationDir = Directory(path.join(path.dirname(realmPackagePath), "macos"));
-    if (await skipDownload(destinationDir.absolute.path, realmPubspec.version.toString())) {
-      return;
-    }
-
-    var archiveName = "macos.tar.gz";
-    final destinationFile = File(path.join(destinationDir.absolute.path, archiveName));
-    if (!await destinationDir.exists()) {
-      await destinationDir.create(recursive: true);
-    }
-
-    print("Downloading Realm binaries for $packageName@${realmPubspec.version} to ${destinationFile.absolute.path}");
-    final client = HttpClient();
-    try {
-      var url = 'https://github.com/realm/realm-dart/releases/download/${realmPubspec.version}/$archiveName';
-      if (debug) {
-        url = 'http://localhost:8000/$archiveName';
-      }
-      final request = await HttpClient().getUrl(Uri.parse(url));
-      final response = await request.close();
-      if (response.statusCode >= 400) {
-        throw Exception("Error downloading Realm binaries from $url. Error code: ${response.statusCode}");
-      }
-      await response.pipe(destinationFile.openWrite());
-    }
-    //TODO: This does not handle download errors.
-     finally {
-      client.close(force: true);
-    }
-
-    print("Extracting Realm binaries to ${destinationDir.absolute.path}");
-    final archive = Archive();
-    await archive.extract(destinationFile, destinationDir);
-    await saveVersionFile(destinationDir, realmPubspec);
-  }
-
-  Future<void> downloadAndExtractWindowsFlutterBinaries(String realmPackagePath, Pubspec realmPubspec) async {
-    var destinationDir = Directory(path.join(path.dirname(realmPackagePath), "windows", "binary", "windows"));
-    if (await skipDownload(destinationDir.absolute.path, realmPubspec.version.toString())) {
-      return;
-    }
-
-    var archiveName = "windows.tar.gz";
-    final destinationFile = File(path.join(destinationDir.absolute.path, archiveName));
-    if (!await destinationDir.exists()) {
-      await destinationDir.create(recursive: true);
-    }
-
-    print("Downloading Realm binaries for $packageName@${realmPubspec.version} to ${destinationFile.absolute.path}");
-    final client = HttpClient();
-    try {
-      // debug url
-      var url = 'https://github.com/realm/realm-dart/releases/download/${realmPubspec.version}/$archiveName';
-      if (debug) {
-        url = 'http://localhost:8000/$archiveName';
-      }
-      final request = await HttpClient().getUrl(Uri.parse(url));
-      final response = await request.close();
-      if (response.statusCode >= 400) {
-        throw Exception("Error downloading Realm binaries from $url. Error code: ${response.statusCode}");
-      }
-      await response.pipe(destinationFile.openWrite());
-    }
-    //TODO: This does not handle download errors.
-     finally {
-      client.close(force: true);
-    }
-
-    print("Extracting Realm binaries to ${destinationDir.absolute.path}");
-    final archive = Archive();
-    await archive.extract(destinationFile, destinationDir);
-    await saveVersionFile(destinationDir, realmPubspec);
-  }
-
-  Future<void> downloadAndExtractWindowsBinaries(String realmPackagePath, Pubspec realmPubspec) async {
-    final destinationDir = Directory(path.join(Directory.systemTemp.absolute.path, "realm-binary", "windows"));
-    final archiveName = "windows.tar.gz";
-    final destinationFile = File(path.join(destinationDir.absolute.path, archiveName));
-    if (!await skipDownload(destinationDir.absolute.path, realmPubspec.version.toString())) {
-      await download(destinationFile, realmPubspec, archiveName);
-    }
-
-    print("Extracting Realm binaries to ${destinationDir.absolute.path}");
-    final archive = Archive();
-    await archive.extract(destinationFile, destinationDir);
-    await saveVersionFile(destinationDir, realmPubspec);
-
-    final binaryName = "realm_dart.dll";
-    final binaryFile = File(path.join(Directory.current.absolute.path, "binary", "windows", binaryName));
-    //create parent dirs if needed
-    await binaryFile.create(recursive: true);
-
-    final dowloadedBinaryFile = File(path.join(destinationDir.absolute.path, binaryName));
-    print("Copying realm binary ${dowloadedBinaryFile.absolute.path} to ${binaryFile.absolute.path}");
-    await dowloadedBinaryFile.copy(binaryFile.absolute.path);
-  }
-
-  Future<void> downloadAndExtractMacOSBinaries(String realmPackagePath, Pubspec realmPubspec) async {
-    final destinationDir = Directory(path.join(Directory.systemTemp.absolute.path, "realm-binary", "macos"));
-    final archiveName = "macos.tar.gz";
-    final destinationFile = File(path.join(destinationDir.absolute.path, archiveName));
-    if (!await skipDownload(destinationDir.absolute.path, realmPubspec.version.toString())) {
-      await download(destinationFile, realmPubspec, archiveName);
-    }
-
-    print("Extracting Realm binaries to ${destinationDir.absolute.path}");
-    final archive = Archive();
-    await archive.extract(destinationFile, destinationDir);
-    await saveVersionFile(destinationDir, realmPubspec);
-
-    final binaryName = "librealm_dart.dylib";
-    final binaryFile = File(path.join(Directory.current.absolute.path, binaryName));
-
-    final dowloadedBinaryFile = File(path.join(destinationDir.absolute.path, binaryName));
-    print("Copying realm binary ${dowloadedBinaryFile.absolute.path} to ${binaryFile.absolute.path}");
-    await dowloadedBinaryFile.copy(binaryFile.absolute.path);
-  }
-
-  Future<void> downloadAndExtractLinuxBinaries(String realmPackagePath, Pubspec realmPubspec) async {
-    final destinationDir = Directory(path.join(Directory.systemTemp.absolute.path, "realm-binary", "linux"));
-    final archiveName = "linux.tar.gz";
-    final destinationFile = File(path.join(destinationDir.absolute.path, archiveName));
-    if (!await skipDownload(destinationDir.absolute.path, realmPubspec.version.toString())) {
-      await download(destinationFile, realmPubspec, archiveName);
-    }
-
-    print("Extracting Realm binaries to ${destinationDir.absolute.path}");
-    final archive = Archive();
-    await archive.extract(destinationFile, destinationDir);
-    await saveVersionFile(destinationDir, realmPubspec);
-
-    final binaryName = "librealm_dart.so";
-    final binaryFile = File(path.join(Directory.current.absolute.path, "binary", "linux", binaryName));
-    //create parent dirs if needed
-    await binaryFile.create(recursive: true);
-
-    final dowloadedBinaryFile = File(path.join(destinationDir.absolute.path, binaryName));
-    print("Copying realm binary ${dowloadedBinaryFile.absolute.path} to ${binaryFile.absolute.path}");
-    await dowloadedBinaryFile.copy(binaryFile.absolute.path);
-  }
-
-  Future<void> download(File destinationFile, Pubspec realmPubspec, String archiveName) async {
-    if (!await destinationFile.exists()) {
-      await destinationFile.create(recursive: true);
-    }
-
-    print("Downloading Realm binaries for $packageName@${realmPubspec.version} to ${destinationFile.absolute.path}");
-    final client = HttpClient();
-    try {
-      var url = 'https://github.com/realm/realm-dart/releases/download/${realmPubspec.version}/$archiveName';
-      if (debug) {
-        url = 'http://localhost:8000/$archiveName';
-      }
-      final request = await HttpClient().getUrl(Uri.parse(url));
-      final response = await request.close();
-      if (response.statusCode >= 400) {
-        throw Exception("Error downloading Realm binaries from $url. Error code: ${response.statusCode}");
-      }
-      await response.pipe(destinationFile.openWrite());
-    }
-    //TODO: This does not handle download errors.
-     finally {
-      client.close(force: true);
-    }
-  }
-
-  Future<void> saveVersionFile(Directory destinationDir, Pubspec realmPubspec) async {
-    var versionFile = File(path.join(destinationDir.absolute.path, versionFileName));
+    final versionFile = File(path.join(destinationDir.absolute.path, versionFileName));
     await versionFile.writeAsString("${realmPubspec.version}");
   }
 
-  Future<String> getRealmPackagePath() async {
+  Future<String> _getRealmPackagePath() async {
     final packageConfig = await findPackageConfig(Directory.current);
     if (packageConfig == null) {
       throw Exception("Package configuration not found. "
@@ -357,7 +143,7 @@ class InstallCommand extends Command<void> {
     return realmPackagePath;
   }
 
-  Future<Pubspec> parseRealmPubspec(String path) async {
+  Future<Pubspec> _parseRealmPubspec(String path) async {
     try {
       var realmPubspecFile = await File(path).readAsString();
       final pubspec = Pubspec.parse(realmPubspecFile);
@@ -367,53 +153,33 @@ class InstallCommand extends Command<void> {
 
       return pubspec;
     } on Exception catch (e) {
-      throw Exception("Error parsing package `$packageName` pubspect at $path. Error $e");
+      throw Exception("Error parsing package `$packageName` pubspec at $path. Error $e");
     }
   }
 
   @override
   FutureOr<void>? run() async {
-    await runInternal();
-    print("Realm install comamnd finished.");
+    await _runInternal();
+    print("Realm install command finished.");
   }
 
-  FutureOr<void>? runInternal() async {
+  FutureOr<void>? _runInternal() async {
     options = parseOptionsResult(argResults!);
-    validateOptions();
+    _validateOptions();
 
-    if (await skipInstall()) {
-      print("Realm install command started from within the realm-dart repo or one of the realm packages is a path dependency or has a path dependency override."
-          " Skipping install.");
-      return;
-    }
+    final realmPackagePath = await _getRealmPackagePath();
+    final realmPubspec = await _parseRealmPubspec(realmPackagePath);
 
-    String realmPackagePath = await getRealmPackagePath();
-    Pubspec realmPubspec = await parseRealmPubspec(realmPackagePath);
-
-    if (isTargetAndroid) {
-      return await downloadAndExtractAndroidBinaries(realmPackagePath, realmPubspec);
-    } else if (isTargetiOS) {
-      return await downloadAndExtractiOSBinaries(realmPackagePath, realmPubspec);
-    } else if (isTargetMacOS && isFlutter) {
-      return await downloadAndExtractMacOSFlutterBinaries(realmPackagePath, realmPubspec);
-    } else if (isTargetWindows && isFlutter) {
-      return await downloadAndExtractWindowsFlutterBinaries(realmPackagePath, realmPubspec);
-    } else if (isTargetWindows && isDart) {
-      return await downloadAndExtractWindowsBinaries(realmPackagePath, realmPubspec);
-    } else if (isTargetMacOS && isDart) {
-      return await downloadAndExtractMacOSBinaries(realmPackagePath, realmPubspec);
-    } else if (isTargetLinux && isDart) {
-      return await downloadAndExtractLinuxBinaries(realmPackagePath, realmPubspec);
-    } else {
-      abort("Unsupported target OS ${options.targetOsType} or package $packageName");
-    }
+    final binaryPath = Directory(_getBinaryPath(path.dirname(realmPackagePath)));
+    final archiveName = "${options.targetOsType!.name}.tar.gz";
+    await _downloadAndExtractBinaries(binaryPath, realmPubspec, archiveName);
   }
 
-  void validateOptions() {
+  void _validateOptions() {
     if (options.targetOsType == null && options.packageName == "realm") {
       abort("Invalid target OS.");
     } else if (options.targetOsType == null && options.packageName == "realm_dart") {
-      options.targetOsType = getTargetOS();
+      options.targetOsType = _getTargetOS();
     }
 
     if (!["realm", "realm_dart"].contains(options.packageName)) {
@@ -425,7 +191,7 @@ class InstallCommand extends Command<void> {
     }
   }
 
-  TargetOsType getTargetOS() {
+  TargetOsType _getTargetOS() {
     if (Platform.isWindows) {
       return TargetOsType.windows;
     } else if (Platform.isLinux) {

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -54,7 +54,12 @@ DynamicLibrary initRealm() {
         return "${File(Platform.resolvedExecutable).parent.absolute.path}/../Frameworks/realm.framework/Resources/lib$binaryName.dylib";
       }
 
-      return "binary/macos/lib$binaryName.dylib";
+      final fullPath = "/binary/macos/lib$binaryName.dylib";
+      if (File(fullPath).existsSync()) {
+        return fullPath;
+      }
+
+      return "/lib$binaryName.dylib";
     }
 
     if (Platform.isWindows) {

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -36,12 +36,7 @@ DynamicLibrary initRealm() {
     }());
   }
 
-  String _getBinaryPath(String binaryName, {String path = ""}) {
-    if (path.isNotEmpty && path.endsWith("/")) {
-      //remove trailing slash
-      path = path.substring(0, path.length - 1);
-    }
-
+  String _getBinaryPath(String binaryName) {
     if (Platform.isAndroid) {
       return "lib$binaryName.so";
     }
@@ -51,33 +46,15 @@ DynamicLibrary initRealm() {
         return '${File(Platform.resolvedExecutable).parent.path}/lib/lib$binaryName.so';
       }
 
-      if (path.isEmpty) {
-        path = 'binary/linux';
-      }
-      return "$path/lib$binaryName.so";
+      return "binary/linux/lib$binaryName.so";
     }
 
     if (Platform.isMacOS) {
       if (isFlutterPlatform) {
-        if (path.isEmpty) {
-          return "${File(Platform.resolvedExecutable).parent.absolute.path}/../Frameworks/realm.framework/Resources/lib$binaryName.dylib";
-        }
+        return "${File(Platform.resolvedExecutable).parent.absolute.path}/../Frameworks/realm.framework/Resources/lib$binaryName.dylib";
       }
 
-      if (path.isEmpty) {
-        Directory sourceDir = Directory.current;
-        path = sourceDir.path;
-      }
-
-      var fullPath = "$path/binary/macos/lib$binaryName.dylib";
-      _debugWrite("Full binary path $fullPath");
-
-      if (File(fullPath).existsSync()) {
-        return fullPath;
-      }
-
-      fullPath = "$path/lib$binaryName.dylib";
-      return fullPath;
+      return "binary/macos/lib$binaryName.dylib";
     }
 
     if (Platform.isWindows) {
@@ -85,11 +62,7 @@ DynamicLibrary initRealm() {
         return "$binaryName.dll";
       }
 
-      if (path.isEmpty) {
-        path = 'binary/windows';
-      }
-
-      return "$path/$binaryName.dll";
+      return "binary/windows/$binaryName.dll";
     }
 
     //ios links statically
@@ -99,12 +72,12 @@ DynamicLibrary initRealm() {
     throw Exception("Platform not implemented");
   }
 
-  DynamicLibrary dlopenPlatformSpecific(String binaryName, {String? path}) {
+  DynamicLibrary dlopenPlatformSpecific(String binaryName) {
     if (Platform.isIOS) {
       return DynamicLibrary.process();
     }
 
-    String fullPath = _getBinaryPath(binaryName, path: path ?? '');
+    String fullPath = _getBinaryPath(binaryName);
     return DynamicLibrary.open(fullPath);
   }
 

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -54,12 +54,7 @@ DynamicLibrary initRealm() {
         return "${File(Platform.resolvedExecutable).parent.absolute.path}/../Frameworks/realm.framework/Resources/lib$binaryName.dylib";
       }
 
-      final fullPath = "/binary/macos/lib$binaryName.dylib";
-      if (File(fullPath).existsSync()) {
-        return fullPath;
-      }
-
-      return "/lib$binaryName.dylib";
+      return "${Directory.current}/binary/macos/lib$binaryName.dylib";
     }
 
     if (Platform.isWindows) {

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -54,7 +54,7 @@ DynamicLibrary initRealm() {
         return "${File(Platform.resolvedExecutable).parent.absolute.path}/../Frameworks/realm.framework/Resources/lib$binaryName.dylib";
       }
 
-      return "${Directory.current}/binary/macos/lib$binaryName.dylib";
+      return "${Directory.current.path}/binary/macos/lib$binaryName.dylib";
     }
 
     if (Platform.isWindows) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,9 +36,8 @@ dev_dependencies:
   json_serializable: ^6.1.0
   lints: ^1.0.1
   test: ^1.14.3
-  
 
-platforms: 
+platforms:
   windows:
   linux:
   macos:


### PR DESCRIPTION
This implements a workflow that uploads binaries to S3 and optionally to pub.dev. It roughly does the following:

* Prepare packages:
  1. Downloads binaries from PR build
  1. Infers the version
    a. [Prod] version is equal to whatever is in pubspec.yaml
    a. [Staging] version is equal to whatever is in pubspec.yaml + commit sha
  1. Runs the `archive` command to produce the platform-specific archives
  1. Updates all references to `realm_common` and `realm_generator`
    a. [Prod] those point to the upcoming version
    a. [Staging] those point to `../realm_common` and `../realm_generator`
  1. Removes `publish_to: none ` from all packages
  1. Prepares the various packages in their respective folders and runs `dart pub publish --dry run` on those
  1. Uploads the release folder containing all the packages as well as all the binaries to S3 (`static.realm.io/downloads/dart/version`)
* Publish packages (only prod):
  1. Downloads the release folder
  1. Uploads all packages to pub.dev
  1. Merges the existing release PR
  1. Publishes a github release
  1. Posts to #realm-releases

This introduces some changes to `install_command.dart` and `init.dart`:
1. Reworked `install_command` to remove most of the code duplication
2. Removed some unused arguments from init.dart to make it more obvious where locations are
3. `install_command` now works with file references. It will still attempt to download binaries for those unless `publish_to: none` is specified in the reference pubspec.yaml
4. `install_command` now downloads packages from S3 rather than github releases.

Example S3 url for the packages: https://s3.amazonaws.com/static.realm.io/downloads/dart/0.3.0-37c7a6092191f97dcff467dca4bfe8be9405d77c/packages.tar.gz

Example S3 url for the binaries: https://s3.amazonaws.com/static.realm.io/downloads/dart/0.3.0-37c7a6092191f97dcff467dca4bfe8be9405d77c/macos.tar.gz

Example Github release: https://github.com/realm/realm-dart/releases/tag/untagged-a796952aac036395c582

Example slack post: https://mongodb.slack.com/archives/CMMLKL5SB/p1651685930973989

TODO:
- [x] In ci.yml: update `todo-update-me-to-release` to `release`
- [x] In prepare-release.yml: update `test-master` and `test-release` to `master` and `release`.
- [x] In publish-release.yml: Remove --dry-run from `Publish packages to pub.dev` step
- [x] In publish-release.yml: Update `Publish Github Release.commit` to `master`
- [x] In publish-release.yml: Update `Publish Github Release.draft` to `false`

Follow-up tasks:
- [ ] Update ci.yml to parallelize all architectures once https://github.com/realm/realm-dart/pull/514 is merged
- [ ] Prepare a workflow to update the standard text of changelog.md after merging (it's a bit of an annoyance so not worth delaying this PR).
- [ ] Update realm/realm_dart references in pubspec.ymls to also point to the released version (these are the two examples).