### PR TITLE
Add missing trampoline

### DIFF
--- a/ffigen/config.yaml
+++ b/ffigen/config.yaml
@@ -11,6 +11,7 @@ headers:
     - 'subscription_set.h'
     - 'sync_session.h'
     - 'sync_client_config.h'
+    - 'sync_client.h'
   include-directives: #generate only for these headers
     - 'realm.h'
     - 'realm_dart.h'
@@ -19,6 +20,7 @@ headers:
     - 'subscription_set.h'
     - 'sync_session.h'
     - 'sync_client_config.h'
+    - 'sync_client.h'
 compiler-opts:
   - '-DRLM_NO_ANON_UNIONS'
   - '-DFFI_GEN'

--- a/ffigen/sync_client.h
+++ b/ffigen/sync_client.h
@@ -1,0 +1,1 @@
+../src/sync_client.h

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3148,6 +3148,40 @@ class RealmLibrary {
               realm_free_userdata_func_t,
               ffi.Pointer<realm_scheduler_t>)>();
 
+  void realm_dart_sync_config_set_error_handler(
+    ffi.Pointer<realm_sync_config_t> config,
+    realm_sync_error_handler_func_t handler,
+    ffi.Pointer<ffi.Void> userdata,
+    realm_free_userdata_func_t userdata_free,
+    ffi.Pointer<realm_scheduler_t> scheduler,
+  ) {
+    return _realm_dart_sync_config_set_error_handler(
+      config,
+      handler,
+      userdata,
+      userdata_free,
+      scheduler,
+    );
+  }
+
+  late final _realm_dart_sync_config_set_error_handlerPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<realm_sync_config_t>,
+                  realm_sync_error_handler_func_t,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>(
+      'realm_dart_sync_config_set_error_handler');
+  late final _realm_dart_sync_config_set_error_handler =
+      _realm_dart_sync_config_set_error_handlerPtr.asFunction<
+          void Function(
+              ffi.Pointer<realm_sync_config_t>,
+              realm_sync_error_handler_func_t,
+              ffi.Pointer<ffi.Void>,
+              realm_free_userdata_func_t,
+              ffi.Pointer<realm_scheduler_t>)>();
+
   /// Register a handler in order to be notified when subscription set is equal to the one passed as parameter
   /// This is an asynchronous operation.
   ///
@@ -9194,6 +9228,16 @@ class _SymbolAddresses {
                   ffi.Pointer<realm_scheduler_t>)>>
       get realm_dart_sync_client_config_set_log_callback =>
           _library._realm_dart_sync_client_config_set_log_callbackPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<realm_sync_config_t>,
+                  realm_sync_error_handler_func_t,
+                  ffi.Pointer<ffi.Void>,
+                  realm_free_userdata_func_t,
+                  ffi.Pointer<realm_scheduler_t>)>>
+      get realm_dart_sync_config_set_error_handler =>
+          _library._realm_dart_sync_config_set_error_handlerPtr;
   ffi.Pointer<
           ffi.NativeFunction<
               ffi.Uint8 Function(

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1573,6 +1573,7 @@ class _RealmCore {
   }
 
   static void _sessionWaitCompletionCallback(Pointer<Void> userdata, Pointer<realm_sync_error_code_t> errorCode) {
+    try {
     final completer = userdata.toObject<Completer<void>>(isPersistent: true);
     if (completer == null) {
       return;
@@ -1583,6 +1584,10 @@ class _RealmCore {
       completer.completeError(RealmException(errorCode.toSyncError().toString()));
     } else {
       completer.complete();
+    }
+    }
+    finally {
+      _realmLib.realm_free(errorCode.cast());
     }
   }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     subscription_set.cpp
     sync_session.cpp
     sync_client_config.cpp
+    sync_client.cpp
 )
 
 set(HEADERS
@@ -22,6 +23,7 @@ set(HEADERS
     subscription_set.h
     sync_session.h
     sync_client_config.h
+    sync_client.h
 )
 
 add_library(realm_dart SHARED ${SOURCES} ${HEADERS})

--- a/src/sync_client.cpp
+++ b/src/sync_client.cpp
@@ -34,11 +34,8 @@ void _callback(void* userdata, realm_sync_session_t* session, const realm_sync_e
     auto error_copy = error; // copy struct
 
     // we need to copy the detailed_message
-    auto message = error.detailed_message;
-    auto len = strlen(message) + 1;
-    auto buffer = (char*)malloc(len);
-    strncpy(buffer, message, len);
-    error_copy.detailed_message = buffer;
+    auto message = duplicate_string(std::string(error.detailed_message));
+    error_copy.detailed_message = message;
 
     // other strings are not read, so we skip those
     error_copy.c_original_file_path_key = nullptr;

--- a/src/sync_client.cpp
+++ b/src/sync_client.cpp
@@ -1,0 +1,70 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "sync_client.h"
+
+#include <realm/object-store/c_api/types.hpp>
+#include <realm/object-store/c_api/util.hpp>
+
+#include "event_loop_dispatcher.hpp"
+
+namespace realm::c_api {
+namespace {
+
+using FreeT = std::function<void()>;
+using CallbackT = std::function<void(realm_sync_session_t*, const realm_sync_error_t)>; // Differs per callback
+using UserdataT = std::tuple<CallbackT, FreeT>;
+
+void _callback(void* userdata, realm_sync_session_t* session, const realm_sync_error_t error) {
+    auto error_copy = error; // copy struct
+
+    // we need to copy the detailed_message
+    auto message = error.detailed_message;
+    auto len = strlen(message) + 1;
+    auto buffer = (char*)malloc(len);
+    strncpy(buffer, message, len);
+    error_copy.detailed_message = buffer;
+
+    // other strings are not read, so we skip those
+    error_copy.c_original_file_path_key = nullptr;
+    error_copy.c_recovery_file_path_key = nullptr;
+
+    auto u = reinterpret_cast<UserdataT*>(userdata);
+    std::get<0>(*u)(session, error_copy);
+}
+
+void _userdata_free(void* userdata) {
+    auto u = reinterpret_cast<UserdataT*>(userdata);
+    std::get<1>(*u)();
+    delete u;
+}
+
+RLM_API void realm_dart_sync_config_set_error_handler(
+    realm_sync_config_t* config,
+    realm_sync_error_handler_func_t handler,
+    realm_userdata_t userdata,
+    realm_free_userdata_func_t userdata_free,
+    realm_scheduler_t* scheduler) noexcept
+{
+    auto u = new UserdataT(std::bind(util::EventLoopDispatcher{ *scheduler, handler }, userdata, std::placeholders::_1, std::placeholders::_2),
+                           std::bind(util::EventLoopDispatcher{ *scheduler, userdata_free }, userdata));
+    return realm_sync_config_set_error_handler(config, _callback, u, _userdata_free);
+}
+
+}
+}

--- a/src/sync_client.h
+++ b/src/sync_client.h
@@ -1,0 +1,30 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_DART_SYNC_CLIENT_H
+#define REALM_DART_SYNC_CLIENT_H
+
+#include "realm.h"
+
+RLM_API void realm_dart_sync_config_set_error_handler(realm_sync_config_t* config, 
+                                                      realm_sync_error_handler_func_t handler,
+                                                      realm_userdata_t userdata,
+                                                      realm_free_userdata_func_t userdata_free,
+                                                      realm_scheduler_t* scheduler) RLM_API_NOEXCEPT;
+
+#endif // REALM_DART_SYNC_CLIENT_H

--- a/src/sync_session.cpp
+++ b/src/sync_session.cpp
@@ -39,11 +39,8 @@ void _callback(void* userdata, realm_sync_error_code_t* error) {
         *error_copy = *error; // copy struct
 
         // we need to copy the message 
-        auto message = error->message;
-        auto len = strlen(message) + 1;
-        auto buffer = (char*)malloc(len);
-        strncpy(buffer, message, len);
-        error_copy->message = buffer;
+        auto message = duplicate_string(std::string(error->message));
+        error_copy->message = message;
 
         std::get<0>(*u)(error_copy);
     }

--- a/src/sync_session.cpp
+++ b/src/sync_session.cpp
@@ -23,6 +23,7 @@
 #include "sync_session.h"
 #include "event_loop_dispatcher.hpp"
 
+#include <iostream>
 
 namespace realm::c_api {
 namespace _1 {
@@ -33,7 +34,22 @@ using UserdataT = std::tuple<CallbackT, FreeT>;
 
 void _callback(void* userdata, realm_sync_error_code_t* error) {
     auto u = reinterpret_cast<UserdataT*>(userdata);
-    std::get<0>(*u)(error);
+    if (error != nullptr) {
+        auto error_copy = (realm_sync_error_code_t*)malloc(sizeof(realm_sync_error_code_t));
+        *error_copy = *error; // copy struct
+
+        // we need to copy the message 
+        auto message = error->message;
+        auto len = strlen(message) + 1;
+        auto buffer = (char*)malloc(len);
+        strncpy(buffer, message, len);
+        error_copy->message = buffer;
+
+        std::get<0>(*u)(error_copy);
+    }
+    else {
+        std::get<0>(*u)(nullptr);
+    }
 }
 
 void _userdata_free(void* userdata) {

--- a/test/subscription_test.dart
+++ b/test/subscription_test.dart
@@ -504,6 +504,12 @@ Future<void> main([List<String>? args]) async {
 
     final syncError = await completer.future;
     expect(syncError.category, SyncErrorCategory.client);
+    expect(
+        syncError.message!.startsWith(
+            "Client attempted a write that is outside of permissions or query filters: cannot write to table \"${(Task).toString()}\" before opening a subscription on it"),
+        isTrue);
+    expect(syncError is SyncClientResetError, isTrue);
+    expect((syncError as SyncClientResetError).code, SyncClientErrorCode.autoClientResetFailure);
   });
 
   baasTest('Writing before subscribe + upload', (configuration) async {
@@ -516,6 +522,6 @@ Future<void> main([List<String>? args]) async {
 
     final realm = getRealm(config);
     realm.write(() => realm.add(Task(ObjectId())));
-    expect(() async => await realm.syncSession.waitForUpload(), throws<RealmException>());
+    expect(() async => await realm.syncSession.waitForUpload(), throws<RealmException>("Client attempted a write that is disallowed by permissions, or modifies an object outside the current query"));
   });
 }

--- a/test/subscription_test.dart
+++ b/test/subscription_test.dart
@@ -21,12 +21,13 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as path;
 import 'package:test/expect.dart';
 
 import '../lib/realm.dart';
 import '../lib/src/native/realm_core.dart';
 import '../lib/src/subscription.dart';
+import '../lib/src/configuration.dart';
+
 import 'test.dart';
 
 @isTest
@@ -483,5 +484,38 @@ Future<void> main([List<String>? args]) async {
 
     final task = realmY.find<Task>(objectId);
     expect(task, isNotNull);
+  });
+
+  baasTest('Writing before subscribe', (configuration) async {
+    final app = App(configuration);
+    final user = await getIntegrationUser(app);
+
+    final completer = Completer<SyncError>();
+    final config = Configuration.flexibleSync(
+      user,
+      [Task.schema],
+      syncClientResetErrorHandler: ManualSyncClientResetHandler((syncError) {
+        completer.complete(syncError);
+      }),
+    );
+
+    final realm = getRealm(config);
+    realm.write(() => realm.add(Task(ObjectId())));
+
+    final syncError = await completer.future;
+    expect(syncError.category, SyncErrorCategory.client);
+  });
+
+  baasTest('Writing before subscribe + upload', (configuration) async {
+    final app = App(configuration);
+    final user = await getIntegrationUser(app);
+    final config = Configuration.flexibleSync(
+      user,
+      [Task.schema],
+    );
+
+    final realm = getRealm(config);
+    realm.write(() => realm.add(Task(ObjectId())));
+    expect(() async => await realm.syncSession.waitForUpload(), throws<RealmException>());
   });
 }

--- a/test/test.dart
+++ b/test/test.dart
@@ -325,7 +325,7 @@ Future<void> baasTest(
 
   test(name, () async {
     final config = await getAppConfig(appName: appName);
-    return await testFunction(config);
+    await testFunction(config);
   }, skip: skip);
 }
 


### PR DESCRIPTION
Add missing trampoline, and copy error messages before bouncing.

* Copy error message native, and free on dart side
* Add trampoline for realm_sync_config_set_error_handler

Fixes:  #630