### PR TITLE
Add support for SyncSession

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,4 +19,8 @@
             "visibility": "hidden"
         }
     },
+    "files.associations": {
+        "filesystem": "cpp",
+        "*.ipp": "cpp"
+    },
 }

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -63,7 +63,7 @@ enum RealmCollectionType {
 class RealmError extends Error {
   final String? message;
   RealmError(String this.message);
-  
+
   @override
   String toString() => "Realm error : $message";
 }
@@ -77,6 +77,36 @@ class RealmUnsupportedSetError extends UnsupportedError implements RealmError {
 /// Thrown if the Realm operation is not allowed by the current state of the object.
 class RealmStateError extends StateError implements RealmError {
   RealmStateError(String message) : super(message);
+}
+
+/// Thrown or reporeted if an error occurs during synchronization
+/// {@category Sync}
+class SyncError extends RealmError {
+  /// The code of the error
+  final int code; // TODO: this should be an enum
+
+  /// The category of the error
+  final SyncErrorCategory category;
+
+  SyncError(String message, this.category, this.code) : super(message);
+}
+
+/// The category of a [SyncError].
+enum SyncErrorCategory {
+  /// The error originated from the client
+  client,
+
+  /// The error originated from the connection
+  connection,
+
+  /// The error originated from the session
+  session,
+
+  /// Another low-level system error occurred
+  system,
+
+  /// The category is unknown
+  unknown,
 }
 
 /// @nodoc

--- a/ffigen/sync_session.h
+++ b/ffigen/sync_session.h
@@ -1,0 +1,1 @@
+../src/sync_session.h

--- a/ffigen/sync_session.h
+++ b/ffigen/sync_session.h
@@ -1,1 +1,0 @@
-../src/sync_session.h

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -148,15 +148,16 @@ class AppConfiguration {
 /// {@category Application}
 class App {
   final AppHandle _handle;
-  final AppConfiguration configuration;
 
   /// Create an app with a particular [AppConfiguration]
-  App(this.configuration) : _handle = realmCore.getApp(configuration);
+  App(AppConfiguration configuration) : this._(realmCore.getApp(configuration));
+
+  App._(this._handle);
 
   /// Logs in a user with the given credentials.
   Future<User> logIn(Credentials credentials) async {
     var userHandle = await realmCore.logIn(this, credentials);
-    return UserInternal.create(this, userHandle);
+    return UserInternal.create(userHandle, app: this);
   }
 
   /// Gets the currently logged in [User]. If none exists, `null` is returned.
@@ -165,12 +166,12 @@ class App {
     if (userHandle == null) {
       return null;
     }
-    return UserInternal.create(this, userHandle);
+    return UserInternal.create(userHandle, app: this);
   }
 
   /// Gets all currently logged in users.
   Iterable<User> get users {
-    return realmCore.getUsers(this).map((handle) => UserInternal.create(this, handle));
+    return realmCore.getUsers(this).map((handle) => UserInternal.create(handle, app: this));
   }
 
   /// Removes a [user] and their local data from the device. If the user is logged in, they will be logged out in the process.
@@ -203,4 +204,6 @@ enum MetadataPersistenceMode {
 /// @nodoc
 extension AppInternal on App {
   AppHandle get handle => _handle;
+
+  static App create(AppHandle handle) => App._(handle);
 }

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -157,7 +157,7 @@ class App {
   /// Logs in a user with the given credentials.
   Future<User> logIn(Credentials credentials) async {
     var userHandle = await realmCore.logIn(this, credentials);
-    return UserInternal.create(userHandle, app: this);
+    return UserInternal.create(userHandle, this);
   }
 
   /// Gets the currently logged in [User]. If none exists, `null` is returned.
@@ -166,12 +166,12 @@ class App {
     if (userHandle == null) {
       return null;
     }
-    return UserInternal.create(userHandle, app: this);
+    return UserInternal.create(userHandle, this);
   }
 
   /// Gets all currently logged in users.
   Iterable<User> get users {
-    return realmCore.getUsers(this).map((handle) => UserInternal.create(handle, app: this));
+    return realmCore.getUsers(this).map((handle) => UserInternal.create(handle, this));
   }
 
   /// Removes a [user] and their local data from the device. If the user is logged in, they will be logged out in the process.

--- a/lib/src/cli/deployapps/baas_client.dart
+++ b/lib/src/cli/deployapps/baas_client.dart
@@ -182,7 +182,7 @@ class BaasClient {
       "flexible_sync": {
         "state": "enabled",
         "database_name": "flexible_sync_data",
-        "queryable_fields_names": ["TODO"],
+        "queryable_fields_names": ["differentiator"],
         "permissions": {
           "rules": {},
           "defaultRoles": [

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3182,6 +3182,165 @@ class RealmLibrary {
               realm_free_userdata_func_t,
               ffi.Pointer<realm_scheduler_t>)>();
 
+  /// Register a callback that will be invoked every time the session's connection state changes.
+  ///
+  /// @return A token value that can be used to unregister the callback.
+  int realm_dart_sync_session_register_connection_state_change_callback(
+    ffi.Pointer<realm_sync_session_t> session,
+    realm_sync_connection_state_changed_func_t callback,
+    ffi.Pointer<ffi.Void> userdata,
+    realm_free_userdata_func_t userdata_free,
+    ffi.Pointer<realm_scheduler_t> scheduler,
+  ) {
+    return _realm_dart_sync_session_register_connection_state_change_callback(
+      session,
+      callback,
+      userdata,
+      userdata_free,
+      scheduler,
+    );
+  }
+
+  late final _realm_dart_sync_session_register_connection_state_change_callbackPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Uint64 Function(
+                      ffi.Pointer<realm_sync_session_t>,
+                      realm_sync_connection_state_changed_func_t,
+                      ffi.Pointer<ffi.Void>,
+                      realm_free_userdata_func_t,
+                      ffi.Pointer<realm_scheduler_t>)>>(
+          'realm_dart_sync_session_register_connection_state_change_callback');
+  late final _realm_dart_sync_session_register_connection_state_change_callback =
+      _realm_dart_sync_session_register_connection_state_change_callbackPtr
+          .asFunction<
+              int Function(
+                  ffi.Pointer<realm_sync_session_t>,
+                  realm_sync_connection_state_changed_func_t,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>();
+
+  /// Register a callback that will be invoked every time the session reports progress.
+  ///
+  /// @param is_streaming If true, then the notifier will be called forever, and will
+  /// always contain the most up-to-date number of downloadable or uploadable bytes.
+  /// Otherwise, the number of downloaded or uploaded bytes will always be reported
+  /// relative to the number of downloadable or uploadable bytes at the point in time
+  /// when the notifier was registered.
+  /// @return A token value that can be used to unregister the notifier.
+  int realm_dart_sync_session_register_progress_notifier(
+    ffi.Pointer<realm_sync_session_t> session,
+    realm_sync_progress_func_t callback,
+    int direction,
+    bool is_streaming,
+    ffi.Pointer<ffi.Void> userdata,
+    realm_free_userdata_func_t userdata_free,
+    ffi.Pointer<realm_scheduler_t> scheduler,
+  ) {
+    return _realm_dart_sync_session_register_progress_notifier(
+      session,
+      callback,
+      direction,
+      is_streaming ? 1 : 0,
+      userdata,
+      userdata_free,
+      scheduler,
+    );
+  }
+
+  late final _realm_dart_sync_session_register_progress_notifierPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Uint64 Function(
+                  ffi.Pointer<realm_sync_session_t>,
+                  realm_sync_progress_func_t,
+                  ffi.Int32,
+                  ffi.Uint8,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>(
+      'realm_dart_sync_session_register_progress_notifier');
+  late final _realm_dart_sync_session_register_progress_notifier =
+      _realm_dart_sync_session_register_progress_notifierPtr.asFunction<
+          int Function(
+              ffi.Pointer<realm_sync_session_t>,
+              realm_sync_progress_func_t,
+              int,
+              int,
+              ffi.Pointer<ffi.Void>,
+              realm_free_userdata_func_t,
+              ffi.Pointer<realm_scheduler_t>)>();
+
+  /// Register a callback that will be invoked when all pending downloads have completed.
+  void realm_dart_sync_session_wait_for_download_completion(
+    ffi.Pointer<realm_sync_session_t> session,
+    realm_sync_download_completion_func_t callback,
+    ffi.Pointer<ffi.Void> userdata,
+    realm_free_userdata_func_t userdata_free,
+    ffi.Pointer<realm_scheduler_t> scheduler,
+  ) {
+    return _realm_dart_sync_session_wait_for_download_completion(
+      session,
+      callback,
+      userdata,
+      userdata_free,
+      scheduler,
+    );
+  }
+
+  late final _realm_dart_sync_session_wait_for_download_completionPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<realm_sync_session_t>,
+                  realm_sync_download_completion_func_t,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>(
+      'realm_dart_sync_session_wait_for_download_completion');
+  late final _realm_dart_sync_session_wait_for_download_completion =
+      _realm_dart_sync_session_wait_for_download_completionPtr.asFunction<
+          void Function(
+              ffi.Pointer<realm_sync_session_t>,
+              realm_sync_download_completion_func_t,
+              ffi.Pointer<ffi.Void>,
+              realm_free_userdata_func_t,
+              ffi.Pointer<realm_scheduler_t>)>();
+
+  /// Register a callback that will be invoked when all pending uploads have completed.
+  void realm_dart_sync_session_wait_for_upload_completion(
+    ffi.Pointer<realm_sync_session_t> session,
+    realm_sync_upload_completion_func_t callback,
+    ffi.Pointer<ffi.Void> userdata,
+    realm_free_userdata_func_t userdata_free,
+    ffi.Pointer<realm_scheduler_t> scheduler,
+  ) {
+    return _realm_dart_sync_session_wait_for_upload_completion(
+      session,
+      callback,
+      userdata,
+      userdata_free,
+      scheduler,
+    );
+  }
+
+  late final _realm_dart_sync_session_wait_for_upload_completionPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<realm_sync_session_t>,
+                  realm_sync_upload_completion_func_t,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>(
+      'realm_dart_sync_session_wait_for_upload_completion');
+  late final _realm_dart_sync_session_wait_for_upload_completion =
+      _realm_dart_sync_session_wait_for_upload_completionPtr.asFunction<
+          void Function(
+              ffi.Pointer<realm_sync_session_t>,
+              realm_sync_upload_completion_func_t,
+              ffi.Pointer<ffi.Void>,
+              realm_free_userdata_func_t,
+              ffi.Pointer<realm_scheduler_t>)>();
+
   Object realm_dart_weak_handle_to_object(
     ffi.Pointer<ffi.Void> handle,
   ) {
@@ -8949,6 +9108,49 @@ class _SymbolAddresses {
                   ffi.Pointer<realm_scheduler_t>)>>
       get realm_dart_sync_on_subscription_set_state_change_async =>
           _library._realm_dart_sync_on_subscription_set_state_change_asyncPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Uint64 Function(
+                  ffi.Pointer<realm_sync_session_t>,
+                  realm_sync_connection_state_changed_func_t,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>
+      get realm_dart_sync_session_register_connection_state_change_callback =>
+          _library
+              ._realm_dart_sync_session_register_connection_state_change_callbackPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Uint64 Function(
+                  ffi.Pointer<realm_sync_session_t>,
+                  realm_sync_progress_func_t,
+                  ffi.Int32,
+                  ffi.Uint8,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>
+      get realm_dart_sync_session_register_progress_notifier =>
+          _library._realm_dart_sync_session_register_progress_notifierPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<realm_sync_session_t>,
+                  realm_sync_download_completion_func_t,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>
+      get realm_dart_sync_session_wait_for_download_completion =>
+          _library._realm_dart_sync_session_wait_for_download_completionPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<realm_sync_session_t>,
+                  realm_sync_upload_completion_func_t,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>
+      get realm_dart_sync_session_wait_for_upload_completion =>
+          _library._realm_dart_sync_session_wait_for_upload_completionPtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Handle Function(ffi.Pointer<ffi.Void>)>>
       get realm_dart_weak_handle_to_object =>
           _library._realm_dart_weak_handle_to_objectPtr;

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -872,8 +872,6 @@ class _RealmCore {
       _realmLib.realm_app_config_set_platform(handle._pointer, Platform.operatingSystem.toUtf8Ptr(arena));
       _realmLib.realm_app_config_set_platform_version(handle._pointer, Platform.operatingSystemVersion.toUtf8Ptr(arena));
 
-      //This sets the realm lib version instead of the SDK version.
-      //TODO:  Read the SDK version from code generated version field
       _realmLib.realm_app_config_set_sdk_version(handle._pointer, libraryVersion.toUtf8Ptr(arena));
 
       return handle;
@@ -895,8 +893,8 @@ class _RealmCore {
   RealmHttpTransportHandle _createHttpTransport(HttpClient httpClient) {
     return RealmHttpTransportHandle._(_realmLib.realm_http_transport_new(
       Pointer.fromFunction(request_callback),
-      httpClient.toWeakHandle(),
-      nullptr,
+      httpClient.toPersistentHandle(),
+      _deletePersistentHandleFuncPtr,
     ));
   }
 

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -23,7 +23,6 @@ import 'dart:typed_data';
 
 // Hide StringUtf8Pointer.toNativeUtf8 and StringUtf16Pointer since these allows silently allocating memory. Use toUtf8Ptr instead
 import 'package:ffi/ffi.dart' hide StringUtf8Pointer, StringUtf16Pointer;
-import 'package:realm_dart/realm.dart';
 
 import '../app.dart';
 import '../collections.dart';
@@ -909,7 +908,7 @@ class _RealmCore {
     // We cannot clone request on the native side with realm_clone,
     // since realm_http_request does not inherit from WrapC.
 
-    HttpClient? userObject = userData.toObject();
+    HttpClient? userObject = userData.toObject(isPersistent: true);
     if (userObject == null) {
       return;
     }
@@ -1343,7 +1342,7 @@ class _RealmCore {
 
   AppHandle userGetApp(UserHandle userHandle) {
     final appPtr = _realmLib.realm_user_get_app(userHandle._pointer);
-    if (appPtr != nullptr) {
+    if (appPtr == nullptr) {
       throw RealmException('User does not have an associated app. This is likely due to the user being logged out.');
     }
 

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1434,9 +1434,8 @@ class _RealmCore {
 
   int sessionRegisterProgressNotifier(Session session, ProgressDirection direction, ProgressMode mode, SessionProgressNotificationsController controller) {
     final isStreaming = mode == ProgressMode.reportIndefinitely;
-    // TODO: this should use the dart version of this method
-    return _realmLib.realm_sync_session_register_progress_notifier(session.handle._pointer, Pointer.fromFunction(on_sync_progress), direction.index,
-        isStreaming, controller.toPersistentHandle(), _deletePersistentHandleFuncPtr);
+    return _realmLib.realm_dart_sync_session_register_progress_notifier(session.handle._pointer, Pointer.fromFunction(on_sync_progress), direction.index,
+        isStreaming, controller.toPersistentHandle(), _deletePersistentHandleFuncPtr, session.scheduler.handle._pointer);
   }
 
   void sessionUnregisterProgressNotifier(Session session, int token) {

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1579,7 +1579,7 @@ class RealmNotificationTokenHandle extends ReleasableHandle<realm_notification_t
 }
 
 class RealmCallbackTokenHandle extends ReleasableHandle<realm_callback_token> {
-  RealmCallbackTokenHandle._(Pointer<realm_callback_token> pointer) : super(pointer, 32);
+  RealmCallbackTokenHandle._(Pointer<realm_callback_token> pointer) : super(pointer, 24);
 }
 
 class RealmCollectionChangesHandle extends Handle<realm_collection_changes> {
@@ -1615,11 +1615,11 @@ class UserHandle extends Handle<realm_user> {
 }
 
 class SubscriptionHandle extends Handle<realm_flx_sync_subscription> {
-  SubscriptionHandle._(Pointer<realm_flx_sync_subscription> pointer) : super(pointer, 24);
+  SubscriptionHandle._(Pointer<realm_flx_sync_subscription> pointer) : super(pointer, 184);
 }
 
 class SubscriptionSetHandle extends ReleasableHandle<realm_flx_sync_subscription_set> {
-  SubscriptionSetHandle._(Pointer<realm_flx_sync_subscription_set> pointer) : super(pointer, 24);
+  SubscriptionSetHandle._(Pointer<realm_flx_sync_subscription_set> pointer) : super(pointer, 128);
 }
 
 class MutableSubscriptionSetHandle extends SubscriptionSetHandle {
@@ -1629,7 +1629,7 @@ class MutableSubscriptionSetHandle extends SubscriptionSetHandle {
 }
 
 class SessionHandle extends ReleasableHandle<realm_sync_session_t> {
-  SessionHandle._(Pointer<realm_sync_session_t> pointer) : super(pointer, 24); // TODO: what is the size?
+  SessionHandle._(Pointer<realm_sync_session_t> pointer) : super(pointer, 24);
 }
 
 extension on List<int> {

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -68,7 +68,7 @@ export 'realm_property.dart';
 export 'results.dart' show RealmResults, RealmResultsChanges;
 export 'subscription.dart' show Subscription, SubscriptionSet, SubscriptionSetState, MutableSubscriptionSet;
 export 'user.dart' show User, UserState;
-export 'session.dart' show Session, SessionState, ConnectionState;
+export 'session.dart' show Session, SessionState, ConnectionState, ProgressDirection, ProgressMode, SyncProgress;
 
 /// A [Realm] instance represents a `Realm` database.
 ///

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -296,7 +296,7 @@ class Realm {
   Session? _syncSession;
 
   /// The [Session] for this [Realm]. The sync session is responsible for two-way synchronization
-  /// with MongoDB Atlas. If the [Realm] was is not synchronized, accessing this property will throw.
+  /// with MongoDB Atlas. If the [Realm] is not synchronized, accessing this property will throw.
   Session get syncSession {
     if (config is! FlexibleSyncConfiguration) {
       throw RealmError('session is only valid on synchronized Realms (i.e. opened with FlexibleSyncConfiguration)');

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -29,6 +29,7 @@ import 'native/realm_core.dart';
 import 'realm_object.dart';
 import 'results.dart';
 import 'subscription.dart';
+import 'session.dart';
 
 export 'package:realm_common/realm_common.dart'
     show
@@ -37,6 +38,8 @@ export 'package:realm_common/realm_common.dart'
         MapTo,
         PrimaryKey,
         RealmError,
+        SyncError,
+        SyncErrorCategory,
         RealmModel,
         RealmUnsupportedSetError,
         RealmStateError,
@@ -65,6 +68,7 @@ export 'realm_property.dart';
 export 'results.dart' show RealmResults, RealmResultsChanges;
 export 'subscription.dart' show Subscription, SubscriptionSet, SubscriptionSetState, MutableSubscriptionSet;
 export 'user.dart' show User, UserState;
+export 'session.dart' show Session, SessionState, ConnectionState;
 
 /// A [Realm] instance represents a `Realm` database.
 ///
@@ -221,6 +225,12 @@ class Realm {
   /// All [RealmObject]s and `Realm ` collections are invalidated and can not be used.
   /// This method will not throw if called multiple times.
   void close() {
+    _syncSession?.handle.release();
+    _syncSession = null;
+
+    _subscriptions?.handle.release();
+    _subscriptions = null;
+
     realmCore.closeRealm(this);
     _scheduler.stop();
   }
@@ -275,12 +285,25 @@ class Realm {
 
   SubscriptionSet? _subscriptions;
 
-  /// The active [subscriptions] for this [Realm]
+  /// The active [SubscriptionSet] for this [Realm]
   SubscriptionSet get subscriptions {
     if (config is! FlexibleSyncConfiguration) throw RealmError('subscriptions is only valid on Realms opened with a FlexibleSyncConfiguration');
     _subscriptions ??= SubscriptionSetInternal.create(this, realmCore.getSubscriptions(this));
     realmCore.refreshSubscriptionSet(_subscriptions!);
     return _subscriptions!;
+  }
+
+  Session? _syncSession;
+
+  /// The [Session] for this [Realm]. The sync session is responsible for two-way synchronization
+  /// with MongoDB Atlas. If the [Realm] was is not synchronized, accessing this property will throw.
+  Session get syncSession {
+    if (config is! FlexibleSyncConfiguration) {
+      throw RealmError('session is only valid on synchronized Realms (i.e. opened with FlexibleSyncConfiguration)');
+    }
+
+    _syncSession ??= SessionInternal.create(realmCore.realmGetSession(this), scheduler);
+    return _syncSession!;
   }
 
   @override

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -145,7 +145,7 @@ class SessionProgressNotificationsController {
   final ProgressDirection _direction;
   final ProgressMode _mode;
 
-  late int? _token;
+  int? _token;
   late final StreamController<SyncProgress> _streamController;
 
   SessionProgressNotificationsController(this._session, this._direction, this._mode);
@@ -157,6 +157,10 @@ class SessionProgressNotificationsController {
 
   void onProgress(int transferredBytes, int transferableBytes) {
     _streamController.add(SyncProgress._(transferredBytes, transferableBytes));
+
+    if (transferredBytes >= transferableBytes && _mode == ProgressMode.forCurrentlyOutstandingWork) {
+      _streamController.close();
+    }
   }
 
   void _start() {

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -1,0 +1,177 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import 'dart:async';
+
+import '../realm.dart';
+import 'native/realm_core.dart';
+import 'user.dart';
+
+/// An object encapsulating a synchronization session. Sessions represent the
+/// communication between the client (and a local Realm file on disk), and the
+/// server. Sessions are always created by the SDK and vended out through various
+/// APIs. The lifespans of sessions associated with Realms are managed automatically.
+/// {@category Sync}
+class Session {
+  final SessionHandle _handle;
+
+  // This is very unpleasant, but the way we dispatch callbacks from native into
+  // dart requires us to pass down the scheudler.
+  final Scheduler _scheduler;
+
+  /// The on-disk path of the file backing the [Realm] this [Session] represents
+  String get path => realmCore.sessionGetPath(this);
+
+  /// The session’s current state. This is different from [connectionState] since a
+  /// session may be active, even if the connection is disconnected (e.g. due to the device
+  /// being offline).
+  SessionState get state => realmCore.sessionGetState(this);
+
+  /// The session’s current connection state. This is the physical state of the connection
+  /// and is different from the session's logical state, which is returned by [state].
+  ConnectionState get connectionState => realmCore.sessionGetConnectionState(this);
+
+  /// The [User] that owns the [Realm] this [Session] is synchronizing.
+  User get user => UserInternal.create(realmCore.sessionGetUser(this));
+
+  Session._(this._handle, this._scheduler);
+
+  /// Pauses any synchronization with the server until the Realm is re-opened again
+  /// after fully closing it or [resume] is called.
+  void pause() => realmCore.sessionPause(this);
+
+  /// Attempts to resume the session and enable synchronization with the server.
+  /// All sessions are active by default and calling this method is only necessary
+  /// if [pause] was called previously.
+  void resume() => realmCore.sessionResume(this);
+
+  /// Waits for the [Session] to finish all pending uploads.
+  Future<void> waitForUpload() => realmCore.sessionWaitForUpload(this);
+
+  /// Waits for the [Session] to finish all pending downloads.
+  Future<void> waitForDownload() => realmCore.sessionWaitForDownload(this);
+
+  /// Gets a [Stream] of [SyncProgress] that can be used to track upload or download progress.
+  Stream<SyncProgress> getProgressStream(ProgressDirection direction, ProgressMode mode) {
+    final controller = SessionProgressNotificationsController(this, direction, mode);
+    return controller.createStream();
+  }
+}
+
+/// The current state of a [Session] object
+enum SessionState {
+  /// The session is connected to the MongoDB Realm server and is actively transferring data.
+  active,
+
+  /// The session is not currently communicating with the server.
+  inactive,
+}
+
+/// The current connection state of a [Session] object
+enum ConnectionState {
+  /// The session is disconnected from the MongoDB Realm server.
+  disconnected,
+
+  /// The session is connecting to the MongoDB Realm server.
+  connecting,
+
+  /// The session is connected to the MongoDB Realm server.
+  connected,
+}
+
+/// The transfer direction (upload or download) tracked by a given progress notification subscription.
+enum ProgressDirection {
+  /// Monitors upload progress.
+  upload,
+
+  /// Monitors download progress.
+  download
+}
+
+/// The desired behavior of a progress notification subscription.
+enum ProgressMode {
+  /// The callback will be called forever, or until it is unregistered by disposing the subscription token.
+  /// Notifications will always report the latest number of transferred bytes, and the most up-to-date number of
+  /// total transferable bytes.
+  reportIndefinitely,
+
+  /// The callback will, upon registration, store the total number of bytes to be transferred. When invoked, it will
+  /// always report the most up-to-date number of transferable bytes out of that original number of transferable bytes.
+  /// When the number of transferred bytes reaches or exceeds the number of transferable bytes, the callback will
+  /// be unregistered.
+  forCurrentlyOutstandingWork,
+}
+
+/// A type containing information about the progress state at a given instant.
+class SyncProgress {
+  /// The number of bytes that have been transferred since subscribing for progress notifications.
+  final int transferredBytes;
+
+  /// The total number of bytes that have to be transferred since subscribing for progress notifications.
+  /// The difference between that number and [transferredBytes] gives you the number of bytes not yet
+  /// transferred. If the difference is 0, then all changes at the instant the callback fires have been
+  /// successfully transferred.
+  final int transferableBytes;
+
+  SyncProgress._(this.transferredBytes, this.transferableBytes);
+}
+
+extension SessionInternal on Session {
+  static Session create(SessionHandle handle, Scheduler scheduler) => Session._(handle, scheduler);
+
+  SessionHandle get handle => _handle;
+
+  Scheduler get scheduler => _scheduler;
+}
+
+/// @nodoc
+class SessionProgressNotificationsController {
+  final Session _session;
+  final ProgressDirection _direction;
+  final ProgressMode _mode;
+
+  late int? _token;
+  late final StreamController<SyncProgress> _streamController;
+
+  SessionProgressNotificationsController(this._session, this._direction, this._mode);
+
+  Stream<SyncProgress> createStream() {
+    _streamController = StreamController<SyncProgress>.broadcast(onListen: _start, onCancel: _stop);
+    return _streamController.stream;
+  }
+
+  void onProgress(int transferredBytes, int transferableBytes) {
+    _streamController.add(SyncProgress._(transferredBytes, transferableBytes));
+  }
+
+  void _start() {
+    if (_token != null) {
+      throw RealmStateError("Session progress subscription already started");
+    }
+
+    _token = realmCore.sessionRegisterProgressNotifier(_session, _direction, _mode, this);
+  }
+
+  void _stop() {
+    if (_token == null) {
+      return;
+    }
+
+    realmCore.sessionUnregisterProgressNotifier(_session, _token!);
+  }
+}

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -35,7 +35,7 @@ class Session {
   final Scheduler _scheduler;
 
   /// The on-disk path of the file backing the [Realm] this [Session] represents
-  String get path => realmCore.sessionGetPath(this);
+  String get realmPath => realmCore.sessionGetPath(this);
 
   /// The session’s current state. This is different from [connectionState] since a
   /// session may be active, even if the connection is disconnected (e.g. due to the device
@@ -105,7 +105,7 @@ enum ProgressDirection {
 
 /// The desired behavior of a progress notification subscription.
 enum ProgressMode {
-  /// The callback will be called forever, or until it is unregistered by disposing the subscription token.
+  /// The callback will be called forever, or until it is unregistered by closing the `Stream<SyncProgress>`.
   /// Notifications will always report the latest number of transferred bytes, and the most up-to-date number of
   /// total transferable bytes.
   reportIndefinitely,
@@ -177,5 +177,6 @@ class SessionProgressNotificationsController {
     }
 
     realmCore.sessionUnregisterProgressNotifier(_session, _token!);
+    _token = null;
   }
 }

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -31,7 +31,7 @@ class Subscription {
 
   Subscription._(this._handle);
 
-  ObjectId get _id => realmCore.subscriptionId(this);
+  late final ObjectId _id = realmCore.subscriptionId(this);
 
   /// Name of the [Subscription], if one was provided at creation time.
   String? get name => realmCore.subscriptionName(this);
@@ -206,11 +206,11 @@ extension SubscriptionSetInternal on SubscriptionSet {
   Realm get realm => _realm;
   SubscriptionSetHandle get handle => _handle;
 
-  static SubscriptionSet create(Realm realm, SubscriptionSetHandle handle) => _ImmutableSubscriptionSet._(realm, handle);
+  static SubscriptionSet create(Realm realm, SubscriptionSetHandle handle) => ImmutableSubscriptionSet._(realm, handle);
 }
 
-class _ImmutableSubscriptionSet extends SubscriptionSet {
-  _ImmutableSubscriptionSet._(Realm realm, SubscriptionSetHandle handle) : super._(realm, handle);
+class ImmutableSubscriptionSet extends SubscriptionSet {
+  ImmutableSubscriptionSet._(Realm realm, SubscriptionSetHandle handle) : super._(realm, handle);
 
   @override
   void update(void Function(MutableSubscriptionSet mutableSubscriptions) action) {

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -34,8 +34,6 @@ class Subscription {
   ObjectId get _id => realmCore.subscriptionId(this);
 
   /// Name of the [Subscription], if one was provided at creation time.
-  /// 
-  /// Otherwise returns null.
   String? get name => realmCore.subscriptionName(this);
 
   /// Class name of objects the [Subscription] refers to.
@@ -45,8 +43,8 @@ class Subscription {
   /// rather than the name of the generated Dart class.
   String get objectClassName => realmCore.subscriptionObjectClassName(this);
 
-  /// Query string that describes the [Subscription]. 
-  /// 
+  /// Query string that describes the [Subscription].
+  ///
   /// Objects matched by the query will be sent to the device by the server.
   String get queryString => realmCore.subscriptionQueryString(this);
 
@@ -62,7 +60,7 @@ class Subscription {
     if (identical(this, other)) return true;
     if (other is! Subscription) return false;
     // TODO: Don't work, issue with C-API
-    // return realmCore.subscriptionEquals(this, other); 
+    // return realmCore.subscriptionEquals(this, other);
     return id == other.id; // <-- do this instead
   }
 }
@@ -134,16 +132,12 @@ abstract class SubscriptionSet with IterableMixin<Subscription> {
   /// Finds an existing [Subscription] in this set by its query
   ///
   /// The [query] is represented by the corresponding [RealmResults] object.
-  ///
-  /// Returns null, if not found
   Subscription? find<T extends RealmObject>(RealmResults<T> query) {
     final result = realmCore.findSubscriptionByResults(this, query);
     return result == null ? null : Subscription._(result);
   }
 
   /// Finds an existing [Subscription] in this set by name.
-  ///
-  /// Returns null, if not found
   Subscription? findByName(String name) {
     final result = realmCore.findSubscriptionByName(this, name);
     return result == null ? null : Subscription._(result);
@@ -203,7 +197,7 @@ abstract class SubscriptionSet with IterableMixin<Subscription> {
       case SubscriptionSetState._bootstrapping:
         return SubscriptionSetState.pending;
       default:
-        return state;  
+        return state;
     }
   }
 }

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -20,6 +20,7 @@ import 'dart:convert';
 
 import 'native/realm_core.dart';
 import 'realm_class.dart';
+import './app.dart';
 
 /// This class represents a `user` in a MongoDB Realm app.
 /// A user can log in to the server and, if access is granted, it is possible to synchronize the local Realm to MongoDB.

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -29,12 +29,17 @@ import './app.dart';
 /// locally on the device, and should be treated as sensitive data.
 /// {@category Application}
 class User {
+  final App? _app;
   final UserHandle _handle;
 
   /// The [App] with which the [User] is associated with.
-  final App app;
+  App get app {
+    // The _app field may be null when we're retrieving a user from the session
+    // rather than from the app.
+    return _app ?? AppInternal.create(realmCore.userGetApp(_handle));
+  }
 
-  User._(this.app, this._handle);
+  User._(this._handle, this._app);
 
   /// The current state of this [User].
   UserState get state {
@@ -187,9 +192,5 @@ extension UserIdentityInternal on UserIdentity {
 extension UserInternal on User {
   UserHandle get handle => _handle;
 
-  static User create(UserHandle handle, [App? app]) {
-    app ??= AppInternal.create(realmCore.userGetApp(handle));
-
-    return User._(app, handle);
-  }
+  static User create(UserHandle handle, [App? app]) => User._(handle, app);
 }

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -105,7 +105,7 @@ class User {
   /// ```
   Future<User> linkCredentials(Credentials credentials) async {
     final userHandle = await realmCore.userLinkCredentials(app, this, credentials);
-    return UserInternal.create(userHandle, app: app);
+    return UserInternal.create(userHandle, app);
   }
 
   @override
@@ -146,25 +146,25 @@ class UserProfile {
 
   /// Gets the name of the [User].
   String? get name => _data["name"] as String?;
-  
+
   /// Gets the first name of the [User].
   String? get firstName => _data["firstName"] as String?;
 
   /// Gets the last name of the [User].
   String? get lastName => _data["lastName"] as String?;
-  
+
   /// Gets the email of the [User].
   String? get email => _data["email"] as String?;
-  
+
   /// Gets the gender of the [User].
   String? get gender => _data["gender"] as String?;
-  
+
   /// Gets the birthday of the user.
   String? get birthDay => _data["birthDay"] as String?;
-  
+
   /// Gets the minimum age of the [User].
   String? get minAge => _data["minAge"] as String?;
-  
+
   /// Gets the maximum age of the [User].
   String? get maxAge => _data["maxAge"] as String?;
 
@@ -172,7 +172,7 @@ class UserProfile {
   String? get pictureUrl => _data["pictureUrl"] as String?;
 
   /// Gets a profile property of the [User].
-  dynamic operator[](String property) => _data[property];
+  dynamic operator [](String property) => _data[property];
 
   const UserProfile(this._data);
 }
@@ -186,7 +186,7 @@ extension UserIdentityInternal on UserIdentity {
 extension UserInternal on User {
   UserHandle get handle => _handle;
 
-  static User create(UserHandle handle, {App? app}) {
+  static User create(UserHandle handle, [App? app]) {
     app ??= AppInternal.create(realmCore.userGetApp(handle));
 
     return User._(app, handle);

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -105,7 +105,7 @@ class User {
   /// ```
   Future<User> linkCredentials(Credentials credentials) async {
     final userHandle = await realmCore.userLinkCredentials(app, this, credentials);
-    return UserInternal.create(app, userHandle);
+    return UserInternal.create(userHandle, app: app);
   }
 
   @override
@@ -186,5 +186,9 @@ extension UserIdentityInternal on UserIdentity {
 extension UserInternal on User {
   UserHandle get handle => _handle;
 
-  static User create(App app, UserHandle handle) => User._(app, handle);
+  static User create(UserHandle handle, {App? app}) {
+    app ??= AppInternal.create(realmCore.userGetApp(handle));
+
+    return User._(app, handle);
+  }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,9 +8,10 @@ endif()
 add_subdirectory(dart-dl)
 
 set(SOURCES
-    realm_dart.cpp
-    realm_dart_scheduler.cpp
-    subscription_set.cpp
+     realm_dart.cpp
+     realm_dart_scheduler.cpp
+     subscription_set.cpp
+     sync_session.cpp
 )
 
 set(HEADERS
@@ -18,6 +19,7 @@ set(HEADERS
     realm_dart_scheduler.h
     realm-core/src/realm.h
     subscription_set.h
+    sync_session.h
 )
 
 add_library(realm_dart SHARED ${SOURCES} ${HEADERS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,10 +8,10 @@ endif()
 add_subdirectory(dart-dl)
 
 set(SOURCES
-     realm_dart.cpp
-     realm_dart_scheduler.cpp
-     subscription_set.cpp
-     sync_session.cpp
+    realm_dart.cpp
+    realm_dart_scheduler.cpp
+    subscription_set.cpp
+    sync_session.cpp
 )
 
 set(HEADERS

--- a/src/sync_session.cpp
+++ b/src/sync_session.cpp
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <realm/object-store/c_api/util.hpp>
+
+#include "sync_session.h"
+#include "event_loop_dispatcher.hpp"
+
+namespace realm::c_api {
+namespace _1 {
+
+using FreeT = std::function<void()>;
+using CallbackT = std::function<void(realm_sync_error_code_t*)>;
+using UserdataT = std::tuple<CallbackT, FreeT>;
+
+void _callback(void* userdata, realm_sync_error_code_t* error) {
+    auto u = reinterpret_cast<UserdataT*>(userdata);
+    std::get<0>(*u)(error);
+}
+
+void _userdata_free(void* userdata) {
+    auto u = reinterpret_cast<UserdataT*>(userdata);
+    std::get<1>(*u)();
+    delete u;
+}
+
+RLM_API void realm_dart_sync_session_wait_for_download_completion(realm_sync_session_t* session,
+                                                                  realm_sync_download_completion_func_t callback,
+                                                                  void* userdata,
+                                                                  realm_free_userdata_func_t userdata_free,
+                                                                  realm_scheduler_t* scheduler) noexcept
+{
+    auto u = new UserdataT(std::bind(util::EventLoopDispatcher{ *scheduler, callback }, userdata, std::placeholders::_1),
+                           std::bind(util::EventLoopDispatcher{ *scheduler, userdata_free }, userdata));
+    realm_sync_session_wait_for_download_completion(session, _callback, u, _userdata_free);
+}
+
+RLM_API void realm_dart_sync_session_wait_for_upload_completion(realm_sync_session_t* session,
+                                                                realm_sync_upload_completion_func_t callback,
+                                                                void* userdata,
+                                                                realm_free_userdata_func_t userdata_free,
+                                                                realm_scheduler_t* scheduler) noexcept
+{
+    auto u = new UserdataT(std::bind(util::EventLoopDispatcher{ *scheduler, callback }, userdata, std::placeholders::_1),
+                           std::bind(util::EventLoopDispatcher{ *scheduler, userdata_free }, userdata));
+    realm_sync_session_wait_for_upload_completion(session, _callback, u, _userdata_free);
+}
+
+} // anonymous namespace
+
+namespace _2 {
+
+using FreeT = std::function<void()>;
+using CallbackT = std::function<void(uint64_t, uint64_t)>;
+using UserdataT = std::tuple<CallbackT, FreeT>;
+
+void _callback(void* userdata, uint64_t transferred_bytes, uint64_t total_bytes) {
+    auto u = reinterpret_cast<UserdataT*>(userdata);
+    std::get<0>(*u)(transferred_bytes, total_bytes);
+}
+
+void _userdata_free(void* userdata) {
+    auto u = reinterpret_cast<UserdataT*>(userdata);
+    std::get<1>(*u)();
+    delete u;
+}
+
+RLM_API uint64_t realm_dart_sync_session_register_progress_notifier(realm_sync_session_t* session,
+                                                                    realm_sync_progress_func_t callback,
+                                                                    realm_sync_progress_direction_e direction,
+                                                                    bool is_streaming,
+                                                                    void* userdata,
+                                                                    realm_free_userdata_func_t userdata_free,
+                                                                    realm_scheduler_t* scheduler) noexcept
+{
+    auto u = new UserdataT(std::bind(util::EventLoopDispatcher{ *scheduler, callback }, userdata, std::placeholders::_1, std::placeholders::_2),
+                           std::bind(util::EventLoopDispatcher{ *scheduler, userdata_free }, userdata));
+    return realm_sync_session_register_progress_notifier(session, _callback, direction, is_streaming, u, _userdata_free);
+}
+
+} // anonymous namespace
+
+namespace _3 {
+
+using FreeT = std::function<void()>;
+using CallbackT = std::function<void(realm_sync_connection_state_e, realm_sync_connection_state_e)>;
+using UserdataT = std::tuple<CallbackT, FreeT>;
+
+void _callback(void* userdata, realm_sync_connection_state_e old_state, realm_sync_connection_state_e new_state) {
+    auto u = reinterpret_cast<UserdataT*>(userdata);
+    std::get<0>(*u)(old_state, new_state);
+}
+
+void _userdata_free(void* userdata) {
+    auto u = reinterpret_cast<UserdataT*>(userdata);
+    std::get<1>(*u)();
+    delete u;
+}
+
+RLM_API uint64_t realm_dart_sync_session_register_connection_state_change_callback(realm_sync_session_t* session,
+                                                                              realm_sync_connection_state_changed_func_t callback,
+                                                                              void* userdata,
+                                                                              realm_free_userdata_func_t userdata_free,
+                                                                              realm_scheduler_t* scheduler) noexcept
+{
+    auto u = new UserdataT(std::bind(util::EventLoopDispatcher{ *scheduler, callback }, userdata, std::placeholders::_1, std::placeholders::_2),
+                           std::bind(util::EventLoopDispatcher{ *scheduler, userdata_free }, userdata));
+    return realm_sync_session_register_connection_state_change_callback(session, _callback, u, _userdata_free);
+}
+
+} // anonymous namespace
+
+} // namespace realm::c_api 

--- a/src/sync_session.h
+++ b/src/sync_session.h
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_DART_SYNC_SESSION_H
+#define REALM_DART_SYNC_SESSION_H
+
+#include "realm.h"
+
+/**
+ * Register a callback that will be invoked when all pending downloads have completed.
+ */
+RLM_API void realm_dart_sync_session_wait_for_download_completion(realm_sync_session_t* session,
+                                                                  realm_sync_download_completion_func_t callback,
+                                                                  void* userdata,
+                                                                  realm_free_userdata_func_t userdata_free,
+                                                                  realm_scheduler_t* scheduler) RLM_API_NOEXCEPT;
+
+/**
+ * Register a callback that will be invoked when all pending uploads have completed.
+ */
+RLM_API void realm_dart_sync_session_wait_for_upload_completion(realm_sync_session_t* session,
+                                                                realm_sync_upload_completion_func_t callback,
+                                                                void* userdata,
+                                                                realm_free_userdata_func_t userdata_free,
+                                                                realm_scheduler_t* scheduler) RLM_API_NOEXCEPT;
+
+/**
+ * Register a callback that will be invoked every time the session reports progress.
+ *
+ * @param is_streaming If true, then the notifier will be called forever, and will
+ *                     always contain the most up-to-date number of downloadable or uploadable bytes.
+ *                     Otherwise, the number of downloaded or uploaded bytes will always be reported
+ *                     relative to the number of downloadable or uploadable bytes at the point in time
+ *                     when the notifier was registered.
+ * @return A token value that can be used to unregister the notifier.
+ */
+RLM_API uint64_t realm_dart_sync_session_register_progress_notifier(realm_sync_session_t* session,
+                                                                    realm_sync_progress_func_t callback,
+                                                                    realm_sync_progress_direction_e direction,
+                                                                    bool is_streaming,
+                                                                    void* userdata,
+                                                                    realm_free_userdata_func_t userdata_free,
+                                                                    realm_scheduler_t* scheduler) RLM_API_NOEXCEPT;
+
+/**
+ * Register a callback that will be invoked every time the session's connection state changes.
+ *
+ * @return A token value that can be used to unregister the callback.
+ */
+RLM_API uint64_t realm_dart_sync_session_register_connection_state_change_callback(realm_sync_session_t* session,
+                                                                                   realm_sync_connection_state_changed_func_t callback,
+                                                                                   void* userdata,
+                                                                                   realm_free_userdata_func_t userdata_free,
+                                                                                   realm_scheduler_t* scheduler) RLM_API_NOEXCEPT;
+
+
+#endif // REALM_DART_SYNC_SESSION_H

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -101,8 +101,7 @@ test('AppConfiguration can be created with defaults', () {
 
   test('App can be created', () async {
     final configuration = AppConfiguration(generateRandomString(10));
-    final app = App(configuration);
-    expect(app.configuration, configuration);
+    App(configuration);
   });
 
   baasTest('App log in', (configuration) async {
@@ -163,7 +162,7 @@ test('AppConfiguration can be created with defaults', () {
 
     final user1 = await app.logIn(Credentials.anonymous());
     expect(app.currentUser, user1);
-    
+
     final user2 = await app.logIn(Credentials.emailPassword(testUsername, testPassword));
 
     expect(app.currentUser, user2);

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -60,17 +60,19 @@ Future<void> main([List<String>? args]) async {
     expect(appConfig.maxConnectionTimeout, const Duration(minutes: 1));
     expect(appConfig.httpClient, httpClient);
   });
-  
-test('AppConfiguration can be created with defaults', () {
+
+  test('AppConfiguration can be created with defaults', () {
     final appConfig = AppConfiguration('myapp1');
-    final app = App(appConfig);
-    expect(app.configuration.appId, 'myapp1');
-    expect(app.configuration.baseUrl, Uri.parse('https://realm.mongodb.com'));
-    expect(app.configuration.defaultRequestTimeout, const Duration(minutes: 1));
-    expect(app.configuration.logLevel, LogLevel.error);
-    expect(app.configuration.metadataPersistenceMode, MetadataPersistenceMode.plaintext);
-    expect(app.configuration.maxConnectionTimeout, const Duration(minutes: 2));
-    expect(app.configuration.httpClient, isNotNull);
+    expect(appConfig.appId, 'myapp1');
+    expect(appConfig.baseUrl, Uri.parse('https://realm.mongodb.com'));
+    expect(appConfig.defaultRequestTimeout, const Duration(minutes: 1));
+    expect(appConfig.logLevel, LogLevel.error);
+    expect(appConfig.metadataPersistenceMode, MetadataPersistenceMode.plaintext);
+    expect(appConfig.maxConnectionTimeout, const Duration(minutes: 2));
+    expect(appConfig.httpClient, isNotNull);
+
+    // Check that the app constructor works
+    App(appConfig);
   });
 
   test('AppConfiguration can be created', () {
@@ -88,15 +90,18 @@ test('AppConfiguration can be created with defaults', () {
       maxConnectionTimeout: const Duration(minutes: 1),
       httpClient: httpClient,
     );
-    final app = App(appConfig);
-    expect(app.configuration.appId, 'myapp1');
-    expect(app.configuration.baseFilePath.path, Directory.systemTemp.path);
-    expect(app.configuration.baseUrl, Uri.parse('https://not_re.al'));
-    expect(app.configuration.defaultRequestTimeout, const Duration(seconds: 2));
-    expect(app.configuration.logLevel, LogLevel.info);
-    expect(app.configuration.metadataPersistenceMode, MetadataPersistenceMode.encrypted);
-    expect(app.configuration.maxConnectionTimeout, const Duration(minutes: 1));
-    expect(app.configuration.httpClient, httpClient);
+
+    expect(appConfig.appId, 'myapp1');
+    expect(appConfig.baseFilePath.path, Directory.systemTemp.path);
+    expect(appConfig.baseUrl, Uri.parse('https://not_re.al'));
+    expect(appConfig.defaultRequestTimeout, const Duration(seconds: 2));
+    expect(appConfig.logLevel, LogLevel.info);
+    expect(appConfig.metadataPersistenceMode, MetadataPersistenceMode.encrypted);
+    expect(appConfig.maxConnectionTimeout, const Duration(minutes: 1));
+    expect(appConfig.httpClient, httpClient);
+
+    // Check that the app constructor works
+    App(appConfig);
   });
 
   test('App can be created', () async {

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -52,7 +52,7 @@ Future<void> main([List<String>? args]) async {
   baasTest('SyncSession.user returns a valid user', (configuration) async {
     final app = App(configuration);
     final user = await getIntegrationUser(app);
-    final config = Configuration.flexibleSync(user, [Task.schema]);
+    final config = Configuration.sync(user, [Task.schema]);
     final realm = getRealm(config);
 
     expect(realm.syncSession.user, user);
@@ -62,7 +62,7 @@ Future<void> main([List<String>? args]) async {
   baasTest('SyncSession when isolate is torn down does not crash', (configuration) async {
     final app = App(configuration);
     final user = await getIntegrationUser(app);
-    final config = Configuration.flexibleSync(user, [Task.schema]);
+    final config = Configuration.sync(user, [Task.schema]);
 
     // Don't use getRealm because we want the Realm to survive
     final realm = Realm(config);

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -42,14 +42,6 @@ Future<void> main([List<String>? args]) async {
     expect(realm.syncSession, realm.syncSession);
   });
 
-  baasTest('Realm.syncSession returns on FLX configuration', (configuration) async {
-    final realm = await getIntegrationRealm();
-
-    expect(realm.syncSession, isNotNull);
-    expect(realm.syncSession.realmPath, realm.config.path);
-    expect(realm.syncSession, realm.syncSession);
-  });
-
   baasTest('SyncSession.user returns a valid user', (configuration) async {
     final app = App(configuration);
     final user = await getIntegrationUser(app);

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -53,7 +53,7 @@ Future<void> main([List<String>? args]) async {
   baasTest('SyncSession.user returns a valid user', (configuration) async {
     final app = App(configuration);
     final user = await getIntegrationUser(app);
-    final config = Configuration.sync(user, [Task.schema]);
+    final config = Configuration.flexibleSync(user, [Task.schema]);
     final realm = getRealm(config);
 
     expect(realm.syncSession.user, user);
@@ -63,7 +63,7 @@ Future<void> main([List<String>? args]) async {
   baasTest('SyncSession when isolate is torn down does not crash', (configuration) async {
     final app = App(configuration);
     final user = await getIntegrationUser(app);
-    final config = Configuration.sync(user, [Task.schema]);
+    final config = Configuration.flexibleSync(user, [Task.schema]);
 
     // Don't use getRealm because we want the Realm to survive
     final realm = Realm(config);

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -38,7 +38,7 @@ Future<void> main([List<String>? args]) async {
     final realm = await getIntegrationRealm();
 
     expect(realm.syncSession, isNotNull);
-    expect(realm.syncSession.path, realm.config.path);
+    expect(realm.syncSession.realmPath, realm.config.path);
     expect(realm.syncSession, realm.syncSession);
   });
 
@@ -46,7 +46,7 @@ Future<void> main([List<String>? args]) async {
     final realm = await getIntegrationRealm();
 
     expect(realm.syncSession, isNotNull);
-    expect(realm.syncSession.path, realm.config.path);
+    expect(realm.syncSession.realmPath, realm.config.path);
     expect(realm.syncSession, realm.syncSession);
   });
 
@@ -71,56 +71,63 @@ Future<void> main([List<String>? args]) async {
     expect(realm.syncSession, isNotNull);
   }, skip: 'crashes');
 
-  Future<void> _validateSessionStates(Session session, {SessionState? sessionState, ConnectionState? connectionState}) async {
-    if (sessionState != null) {
-      expect(session.state.name, sessionState.name);
+  Future<void> validateSessionStates(Session session, {SessionState? expectedSessionState, ConnectionState? expectedConnectionState}) async {
+    if (expectedSessionState != null) {
+      expect(session.state.name, expectedSessionState.name);
     }
 
-    if (connectionState != null) {
-      // The connection requires a bit of time to update its state
-      await Future<void>.delayed(Duration(milliseconds: 100));
-      expect(session.connectionState.name, connectionState.name);
+    if (expectedConnectionState != null) {
+      for (var i = 0; i < 5; i++) {
+        if (session.connectionState.name == expectedConnectionState.name) {
+          break;
+        }
+
+        // The connection requires a bit of time to update its state
+        await Future<void>.delayed(Duration(milliseconds: 100));
+      }
+
+      expect(session.connectionState.name, expectedConnectionState.name);
     }
   }
 
   baasTest('SyncSession.pause/resume', (configuration) async {
     final realm = await getIntegrationRealm();
 
-    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active, connectionState: ConnectionState.connected);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.active, expectedConnectionState: ConnectionState.connected);
 
     realm.syncSession.pause();
 
-    await _validateSessionStates(realm.syncSession, sessionState: SessionState.inactive, connectionState: ConnectionState.disconnected);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.inactive, expectedConnectionState: ConnectionState.disconnected);
 
     realm.syncSession.resume();
 
-    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active, connectionState: ConnectionState.connected);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.active, expectedConnectionState: ConnectionState.connected);
   });
 
   baasTest('SyncSession.pause called multiple times is a no-op', (configuration) async {
     final realm = await getIntegrationRealm();
 
-    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.active);
 
     realm.syncSession.pause();
 
-    await _validateSessionStates(realm.syncSession, sessionState: SessionState.inactive);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.inactive);
 
     // This should not do anything
     realm.syncSession.pause();
 
-    await _validateSessionStates(realm.syncSession, sessionState: SessionState.inactive);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.inactive);
   });
 
   baasTest('SyncSession.resume called multiple times is a no-op', (configuration) async {
     final realm = await getIntegrationRealm();
 
-    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.active);
 
     realm.syncSession.resume();
     realm.syncSession.resume();
 
-    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.active);
   });
 
   baasTest('SyncSession.waitForUpload with no changes', (configuration) async {
@@ -297,3 +304,4 @@ class StreamProgressData {
             doneInvoked: other.doneInvoked,
             transferredBytes: other.transferredBytes);
 }
+-

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:test/test.dart' hide test, throws;
@@ -34,7 +35,7 @@ Future<void> main([List<String>? args]) async {
   });
 
   baasTest('Realm.syncSession returns on FLX configuration', (configuration) async {
-    final realm = await getIntegrationRealm([Task.schema]);
+    final realm = await getIntegrationRealm();
 
     expect(realm.syncSession, isNotNull);
     expect(realm.syncSession.path, realm.config.path);
@@ -42,7 +43,7 @@ Future<void> main([List<String>? args]) async {
   });
 
   baasTest('Realm.syncSession returns on FLX configuration', (configuration) async {
-    final realm = await getIntegrationRealm([Task.schema]);
+    final realm = await getIntegrationRealm();
 
     expect(realm.syncSession, isNotNull);
     expect(realm.syncSession.path, realm.config.path);
@@ -83,7 +84,7 @@ Future<void> main([List<String>? args]) async {
   }
 
   baasTest('SyncSession.pause/resume', (configuration) async {
-    final realm = await getIntegrationRealm([Task.schema]);
+    final realm = await getIntegrationRealm();
 
     await _validateSessionStates(realm.syncSession, sessionState: SessionState.active, connectionState: ConnectionState.connected);
 
@@ -97,7 +98,7 @@ Future<void> main([List<String>? args]) async {
   });
 
   baasTest('SyncSession.pause called multiple times is a no-op', (configuration) async {
-    final realm = await getIntegrationRealm([Task.schema]);
+    final realm = await getIntegrationRealm();
 
     await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
 
@@ -112,7 +113,7 @@ Future<void> main([List<String>? args]) async {
   });
 
   baasTest('SyncSession.resume called multiple times is a no-op', (configuration) async {
-    final realm = await getIntegrationRealm([Task.schema]);
+    final realm = await getIntegrationRealm();
 
     await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
 
@@ -121,4 +122,178 @@ Future<void> main([List<String>? args]) async {
 
     await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
   });
+
+  baasTest('SyncSession.waitForUpload with no changes', (configuration) async {
+    final realm = await getIntegrationRealm();
+
+    await realm.syncSession.waitForUpload();
+
+    // Call it multiple times to make sure it doesn't throw
+    await realm.syncSession.waitForUpload();
+  });
+
+  baasTest('SyncSession.waitForDownload with no changes', (configuration) async {
+    final realm = await getIntegrationRealm();
+
+    await realm.syncSession.waitForDownload();
+
+    // Call it multiple times to make sure it doesn't throw
+    await realm.syncSession.waitForDownload();
+  });
+
+  baasTest('SyncSesison.waitForUpload with changes', (configuration) async {
+    final differentiator = ObjectId();
+
+    final realmA = await getIntegrationRealm(differentiator: differentiator);
+    final realmB = await getIntegrationRealm(differentiator: differentiator, path: generateRandomRealmPath());
+
+    realmA.write(() {
+      realmA.add(NullableTypes(ObjectId(), differentiator, stringProp: 'abc'));
+    });
+
+    await realmA.syncSession.waitForUpload();
+    await realmB.syncSession.waitForDownload();
+
+    expect(realmA.all<NullableTypes>().map((e) => e.stringProp), realmB.all<NullableTypes>().map((e) => e.stringProp));
+
+    realmB.write(() {
+      realmB.add(NullableTypes(ObjectId(), differentiator, stringProp: 'def'));
+    });
+
+    await realmB.syncSession.waitForUpload();
+    await realmA.syncSession.waitForDownload();
+
+    expect(realmA.all<NullableTypes>().map((e) => e.stringProp), realmB.all<NullableTypes>().map((e) => e.stringProp));
+  });
+
+  StreamProgressData subscribeToProgress(Realm realm, ProgressDirection direction, ProgressMode mode) {
+    final data = StreamProgressData();
+    final stream = realm.syncSession.getProgressStream(direction, mode);
+    data.subscription = stream.listen((event) {
+      expect(event.transferredBytes, greaterThanOrEqualTo(data.transferredBytes));
+      if (data.transferableBytes != 0) {
+        // We need to wait for the first event to store the total bytes we expect.
+        if (mode == ProgressMode.forCurrentlyOutstandingWork) {
+          // Transferable should not change after the first event
+          expect(event.transferableBytes, data.transferableBytes);
+        } else {
+          // For indefinite progress, we expect the transferable bytes to not decrease
+          expect(event.transferableBytes, greaterThanOrEqualTo(data.transferableBytes));
+        }
+      }
+
+      data.transferredBytes = event.transferredBytes;
+      data.transferableBytes = event.transferableBytes;
+      data.callbacksInvoked++;
+    });
+
+    data.subscription.onDone(() {
+      data.doneInvoked = true;
+    });
+
+    return data;
+  }
+
+  Future<void> validateData(StreamProgressData data, {bool expectDone = false}) async {
+    // Wait a little since the last event is sent asynchronously
+    await Future<void>.delayed(Duration(milliseconds: 100));
+
+    expect(data.callbacksInvoked, greaterThan(0));
+    expect(data.transferableBytes, greaterThan(0));
+    expect(data.transferredBytes, greaterThan(0));
+    if (expectDone) {
+      expect(data.transferredBytes, data.transferableBytes);
+    } else {
+      expect(data.transferredBytes, lessThanOrEqualTo(data.transferableBytes));
+    }
+    expect(data.doneInvoked, expectDone);
+  }
+
+  baasTest('SyncSession.getProgressStream forCurrentlyOutstandingWork', (configuration) async {
+    final differentiator = ObjectId();
+    final realmA = await getIntegrationRealm(differentiator: differentiator);
+    final realmB = await getIntegrationRealm(differentiator: differentiator, path: generateRandomRealmPath());
+
+    for (var i = 0; i < 10; i++) {
+      realmA.write(() {
+        realmA.add(NullableTypes(ObjectId(), differentiator, stringProp: generateRandomString(50)));
+      });
+    }
+
+    final uploadData = subscribeToProgress(realmA, ProgressDirection.upload, ProgressMode.forCurrentlyOutstandingWork);
+
+    await realmA.syncSession.waitForUpload();
+
+    // Subscribe immediately after the upload to ensure we get the entire upload message as progress notifications
+    final downloadData = subscribeToProgress(realmB, ProgressDirection.download, ProgressMode.forCurrentlyOutstandingWork);
+
+    await validateData(uploadData, expectDone: true);
+
+    await realmB.syncSession.waitForDownload();
+
+    await validateData(downloadData, expectDone: true);
+
+    await uploadData.subscription.cancel();
+    await downloadData.subscription.cancel();
+  });
+
+  baasTest('SyncSession.getProgressStream reportIndefinitely', (configuration) async {
+    final differentiator = ObjectId();
+    final realmA = await getIntegrationRealm(differentiator: differentiator);
+    final realmB = await getIntegrationRealm(differentiator: differentiator, path: generateRandomRealmPath());
+
+    for (var i = 0; i < 10; i++) {
+      realmA.write(() {
+        realmA.add(NullableTypes(ObjectId(), differentiator, stringProp: generateRandomString(50)));
+      });
+    }
+
+    final uploadData = subscribeToProgress(realmA, ProgressDirection.upload, ProgressMode.reportIndefinitely);
+    final downloadData = subscribeToProgress(realmB, ProgressDirection.download, ProgressMode.reportIndefinitely);
+
+    await realmA.syncSession.waitForUpload();
+    await validateData(uploadData);
+
+    await realmB.syncSession.waitForDownload();
+    await validateData(downloadData);
+
+    // Snapshot the current state, then add a new object. We should receive more notifications
+    final uploadSnapshot = StreamProgressData.snapshot(uploadData);
+    final downloadSnapshot = StreamProgressData.snapshot(downloadData);
+
+    realmA.write(() {
+      realmA.add(NullableTypes(ObjectId(), differentiator, stringProp: generateRandomString(50)));
+    });
+
+    await validateData(uploadData);
+    await validateData(downloadData);
+
+    expect(uploadData.transferredBytes, greaterThan(uploadSnapshot.transferredBytes));
+    expect(uploadData.transferableBytes, greaterThan(uploadSnapshot.transferableBytes));
+    expect(uploadData.callbacksInvoked, greaterThan(uploadSnapshot.callbacksInvoked));
+
+    expect(downloadData.transferredBytes, greaterThan(downloadSnapshot.transferredBytes));
+    expect(downloadData.transferableBytes, greaterThan(downloadSnapshot.transferableBytes));
+    expect(downloadData.callbacksInvoked, greaterThan(downloadSnapshot.callbacksInvoked));
+
+    await uploadData.subscription.cancel();
+    await downloadData.subscription.cancel();
+  });
+}
+
+class StreamProgressData {
+  int transferredBytes;
+  int transferableBytes;
+  int callbacksInvoked;
+  bool doneInvoked;
+  late StreamSubscription<SyncProgress> subscription;
+
+  StreamProgressData({this.transferableBytes = 0, this.transferredBytes = 0, this.callbacksInvoked = 0, this.doneInvoked = false});
+
+  StreamProgressData.snapshot(StreamProgressData other)
+      : this(
+            transferableBytes: other.transferableBytes,
+            callbacksInvoked: other.callbacksInvoked,
+            doneInvoked: other.doneInvoked,
+            transferredBytes: other.transferredBytes);
 }

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -304,4 +304,3 @@ class StreamProgressData {
             doneInvoked: other.doneInvoked,
             transferredBytes: other.transferredBytes);
 }
--

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -1,0 +1,124 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import 'dart:io';
+
+import 'package:test/test.dart' hide test, throws;
+import '../lib/realm.dart';
+import 'test.dart';
+
+Future<void> main([List<String>? args]) async {
+  print("Current PID $pid");
+
+  await setupTests(args);
+
+  test('Realm.syncSession throws on wrong configuration', () {
+    final config = Configuration.local([Task.schema]);
+    final realm = getRealm(config);
+    expect(() => realm.syncSession, throws<RealmError>());
+  });
+
+  baasTest('Realm.syncSession returns on FLX configuration', (configuration) async {
+    final realm = await getIntegrationRealm([Task.schema]);
+
+    expect(realm.syncSession, isNotNull);
+    expect(realm.syncSession.path, realm.config.path);
+    expect(realm.syncSession, realm.syncSession);
+  });
+
+  baasTest('Realm.syncSession returns on FLX configuration', (configuration) async {
+    final realm = await getIntegrationRealm([Task.schema]);
+
+    expect(realm.syncSession, isNotNull);
+    expect(realm.syncSession.path, realm.config.path);
+    expect(realm.syncSession, realm.syncSession);
+  });
+
+  baasTest('SyncSession.user returns a valid user', (configuration) async {
+    final app = App(configuration);
+    final user = await getIntegrationUser(app);
+    final config = Configuration.flexibleSync(user, [Task.schema]);
+    final realm = getRealm(config);
+
+    expect(realm.syncSession.user, user);
+    expect(realm.syncSession.user.id, user.id);
+  });
+
+  baasTest('SyncSession when isolate is torn down does not crash', (configuration) async {
+    final app = App(configuration);
+    final user = await getIntegrationUser(app);
+    final config = Configuration.flexibleSync(user, [Task.schema]);
+
+    // Don't use getRealm because we want the Realm to survive
+    final realm = Realm(config);
+
+    expect(realm.syncSession, isNotNull);
+  }, skip: 'crashes');
+
+  Future<void> _validateSessionStates(Session session, {SessionState? sessionState, ConnectionState? connectionState}) async {
+    if (sessionState != null) {
+      expect(session.state.name, sessionState.name);
+    }
+
+    if (connectionState != null) {
+      // The connection requires a bit of time to update its state
+      await Future<void>.delayed(Duration(milliseconds: 100));
+      expect(session.connectionState.name, connectionState.name);
+    }
+  }
+
+  baasTest('SyncSession.pause/resume', (configuration) async {
+    final realm = await getIntegrationRealm([Task.schema]);
+
+    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active, connectionState: ConnectionState.connected);
+
+    realm.syncSession.pause();
+
+    await _validateSessionStates(realm.syncSession, sessionState: SessionState.inactive, connectionState: ConnectionState.disconnected);
+
+    realm.syncSession.resume();
+
+    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active, connectionState: ConnectionState.connected);
+  });
+
+  baasTest('SyncSession.pause called multiple times is a no-op', (configuration) async {
+    final realm = await getIntegrationRealm([Task.schema]);
+
+    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
+
+    realm.syncSession.pause();
+
+    await _validateSessionStates(realm.syncSession, sessionState: SessionState.inactive);
+
+    // This should not do anything
+    realm.syncSession.pause();
+
+    await _validateSessionStates(realm.syncSession, sessionState: SessionState.inactive);
+  });
+
+  baasTest('SyncSession.resume called multiple times is a no-op', (configuration) async {
+    final realm = await getIntegrationRealm([Task.schema]);
+
+    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
+
+    realm.syncSession.resume();
+    realm.syncSession.resume();
+
+    await _validateSessionStates(realm.syncSession, sessionState: SessionState.active);
+  });
+}

--- a/test/test.dart
+++ b/test/test.dart
@@ -325,7 +325,7 @@ Future<Realm> getIntegrationRealm({App? app, ObjectId? differentiator, String? p
   final user = await getIntegrationUser(app);
 
   // TODO: path will not be needed after https://github.com/realm/realm-dart/pull/574
-  final config = Configuration.sync(user, [Task.schema, Schedule.schema, NullableTypes.schema], path: path);
+  final config = Configuration.flexibleSync(user, [Task.schema, Schedule.schema, NullableTypes.schema], path: path);
   final realm = getRealm(config);
   if (differentiator != null) {
     realm.subscriptions.update((mutableSubscriptions) {

--- a/test/test.dart
+++ b/test/test.dart
@@ -306,7 +306,7 @@ Future<User> getIntegrationUser(App app) async {
 Future<Realm> getIntegrationRealm(List<SchemaObject> schemas, {App? app}) async {
   app ??= App(await getAppConfig());
   final user = await getIntegrationUser(app);
-  final config = Configuration.flexibleSync(user, schemas);
+  final config = Configuration.sync(user, schemas);
   return getRealm(config);
 }
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -125,6 +125,23 @@ class _AllCollections {
 }
 
 
+@RealmModel()
+class _NullableTypes {
+  @PrimaryKey()
+  @MapTo('_id')
+  late ObjectId id;
+
+  late ObjectId differentiator;
+
+  late String? stringProp;
+  late bool? boolProp;
+  late DateTime? dateProp;
+  late double? doubleProp;
+  late ObjectId? objectIdProp;
+  late Uuid? uuidProp;
+  late int? intProp;
+}
+
 String? testName;
 final baasApps = <String, BaasApp>{};
 final _openRealms = Queue<Realm>();
@@ -303,11 +320,22 @@ Future<User> getIntegrationUser(App app) async {
   return await loginWithRetry(app, Credentials.emailPassword(email, password));
 }
 
-Future<Realm> getIntegrationRealm(List<SchemaObject> schemas, {App? app}) async {
+Future<Realm> getIntegrationRealm({App? app, ObjectId? differentiator, String? path}) async {
   app ??= App(await getAppConfig());
   final user = await getIntegrationUser(app);
-  final config = Configuration.sync(user, schemas);
-  return getRealm(config);
+
+  // TODO: path will not be needed after https://github.com/realm/realm-dart/pull/574
+  final config = Configuration.sync(user, [Task.schema, Schedule.schema, NullableTypes.schema], path: path);
+  final realm = getRealm(config);
+  if (differentiator != null) {
+    realm.subscriptions.update((mutableSubscriptions) {
+      mutableSubscriptions.add(realm.query<NullableTypes>('differentiator = \$0', [differentiator]));
+    });
+
+    await realm.subscriptions.waitForSynchronization();
+  }
+
+  return realm;
 }
 
 Future<User> loginWithRetry(App app, Credentials credentials, {int retryCount = 3}) async {

--- a/test/test.g.dart
+++ b/test/test.g.dart
@@ -577,3 +577,104 @@ class AllCollections extends _AllCollections with RealmEntity, RealmObject {
     ]);
   }
 }
+
+class NullableTypes extends _NullableTypes with RealmEntity, RealmObject {
+  NullableTypes(
+    ObjectId id,
+    ObjectId differentiator, {
+    String? stringProp,
+    bool? boolProp,
+    DateTime? dateProp,
+    double? doubleProp,
+    ObjectId? objectIdProp,
+    Uuid? uuidProp,
+    int? intProp,
+  }) {
+    RealmObject.set(this, '_id', id);
+    RealmObject.set(this, 'differentiator', differentiator);
+    RealmObject.set(this, 'stringProp', stringProp);
+    RealmObject.set(this, 'boolProp', boolProp);
+    RealmObject.set(this, 'dateProp', dateProp);
+    RealmObject.set(this, 'doubleProp', doubleProp);
+    RealmObject.set(this, 'objectIdProp', objectIdProp);
+    RealmObject.set(this, 'uuidProp', uuidProp);
+    RealmObject.set(this, 'intProp', intProp);
+  }
+
+  NullableTypes._();
+
+  @override
+  ObjectId get id => RealmObject.get<ObjectId>(this, '_id') as ObjectId;
+  @override
+  set id(ObjectId value) => throw RealmUnsupportedSetError();
+
+  @override
+  ObjectId get differentiator =>
+      RealmObject.get<ObjectId>(this, 'differentiator') as ObjectId;
+  @override
+  set differentiator(ObjectId value) =>
+      RealmObject.set(this, 'differentiator', value);
+
+  @override
+  String? get stringProp =>
+      RealmObject.get<String>(this, 'stringProp') as String?;
+  @override
+  set stringProp(String? value) => RealmObject.set(this, 'stringProp', value);
+
+  @override
+  bool? get boolProp => RealmObject.get<bool>(this, 'boolProp') as bool?;
+  @override
+  set boolProp(bool? value) => RealmObject.set(this, 'boolProp', value);
+
+  @override
+  DateTime? get dateProp =>
+      RealmObject.get<DateTime>(this, 'dateProp') as DateTime?;
+  @override
+  set dateProp(DateTime? value) => RealmObject.set(this, 'dateProp', value);
+
+  @override
+  double? get doubleProp =>
+      RealmObject.get<double>(this, 'doubleProp') as double?;
+  @override
+  set doubleProp(double? value) => RealmObject.set(this, 'doubleProp', value);
+
+  @override
+  ObjectId? get objectIdProp =>
+      RealmObject.get<ObjectId>(this, 'objectIdProp') as ObjectId?;
+  @override
+  set objectIdProp(ObjectId? value) =>
+      RealmObject.set(this, 'objectIdProp', value);
+
+  @override
+  Uuid? get uuidProp => RealmObject.get<Uuid>(this, 'uuidProp') as Uuid?;
+  @override
+  set uuidProp(Uuid? value) => RealmObject.set(this, 'uuidProp', value);
+
+  @override
+  int? get intProp => RealmObject.get<int>(this, 'intProp') as int?;
+  @override
+  set intProp(int? value) => RealmObject.set(this, 'intProp', value);
+
+  @override
+  Stream<RealmObjectChanges<NullableTypes>> get changes =>
+      RealmObject.getChanges<NullableTypes>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(NullableTypes._);
+    return const SchemaObject(NullableTypes, 'NullableTypes', [
+      SchemaProperty('_id', RealmPropertyType.objectid,
+          mapTo: '_id', primaryKey: true),
+      SchemaProperty('differentiator', RealmPropertyType.objectid),
+      SchemaProperty('stringProp', RealmPropertyType.string, optional: true),
+      SchemaProperty('boolProp', RealmPropertyType.bool, optional: true),
+      SchemaProperty('dateProp', RealmPropertyType.timestamp, optional: true),
+      SchemaProperty('doubleProp', RealmPropertyType.double, optional: true),
+      SchemaProperty('objectIdProp', RealmPropertyType.objectid,
+          optional: true),
+      SchemaProperty('uuidProp', RealmPropertyType.uuid, optional: true),
+      SchemaProperty('intProp', RealmPropertyType.int, optional: true),
+    ]);
+  }
+}


### PR DESCRIPTION
This adds support for most session API. Currently covered are:

- [x] `path`
- [x] `state`
- [x] `connectionState`
- [x] `pause()`
- [x] `resume()`
- [x] `waitForUpload()`
- [x] `waitForDownload()`
- [x] `getProgressStream()`
- [x] `user`
- [x] Figure out why we're crashing when we don't close the Realm

Remaining for a follow up PR are:
- [ ] `getConnectionStateStream` - an API to subscribe for notifications on `connectionState`
- [ ] More comprehensive tests for `getProgressStream()`
- [ ] Tests for `session.user`
