### PR TITLE
fix generator coverage error on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,6 +714,7 @@ jobs:
         working-directory: ./generator/
 
       - name: Publish Generator Coverage
+        if: ${{ false }}
         id: publish-generator-coverage
         uses: coverallsapp/github-action@1.1.3
         with:
@@ -723,4 +724,5 @@ jobs:
         continue-on-error: true
 
       - name: Output Coveralls response
+        if: ${{ false }}
         run: echo ${{ steps.publish-generator-coverage.outputs.coveralls-api-result }}


### PR DESCRIPTION
This fixes a small error in the generator coverage on CI. We forgot to disable the upload step while we disabled the generator