### PR TITLE
Add support for remaining session API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,12 @@
   * `realmPath` returning the path of the Realm for the session.
   * `state` returning the current state of the session.
   * `connectionState` returning the current state of the connection.
+  * `connectionStateChanges` returns a Stream that emits connection state updates.
   * `user` returning the user that owns the session.
   * `pause()` pauses synchronization.
   * `resume()` resumes synchronization.
   * `waitForUpload/waitForDownload` returns a Future that completes when the session uploaded/downloaded all changes.
   * `getProgressStream` returns a Stream that emits progress updates.
-  * `getConnectionStateStream` returns a Stream that emits connection state updates.
 
 ### Fixed
 * Fixed an issue that would result in the wrong transaction being rolled back if you start a write transaction inside a write transaction. ([#442](https://github.com/realm/realm-dart/issues/442))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@
 * Support session error handler. ([#577](https://github.com/realm/realm-dart/pull/577))
 * Support setting logger on AppConfiguration. ([#583](https://github.com/realm/realm-dart/pull/583))
 * Support setting logger on Realm class. Default is to print info message or worse to the console. ([#583](https://github.com/realm/realm-dart/pull/583))
+* Support getting the `SyncSession` for a synchronized Realm via the `realm.syncSession` property.
+* Support the following `SyncSession` API:
+  * `realmPath` returning the path of the Realm for the session.
+  * `state` returning the current state of the session.
+  * `connectionState` returning the current state of the connection.
+  * `user` returning the user that owns the session.
+  * `pause()` pauses synchronization.
+  * `resume()` resumes synchronization.
+  * `waitForUpload/waitForDownload` returns a Future that completes when the session uploaded/downloaded all changes.
+  * `getProgressStream` returns a Stream that emits progress updates.
+  * `getConnectionStateStream` returns a Stream that emits connection state updates.
 
 ### Fixed
 * Fixed an issue that would result in the wrong transaction being rolled back if you start a write transaction inside a write transaction. ([#442](https://github.com/realm/realm-dart/issues/442))

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1494,7 +1494,7 @@ class _RealmCore {
 
   int sessionRegisterProgressNotifier(Session session, ProgressDirection direction, ProgressMode mode, SessionProgressNotificationsController controller) {
     final isStreaming = mode == ProgressMode.reportIndefinitely;
-    return _realmLib.realm_dart_sync_session_register_progress_notifier(session.handle._pointer, Pointer.fromFunction(on_sync_progress), direction.index,
+    return _realmLib.realm_dart_sync_session_register_progress_notifier(session.handle._pointer, Pointer.fromFunction(_onSyncProgress), direction.index,
         isStreaming, controller.toPersistentHandle(), _realmLib.addresses.realm_dart_delete_persistent_handle, scheduler.handle._pointer);
   }
 
@@ -1502,35 +1502,31 @@ class _RealmCore {
     _realmLib.realm_sync_session_unregister_progress_notifier(session.handle._pointer, token);
   }
 
-  int sessionRegisterConnectionStateNotifier(Session session, SessionConnectionStateController controller) {
-    return _realmLib.realm_dart_sync_session_register_connection_state_change_callback(
-        session.handle._pointer,
-        Pointer.fromFunction(on_connection_state_change),
-        controller.toPersistentHandle(),
-        _realmLib.addresses.realm_dart_delete_persistent_handle,
-        scheduler.handle._pointer);
-  }
-
-  void sessionUnregisterConnectionStateNotifier(Session session, int token) {
-    _realmLib.realm_sync_session_unregister_connection_state_change_callback(session.handle._pointer, token);
-  }
-
-  static void on_connection_state_change(Pointer<Void> userdata, int oldState, int newState) {
-    final SessionConnectionStateController? controller = userdata.toObject(isPersistent: true);
-    if (controller == null) {
-      return;
-    }
-
-    controller.onConnectionStateChange(ConnectionState.values[oldState], ConnectionState.values[newState]);
-  }
-
-  static void on_sync_progress(Pointer<Void> userdata, int transferred, int transferable) {
+  static void _onSyncProgress(Pointer<Void> userdata, int transferred, int transferable) {
     final SessionProgressNotificationsController? controller = userdata.toObject(isPersistent: true);
     if (controller == null) {
       return;
     }
 
     controller.onProgress(transferred, transferable);
+  }
+
+  int sessionRegisterConnectionStateNotifier(Session session, SessionConnectionStateController controller) {
+    return _realmLib.realm_dart_sync_session_register_connection_state_change_callback(session.handle._pointer, Pointer.fromFunction(_onConnectionStateChange),
+        controller.toPersistentHandle(), _realmLib.addresses.realm_dart_delete_persistent_handle, scheduler.handle._pointer);
+  }
+
+  void sessionUnregisterConnectionStateNotifier(Session session, int token) {
+    _realmLib.realm_sync_session_unregister_connection_state_change_callback(session.handle._pointer, token);
+  }
+
+  static void _onConnectionStateChange(Pointer<Void> userdata, int oldState, int newState) {
+    final SessionConnectionStateController? controller = userdata.toObject(isPersistent: true);
+    if (controller == null) {
+      return;
+    }
+
+    controller.onConnectionStateChange(ConnectionState.values[oldState], ConnectionState.values[newState]);
   }
 
   Future<void> sessionWaitForUpload(Session session) {

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -50,7 +50,7 @@ export 'package:realm_common/realm_common.dart'
         Uuid;
 
 // always expose with `show` to explicitly control the public API surface
-export 'app.dart' show AppConfiguration, MetadataPersistenceMode, LogLevel, App;
+export 'app.dart' show AppConfiguration, MetadataPersistenceMode, App;
 export "configuration.dart"
     show
         Configuration,
@@ -69,7 +69,7 @@ export 'realm_property.dart';
 export 'results.dart' show RealmResults, RealmResultsChanges;
 export 'subscription.dart' show Subscription, SubscriptionSet, SubscriptionSetState, MutableSubscriptionSet;
 export 'user.dart' show User, UserState, UserIdentity;
-export 'session.dart' show Session, SessionState, ConnectionState, ProgressDirection, ProgressMode, SyncProgress;
+export 'session.dart' show Session, SessionState, ConnectionState, ProgressDirection, ProgressMode, SyncProgress, ConnectionStateChange;
 
 /// Specifies the criticality level above which messages will be logged
 /// by the default sync client logger.

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -70,7 +70,7 @@ class Session {
 
   /// Gets a [Stream] of [ConnectionState] that can be used to be notified whenever the
   /// connection state changes.
-  Stream<ConnectionStateChange> getConnectionStateStream() {
+  Stream<ConnectionStateChange> get connectionStateChanges {
     final controller = SessionConnectionStateController(this);
     return controller.createStream();
   }

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -330,7 +330,7 @@ Future<void> main([List<String>? args]) async {
   baasTest('SyncSession.getConnectionStateStream', (configuration) async {
     final realm = await getIntegrationRealm();
 
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected);
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected, timeout: Duration(seconds: 5));
 
     final states = <ConnectionStateChange>[];
     final stream = realm.syncSession.connectionStateChanges;

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -340,16 +340,16 @@ Future<void> main([List<String>? args]) async {
 
     // Verify we get a notification when we pause the session
     realm.syncSession.pause();
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.disconnected);
-    await waitForCondition(() => states.length == 1);
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.disconnected, timeout: Duration(seconds: 5));
+    await waitForCondition(() => states.length == 1, timeout: Duration(seconds: 5));
 
     expect(states[0].previous, ConnectionState.connected);
     expect(states[0].current, ConnectionState.disconnected);
 
     // When resuming, we should get two notifications - first we go to connecting, then connected
     realm.syncSession.resume();
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected);
-    await waitForCondition(() => states.length == 3);
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected, timeout: Duration(seconds: 5));
+    await waitForCondition(() => states.length == 3, timeout: Duration(seconds: 5));
 
     expect(states[1].previous, ConnectionState.disconnected);
     expect(states[1].current, ConnectionState.connecting);

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -298,7 +298,7 @@ Future<void> main([List<String>? args]) async {
     await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected);
 
     final states = <ConnectionStateChange>[];
-    final stream = realm.syncSession.getConnectionStateStream();
+    final stream = realm.syncSession.connectionStateChanges;
     final subscription = stream.listen((event) {
       states.add(event);
     });

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -51,6 +51,8 @@ Future<void> main([List<String>? args]) async {
 
     expect(realm.syncSession.user, user);
     expect(realm.syncSession.user.id, user.id);
+    expect(realm.syncSession.user.app.id, configuration.appId);
+    expect(realm.syncSession.user.app.currentUser, user);
   });
 
   baasTest('SyncSession when isolate is torn down does not crash', (configuration) async {
@@ -288,6 +290,39 @@ Future<void> main([List<String>? args]) async {
     final realm = getRealm(config);
 
     realm.syncSession.raiseSessionError(SyncErrorCategory.session, 100, false);
+  });
+
+  baasTest('SyncSession.getConnectionStateStream', (configuration) async {
+    final realm = await getIntegrationRealm();
+
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected);
+
+    final states = <ConnectionStateChange>[];
+    final stream = realm.syncSession.getConnectionStateStream();
+    final subscription = stream.listen((event) {
+      states.add(event);
+    });
+
+    // Verify we get a notification when we pause the session
+    realm.syncSession.pause();
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.disconnected);
+    await waitForCondition(() => states.length == 1);
+
+    expect(states[0].previous, ConnectionState.connected);
+    expect(states[0].current, ConnectionState.disconnected);
+
+    // When resuming, we should get two notifications - first we go to connecting, then connected
+    realm.syncSession.resume();
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected);
+    await waitForCondition(() => states.length == 3);
+
+    expect(states[1].previous, ConnectionState.disconnected);
+    expect(states[1].current, ConnectionState.connecting);
+
+    expect(states[2].previous, ConnectionState.connecting);
+    expect(states[2].current, ConnectionState.connected);
+
+    await subscription.cancel();
   });
 }
 


### PR DESCRIPTION
This adds support for connection state change notifications on the sync session and extends the session user test.

Fixes https://github.com/realm/realm-dart/issues/596
Fixes https://github.com/realm/realm-dart/issues/595