### PR TITLE
Fix a sporadic session test failure

### DIFF
--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -65,11 +65,13 @@ Future<void> main([List<String>? args]) async {
 
   Future<void> validateSessionStates(Session session, {SessionState? expectedSessionState, ConnectionState? expectedConnectionState}) async {
     if (expectedSessionState != null) {
-      await waitForCondition(() => session.state.name == expectedSessionState.name);
+      await waitForCondition(() => session.state.name == expectedSessionState.name,
+          timeout: Duration(seconds: 1), message: 'Expected ${session.state} to equal $expectedSessionState');
     }
 
     if (expectedConnectionState != null) {
-      await waitForCondition(() => session.connectionState.name == expectedConnectionState.name);
+      await waitForCondition(() => session.connectionState.name == expectedConnectionState.name,
+          timeout: Duration(seconds: 1), message: 'Expected ${session.connectionState} to equal $expectedConnectionState');
     }
   }
 

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -65,20 +65,11 @@ Future<void> main([List<String>? args]) async {
 
   Future<void> validateSessionStates(Session session, {SessionState? expectedSessionState, ConnectionState? expectedConnectionState}) async {
     if (expectedSessionState != null) {
-      expect(session.state.name, expectedSessionState.name);
+      await waitForCondition(() => session.state.name == expectedSessionState.name);
     }
 
     if (expectedConnectionState != null) {
-      for (var i = 0; i < 10; i++) {
-        if (session.connectionState.name == expectedConnectionState.name) {
-          break;
-        }
-
-        // The connection requires a bit of time to update its state
-        await Future<void>.delayed(Duration(milliseconds: 100));
-      }
-
-      expect(session.connectionState.name, expectedConnectionState.name);
+      await waitForCondition(() => session.connectionState.name == expectedConnectionState.name);
     }
   }
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -324,7 +324,7 @@ Future<void> baasTest(
 
 Future<AppConfiguration> getAppConfig({AppNames appName = AppNames.flexible}) async {
   final baasUrl = arguments[argBaasUrl];
-  
+
   final app = baasApps[appName.name] ??
       baasApps.values.firstWhere((element) => element.name == BaasClient.defaultAppName, orElse: () => throw RealmError("No BAAS apps"));
 
@@ -371,6 +371,18 @@ Future<User> loginWithRetry(App app, Credentials credentials, {int retryCount = 
       return await loginWithRetry(app, credentials, retryCount: retryCount - 1);
     }
     rethrow;
+  }
+}
+
+Future<void> waitForCondition(bool Function() condition,
+    {Duration timeout = const Duration(seconds: 10), Duration retryDelay = const Duration(milliseconds: 100)}) async {
+  final start = DateTime.now();
+  while (!condition()) {
+    if (DateTime.now().difference(start) > timeout) {
+      throw TimeoutException('Condition not met within $timeout');
+    }
+
+    await Future<void>.delayed(retryDelay);
   }
 }
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -375,11 +375,11 @@ Future<User> loginWithRetry(App app, Credentials credentials, {int retryCount = 
 }
 
 Future<void> waitForCondition(bool Function() condition,
-    {Duration timeout = const Duration(seconds: 10), Duration retryDelay = const Duration(milliseconds: 100)}) async {
+    {Duration timeout = const Duration(seconds: 10), Duration retryDelay = const Duration(milliseconds: 100), String? message}) async {
   final start = DateTime.now();
   while (!condition()) {
     if (DateTime.now().difference(start) > timeout) {
-      throw TimeoutException('Condition not met within $timeout');
+      throw TimeoutException('Condition not met within $timeout${message != null ? ': $message' : ''}');
     }
 
     await Future<void>.delayed(retryDelay);


### PR DESCRIPTION
Sometimes `session.state` would be `connecting` rather than `connected` when we first check it, leading to a sporadic test failure. This adds some leeway by retrying the check a couple of times. 