### PR TITLE
Use only one cluster for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             --api-key ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }} \
             --private-api-key ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }} \
             --project-id ${{ secrets.ATLAS_QA_PROJECT_ID }} \
-            --database-prefix "${{ matrix.package }}-${{ matrix.platform }}"
+            --differentiator "${{ matrix.package }}-${{ matrix.platform }}"
 
   cleanup-cluster:
     runs-on: ubuntu-latest
@@ -247,7 +247,7 @@ jobs:
     name: Tests Linux
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: dart-linux
+      BAAS_DIFFERENTIATOR: dart-linux
     needs:
       - baas-matrix
       - deploy-cluster
@@ -280,7 +280,7 @@ jobs:
     name: Flutter Tests Linux
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: flutter-linux
+      BAAS_DIFFERENTIATOR: flutter-linux
     needs:
       - baas-matrix
       - deploy-cluster
@@ -327,7 +327,7 @@ jobs:
     name: Tests macOS
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: dart-macos
+      BAAS_DIFFERENTIATOR: dart-macos
     needs:
       - baas-matrix
       - deploy-cluster
@@ -360,7 +360,7 @@ jobs:
     name: Flutter Tests macOS
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: flutter-macos
+      BAAS_DIFFERENTIATOR: flutter-macos
     needs:
       - baas-matrix
       - deploy-cluster
@@ -399,7 +399,7 @@ jobs:
     name: Tests Windows
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: dart-windows
+      BAAS_DIFFERENTIATOR: dart-windows
     needs:
       - baas-matrix
       - deploy-cluster
@@ -434,7 +434,7 @@ jobs:
     name: Flutter Tests Windows
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: flutter-windows
+      BAAS_DIFFERENTIATOR: flutter-windows
     needs:
       - baas-matrix
       - deploy-cluster
@@ -473,7 +473,7 @@ jobs:
     name: Flutter Tests iOS
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: flutter-ios
+      BAAS_DIFFERENTIATOR: flutter-ios
     needs:
       - baas-matrix
       - deploy-cluster
@@ -520,7 +520,7 @@ jobs:
     name: Flutter Tests Android
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: flutter-android
+      BAAS_DIFFERENTIATOR: flutter-android
     needs:
       - baas-matrix
       - deploy-cluster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,25 @@ env:
 
 jobs:
 
-  baas_matrix:
+  deploy-cluster:
+    runs-on: ubuntu-latest
+    name: Deploy Cluster
+    outputs:
+      clusterName: ${{ steps.deploy-mdb-apps.outputs.clusterName }}
+    steps:
+      - uses: realm/ci-actions/mdb-realm/deployApps@fac1d6958f03d71de743305ce3ab27594efbe7b7
+        id: deploy-mdb-apps
+        with:
+          realmUrl: ${{ secrets.REALM_QA_URL }}
+          atlasUrl: ${{ secrets.ATLAS_QA_URL }}
+          projectId: ${{ secrets.ATLAS_QA_PROJECT_ID }}
+          apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
+          privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
+          differentiator: realm-dart
+
+  baas-matrix:
+    needs:
+      - deploy-cluster
     strategy:
       fail-fast: false
       matrix:
@@ -26,32 +44,13 @@ jobs:
           - platform: android
             package: flutter
     runs-on: ubuntu-latest
-    name: BaaS ${{ matrix.platform }} for ${{ matrix.package }}
-    outputs:
-      dart-linux-clusterName: ${{ steps.set-output.outputs.dart-linux-clusterName }}
-      dart-windows-clusterName: ${{ steps.set-output.outputs.dart-windows-clusterName }}
-      dart-macos-clusterName: ${{ steps.set-output.outputs.dart-macos-clusterName }}
-      flutter-linux-clusterName: ${{ steps.set-output.outputs.flutter-linux-clusterName }}
-      flutter-windows-clusterName: ${{ steps.set-output.outputs.flutter-windows-clusterName }}
-      flutter-macos-clusterName: ${{ steps.set-output.outputs.flutter-macos-clusterName }}
-      flutter-ios-clusterName: ${{ steps.set-output.outputs.flutter-ios-clusterName }}
-      flutter-android-clusterName: ${{ steps.set-output.outputs.flutter-android-clusterName }}
+    name: Deploy apps ${{ matrix.platform }} for ${{ matrix.package }}
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: false
-
-      - uses: realm/ci-actions/mdb-realm/deployApps@fac1d6958f03d71de743305ce3ab27594efbe7b7
-        id: deploy-mdb-apps
-        with:
-          realmUrl: ${{ secrets.REALM_QA_URL }}
-          atlasUrl: ${{ secrets.ATLAS_QA_URL }}
-          projectId: ${{ secrets.ATLAS_QA_PROJECT_ID }}
-          apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
-          privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
-          differentiator: ${{ matrix.package }}-${{ matrix.platform }}
 
       - name : Setup Dart SDK
         uses: dart-lang/setup-dart@main
@@ -62,28 +61,15 @@ jobs:
         run: |
           dart run realm_dart deploy-apps \
             --baas-url ${{ secrets.REALM_QA_URL }} \
-            --atlas-cluster ${{ steps.deploy-mdb-apps.outputs.clusterName }} \
+            --atlas-cluster ${{ needs.deploy-cluster.outputs.clusterName }} \
             --api-key ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }} \
             --private-api-key ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }} \
-            --project-id ${{ secrets.ATLAS_QA_PROJECT_ID }}
+            --project-id ${{ secrets.ATLAS_QA_PROJECT_ID }} \
+            --database-prefix "${{ matrix.package }}-${{ matrix.platform }}"
 
-      - name: Set ${{ matrix.package }}-${{ matrix.platform }} outputs
-        id: set-output
-        run: echo '::set-output name=${{ matrix.package }}-${{ matrix.platform }}-clusterName::${{ steps.deploy-mdb-apps.outputs.clusterName }}'
-
-  cleanup-matrix:
-    strategy:
-      fail-fast: false
-      matrix:
-        package: [flutter, dart]
-        platform: [linux, windows, macos]
-        include:
-          - platform: ios
-            package: flutter
-          - platform: android
-            package: flutter
+  cleanup-cluster:
     runs-on: ubuntu-latest
-    name: Cleanup ${{ matrix.platform }} for ${{ matrix.package }}
+    name: Cleanup cluster
     needs:
       - tests-linux
       - flutter-linux
@@ -103,7 +89,7 @@ jobs:
           projectId: ${{ secrets.ATLAS_QA_PROJECT_ID}}
           apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY}}
           privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
-          differentiator: ${{ matrix.package }}-${{ matrix.platform }}
+          differentiator: realm-dart
 
   build-native:
     runs-on: ${{ matrix.runner }}-latest
@@ -169,7 +155,7 @@ jobs:
     name: Combine .xcframework
     runs-on: macos-latest
     needs: build-native
-    
+
     steps:
       - name: Fetch device build
         uses: actions/download-artifact@v2
@@ -215,7 +201,7 @@ jobs:
     name: Combine Android binaries
     runs-on: ubuntu-latest
     needs: build-native
-    
+
     steps:
       - name: Fetch x86 build
         uses: actions/download-artifact@v2
@@ -260,9 +246,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Tests Linux
     env:
-      BAAS_CLUSTER: ${{ needs.baas_matrix.outputs.dart-linux-clusterName }}
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DATABASE_PREFIX: ${{ dart-linux }}
     needs:
-      - baas_matrix
+      - baas-matrix
+      - deploy-cluster
       - build-native
     steps:
       - name: Checkout
@@ -291,9 +279,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Flutter Tests Linux
     env:
-      BAAS_CLUSTER: ${{ needs.baas_matrix.outputs.flutter-linux-clusterName }}
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DATABASE_PREFIX: ${{ flutter-linux }}
     needs:
-      - baas_matrix
+      - baas-matrix
+      - deploy-cluster
       - build-native
     steps:
       - name: Checkout
@@ -336,9 +326,11 @@ jobs:
     runs-on: macos-latest
     name: Tests macOS
     env:
-      BAAS_CLUSTER: ${{ needs.baas_matrix.outputs.dart-macos-clusterName }}
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DATABASE_PREFIX: ${{ dart-macos }}
     needs:
-      - baas_matrix
+      - baas-matrix
+      - deploy-cluster
       - build-native
     steps:
       - name: Checkout
@@ -367,9 +359,11 @@ jobs:
     runs-on: macos-latest
     name: Flutter Tests macOS
     env:
-      BAAS_CLUSTER: ${{ needs.baas_matrix.outputs.flutter-macos-clusterName }}
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DATABASE_PREFIX: ${{ flutter-macos }}
     needs:
-      - baas_matrix
+      - baas-matrix
+      - deploy-cluster
       - build-native
     steps:
       - name: Checkout
@@ -398,16 +392,17 @@ jobs:
         run: flutter drive -d macos --target=test_driver/app.dart --suppress-analytics --dart-entrypoint-args="" #--verbose #-a="Some test name"
         working-directory: ./flutter/realm_flutter/tests
 
-
 # Windows jobs
 
   tests-windows:
     runs-on: windows-latest
     name: Tests Windows
     env:
-      BAAS_CLUSTER: ${{ needs.baas_matrix.outputs.dart-windows-clusterName }}
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DATABASE_PREFIX: ${{ dart-windows }}
     needs:
-      - baas_matrix
+      - baas-matrix
+      - deploy-cluster
       - build-native
     steps:
       - name: Checkout
@@ -438,9 +433,11 @@ jobs:
     runs-on: windows-2019
     name: Flutter Tests Windows
     env:
-      BAAS_CLUSTER: ${{ needs.baas_matrix.outputs.flutter-windows-clusterName }}
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DATABASE_PREFIX: ${{ flutter-windows }}
     needs:
-      - baas_matrix
+      - baas-matrix
+      - deploy-cluster
       - build-native
     steps:
       - name: Checkout
@@ -475,9 +472,11 @@ jobs:
     runs-on: macos-latest
     name: Flutter Tests iOS
     env:
-      BAAS_CLUSTER: ${{ needs.baas_matrix.outputs.flutter-ios-clusterName }}
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DATABASE_PREFIX: ${{ flutter-ios }}
     needs:
-      - baas_matrix
+      - baas-matrix
+      - deploy-cluster
       - build-ios-xcframework
     steps:
       - name: Checkout
@@ -520,9 +519,11 @@ jobs:
     runs-on: macos-latest
     name: Flutter Tests Android
     env:
-      BAAS_CLUSTER: ${{ needs.baas_matrix.outputs.flutter-android-clusterName }}
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DATABASE_PREFIX: ${{ flutter-android }}
     needs:
-      - baas_matrix
+      - baas-matrix
+      - deploy-cluster
       - build-android-combined
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
     name: Tests Linux
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: ${{ dart-linux }}
+      BAAS_DATABASE_PREFIX: dart-linux
     needs:
       - baas-matrix
       - deploy-cluster
@@ -280,7 +280,7 @@ jobs:
     name: Flutter Tests Linux
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: ${{ flutter-linux }}
+      BAAS_DATABASE_PREFIX: flutter-linux
     needs:
       - baas-matrix
       - deploy-cluster
@@ -327,7 +327,7 @@ jobs:
     name: Tests macOS
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: ${{ dart-macos }}
+      BAAS_DATABASE_PREFIX: dart-macos
     needs:
       - baas-matrix
       - deploy-cluster
@@ -360,7 +360,7 @@ jobs:
     name: Flutter Tests macOS
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: ${{ flutter-macos }}
+      BAAS_DATABASE_PREFIX: flutter-macos
     needs:
       - baas-matrix
       - deploy-cluster
@@ -399,7 +399,7 @@ jobs:
     name: Tests Windows
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: ${{ dart-windows }}
+      BAAS_DATABASE_PREFIX: dart-windows
     needs:
       - baas-matrix
       - deploy-cluster
@@ -434,7 +434,7 @@ jobs:
     name: Flutter Tests Windows
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: ${{ flutter-windows }}
+      BAAS_DATABASE_PREFIX: flutter-windows
     needs:
       - baas-matrix
       - deploy-cluster
@@ -473,7 +473,7 @@ jobs:
     name: Flutter Tests iOS
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: ${{ flutter-ios }}
+      BAAS_DATABASE_PREFIX: flutter-ios
     needs:
       - baas-matrix
       - deploy-cluster
@@ -520,7 +520,7 @@ jobs:
     name: Flutter Tests Android
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
-      BAAS_DATABASE_PREFIX: ${{ flutter-android }}
+      BAAS_DATABASE_PREFIX: flutter-android
     needs:
       - baas-matrix
       - deploy-cluster

--- a/lib/src/cli/deployapps/deployapps_command.dart
+++ b/lib/src/cli/deployapps/deployapps_command.dart
@@ -58,11 +58,11 @@ class DeployAppsCommand extends Command<void> {
       }
     }
 
-    final databasePrefix = options.databasePrefix ?? 'local';
+    final differentiator = options.differentiator ?? 'local';
 
     final client = await (options.atlasCluster == null
-        ? BaasClient.docker(options.baasUrl, databasePrefix)
-        : BaasClient.atlas(options.baasUrl, options.atlasCluster!, options.apiKey!, options.privateApiKey!, options.projectId!, databasePrefix));
+        ? BaasClient.docker(options.baasUrl, differentiator)
+        : BaasClient.atlas(options.baasUrl, options.atlasCluster!, options.apiKey!, options.privateApiKey!, options.projectId!, differentiator));
 
     final apps = await client.getOrCreateApps();
 

--- a/lib/src/cli/deployapps/deployapps_command.dart
+++ b/lib/src/cli/deployapps/deployapps_command.dart
@@ -58,9 +58,11 @@ class DeployAppsCommand extends Command<void> {
       }
     }
 
+    final databasePrefix = options.databasePrefix ?? 'local';
+
     final client = await (options.atlasCluster == null
-        ? BaasClient.docker(options.baasUrl)
-        : BaasClient.atlas(options.baasUrl, options.atlasCluster!, options.apiKey!, options.privateApiKey!, options.projectId!));
+        ? BaasClient.docker(options.baasUrl, databasePrefix)
+        : BaasClient.atlas(options.baasUrl, options.atlasCluster!, options.apiKey!, options.privateApiKey!, options.projectId!, databasePrefix));
 
     final apps = await client.getOrCreateApps();
 

--- a/lib/src/cli/deployapps/options.dart
+++ b/lib/src/cli/deployapps/options.dart
@@ -26,7 +26,7 @@ class Options {
   final String baasUrl;
 
   @CliOption(help: 'The database prefix that will be used for the sync service.')
-  final String? databasePrefix;
+  final String? differentiator;
 
   @CliOption(help: 'Atlas Cluster to link in the application.')
   final String? atlasCluster;
@@ -40,7 +40,7 @@ class Options {
   @CliOption(help: 'The Atlas project id to use for the import. Only used if atlas-cluster is specified.')
   final String? projectId;
 
-  Options(this.baasUrl, {this.atlasCluster, this.apiKey, this.privateApiKey, this.projectId, this.databasePrefix});
+  Options(this.baasUrl, {this.atlasCluster, this.apiKey, this.privateApiKey, this.projectId, this.differentiator});
 }
 
 String get usage => _$parserForOptions.usage;

--- a/lib/src/cli/deployapps/options.dart
+++ b/lib/src/cli/deployapps/options.dart
@@ -25,6 +25,9 @@ class Options {
   @CliOption(help: 'Url for MongoDB Atlas.', defaultsTo: 'http://localhost:9090')
   final String baasUrl;
 
+  @CliOption(help: 'The database prefix that will be used for the sync service.')
+  final String? databasePrefix;
+
   @CliOption(help: 'Atlas Cluster to link in the application.')
   final String? atlasCluster;
 
@@ -37,7 +40,7 @@ class Options {
   @CliOption(help: 'The Atlas project id to use for the import. Only used if atlas-cluster is specified.')
   final String? projectId;
 
-  Options(this.baasUrl, {this.atlasCluster, this.apiKey, this.privateApiKey, this.projectId});
+  Options(this.baasUrl, {this.atlasCluster, this.apiKey, this.privateApiKey, this.projectId, this.databasePrefix});
 }
 
 String get usage => _$parserForOptions.usage;

--- a/lib/src/cli/deployapps/options.g.dart
+++ b/lib/src/cli/deployapps/options.g.dart
@@ -12,6 +12,7 @@ Options _$parseOptionsResult(ArgResults result) => Options(
       apiKey: result['api-key'] as String?,
       privateApiKey: result['private-api-key'] as String?,
       projectId: result['project-id'] as String?,
+      databasePrefix: result['database-prefix'] as String?,
     );
 
 ArgParser _$populateOptionsParser(ArgParser parser) => parser
@@ -19,6 +20,10 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
     'baas-url',
     help: 'Url for MongoDB Atlas.',
     defaultsTo: 'http://localhost:9090',
+  )
+  ..addOption(
+    'database-prefix',
+    help: 'The database prefix that will be used for the sync service.',
   )
   ..addOption(
     'atlas-cluster',

--- a/lib/src/cli/deployapps/options.g.dart
+++ b/lib/src/cli/deployapps/options.g.dart
@@ -12,7 +12,7 @@ Options _$parseOptionsResult(ArgResults result) => Options(
       apiKey: result['api-key'] as String?,
       privateApiKey: result['private-api-key'] as String?,
       projectId: result['project-id'] as String?,
-      databasePrefix: result['database-prefix'] as String?,
+      differentiator: result['differentiator'] as String?,
     );
 
 ArgParser _$populateOptionsParser(ArgParser parser) => parser
@@ -22,7 +22,7 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
     defaultsTo: 'http://localhost:9090',
   )
   ..addOption(
-    'database-prefix',
+    'differentiator',
     help: 'The database prefix that will be used for the sync service.',
   )
   ..addOption(

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -330,8 +330,7 @@ Future<void> main([List<String>? args]) async {
   baasTest('SyncSession.getConnectionStateStream', (configuration) async {
     final realm = await getIntegrationRealm();
 
-    await waitForCondition(() => realm.syncSession.connectionState.name == ConnectionState.connected.name,
-        timeout: Duration(seconds: 15), message: 'Expected session to be connected');
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.active, expectedConnectionState: ConnectionState.connected);
 
     final states = <ConnectionStateChange>[];
     final stream = realm.syncSession.connectionStateChanges;
@@ -342,7 +341,7 @@ Future<void> main([List<String>? args]) async {
     // Verify we get a notification when we pause the session
     realm.syncSession.pause();
 
-    await validateSessionStates(realm.syncSession, expectedConnectionState: ConnectionState.disconnected);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.inactive, expectedConnectionState: ConnectionState.disconnected);
     await waitForCondition(() => states.length == 1, timeout: Duration(seconds: 15), message: 'expected 1 notification, got ${states.length}');
 
     expect(states[0].previous.name, ConnectionState.connected.name);
@@ -351,7 +350,7 @@ Future<void> main([List<String>? args]) async {
     // When resuming, we should get two notifications - first we go to connecting, then connected
     realm.syncSession.resume();
 
-    await validateSessionStates(realm.syncSession, expectedConnectionState: ConnectionState.connected);
+    await validateSessionStates(realm.syncSession, expectedSessionState: SessionState.active, expectedConnectionState: ConnectionState.connected);
     await waitForCondition(() => states.length == 3, timeout: Duration(seconds: 15), message: 'expected 3 notifications, got ${states.length}');
 
     expect(states[1].previous.name, ConnectionState.disconnected.name);

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -330,7 +330,7 @@ Future<void> main([List<String>? args]) async {
   baasTest('SyncSession.getConnectionStateStream', (configuration) async {
     final realm = await getIntegrationRealm();
 
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected,
+    await waitForCondition(() => realm.syncSession.connectionState.name == ConnectionState.connected.name,
         timeout: Duration(seconds: 15), message: 'Expected session to be connected');
 
     final states = <ConnectionStateChange>[];
@@ -341,25 +341,25 @@ Future<void> main([List<String>? args]) async {
 
     // Verify we get a notification when we pause the session
     realm.syncSession.pause();
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.disconnected,
+    await waitForCondition(() => realm.syncSession.connectionState.name == ConnectionState.disconnected.name,
         timeout: Duration(seconds: 15), message: 'expected session to be disconnected');
     await waitForCondition(() => states.length == 1, timeout: Duration(seconds: 15), message: 'expected to get a disconnected state change notification');
 
-    expect(states[0].previous, ConnectionState.connected);
-    expect(states[0].current, ConnectionState.disconnected);
+    expect(states[0].previous.name, ConnectionState.connected.name);
+    expect(states[0].current.name, ConnectionState.disconnected.name);
 
     // When resuming, we should get two notifications - first we go to connecting, then connected
     realm.syncSession.resume();
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected,
+    await waitForCondition(() => realm.syncSession.connectionState.name == ConnectionState.connected.name,
         timeout: Duration(seconds: 15), message: 'expected session to be reconnected');
     await waitForCondition(() => states.length == 3,
         timeout: Duration(seconds: 15), message: 'expected to get connection state change notifications for connecting and connected');
 
-    expect(states[1].previous, ConnectionState.disconnected);
-    expect(states[1].current, ConnectionState.connecting);
+    expect(states[1].previous.name, ConnectionState.disconnected.name);
+    expect(states[1].current.name, ConnectionState.connecting.name);
 
-    expect(states[2].previous, ConnectionState.connecting);
-    expect(states[2].current, ConnectionState.connected);
+    expect(states[2].previous.name, ConnectionState.connecting.name);
+    expect(states[2].current.name, ConnectionState.connected.name);
 
     await subscription.cancel();
   });

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -341,19 +341,18 @@ Future<void> main([List<String>? args]) async {
 
     // Verify we get a notification when we pause the session
     realm.syncSession.pause();
-    await waitForCondition(() => realm.syncSession.connectionState.name == ConnectionState.disconnected.name,
-        timeout: Duration(seconds: 15), message: 'expected session to be disconnected');
-    await waitForCondition(() => states.length == 1, timeout: Duration(seconds: 15), message: 'expected to get a disconnected state change notification');
+
+    await validateSessionStates(realm.syncSession, expectedConnectionState: ConnectionState.disconnected);
+    await waitForCondition(() => states.length == 1, timeout: Duration(seconds: 15), message: 'expected 1 notification, got ${states.length}');
 
     expect(states[0].previous.name, ConnectionState.connected.name);
     expect(states[0].current.name, ConnectionState.disconnected.name);
 
     // When resuming, we should get two notifications - first we go to connecting, then connected
     realm.syncSession.resume();
-    await waitForCondition(() => realm.syncSession.connectionState.name == ConnectionState.connected.name,
-        timeout: Duration(seconds: 15), message: 'expected session to be reconnected');
-    await waitForCondition(() => states.length == 3,
-        timeout: Duration(seconds: 15), message: 'expected to get connection state change notifications for connecting and connected');
+
+    await validateSessionStates(realm.syncSession, expectedConnectionState: ConnectionState.connected);
+    await waitForCondition(() => states.length == 3, timeout: Duration(seconds: 15), message: 'expected 3 notifications, got ${states.length}');
 
     expect(states[1].previous.name, ConnectionState.disconnected.name);
     expect(states[1].current.name, ConnectionState.connecting.name);

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -330,7 +330,8 @@ Future<void> main([List<String>? args]) async {
   baasTest('SyncSession.getConnectionStateStream', (configuration) async {
     final realm = await getIntegrationRealm();
 
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected, timeout: Duration(seconds: 5));
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected,
+        timeout: Duration(seconds: 15), message: 'Expected session to be connected');
 
     final states = <ConnectionStateChange>[];
     final stream = realm.syncSession.connectionStateChanges;
@@ -340,16 +341,19 @@ Future<void> main([List<String>? args]) async {
 
     // Verify we get a notification when we pause the session
     realm.syncSession.pause();
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.disconnected, timeout: Duration(seconds: 5));
-    await waitForCondition(() => states.length == 1, timeout: Duration(seconds: 5));
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.disconnected,
+        timeout: Duration(seconds: 15), message: 'expected session to be disconnected');
+    await waitForCondition(() => states.length == 1, timeout: Duration(seconds: 15), message: 'expected to get a disconnected state change notification');
 
     expect(states[0].previous, ConnectionState.connected);
     expect(states[0].current, ConnectionState.disconnected);
 
     // When resuming, we should get two notifications - first we go to connecting, then connected
     realm.syncSession.resume();
-    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected, timeout: Duration(seconds: 5));
-    await waitForCondition(() => states.length == 3, timeout: Duration(seconds: 5));
+    await waitForCondition(() => realm.syncSession.connectionState == ConnectionState.connected,
+        timeout: Duration(seconds: 15), message: 'expected session to be reconnected');
+    await waitForCondition(() => states.length == 3,
+        timeout: Duration(seconds: 15), message: 'expected to get connection state change notifications for connecting and connected');
 
     expect(states[1].previous, ConnectionState.disconnected);
     expect(states[1].current, ConnectionState.connecting);

--- a/test/test.dart
+++ b/test/test.dart
@@ -152,6 +152,7 @@ const String argBaasCluster = "BAAS_CLUSTER";
 const String argBaasApiKey = "BAAS_API_KEY";
 const String argBaasPrivateApiKey = "BAAS_PRIVATE_API_KEY";
 const String argBaasProjectId = "BAAS_PROJECT_ID";
+const String argDatabasePrefix = "BAAS_DATABASE_PREFIX";
 
 String testUsername = "realm-test@realm.io";
 String testPassword = "123456";
@@ -272,7 +273,8 @@ Map<String, String?> parseTestArguments(List<String>? arguments) {
     ..addOption(argBaasCluster)
     ..addOption(argBaasApiKey)
     ..addOption(argBaasPrivateApiKey)
-    ..addOption(argBaasProjectId);
+    ..addOption(argBaasProjectId)
+    ..addOption(argDatabasePrefix);
 
   final result = parser.parse(arguments ?? []);
   testArgs
@@ -281,13 +283,18 @@ Map<String, String?> parseTestArguments(List<String>? arguments) {
     ..addArgument(result, argBaasCluster)
     ..addArgument(result, argBaasApiKey)
     ..addArgument(result, argBaasPrivateApiKey)
-    ..addArgument(result, argBaasProjectId);
+    ..addArgument(result, argBaasProjectId)
+    ..addArgument(result, argDatabasePrefix);
+
   return testArgs;
 }
 
 extension on Map<String, String?> {
   void addArgument(ArgResults parsedResult, String argName) {
-    this[argName] = parsedResult.wasParsed(argName) ? parsedResult[argName]?.toString() : Platform.environment[argName];
+    final value = parsedResult.wasParsed(argName) ? parsedResult[argName]?.toString() : Platform.environment[argName];
+    if (value != null && value.isNotEmpty) {
+      this[argName] = value;
+    }
   }
 }
 
@@ -301,8 +308,11 @@ Future<void> setupBaas() async {
   final apiKey = arguments[argBaasApiKey];
   final privateApiKey = arguments[argBaasPrivateApiKey];
   final projectId = arguments[argBaasProjectId];
+  final databasePrefix = arguments[argDatabasePrefix];
 
-  final client = await (cluster == null ? BaasClient.docker(baasUrl) : BaasClient.atlas(baasUrl, cluster, apiKey!, privateApiKey!, projectId!));
+  final client = await (cluster == null
+      ? BaasClient.docker(baasUrl, databasePrefix)
+      : BaasClient.atlas(baasUrl, cluster, apiKey!, privateApiKey!, projectId!, databasePrefix));
   var apps = await client.getOrCreateApps();
   baasApps.addAll(apps);
 }

--- a/test/test.dart
+++ b/test/test.dart
@@ -152,7 +152,7 @@ const String argBaasCluster = "BAAS_CLUSTER";
 const String argBaasApiKey = "BAAS_API_KEY";
 const String argBaasPrivateApiKey = "BAAS_PRIVATE_API_KEY";
 const String argBaasProjectId = "BAAS_PROJECT_ID";
-const String argDatabasePrefix = "BAAS_DATABASE_PREFIX";
+const String argDifferentiator = "BAAS_DIFFERENTIATOR";
 
 String testUsername = "realm-test@realm.io";
 String testPassword = "123456";
@@ -274,7 +274,7 @@ Map<String, String?> parseTestArguments(List<String>? arguments) {
     ..addOption(argBaasApiKey)
     ..addOption(argBaasPrivateApiKey)
     ..addOption(argBaasProjectId)
-    ..addOption(argDatabasePrefix);
+    ..addOption(argDifferentiator);
 
   final result = parser.parse(arguments ?? []);
   testArgs
@@ -284,7 +284,7 @@ Map<String, String?> parseTestArguments(List<String>? arguments) {
     ..addArgument(result, argBaasApiKey)
     ..addArgument(result, argBaasPrivateApiKey)
     ..addArgument(result, argBaasProjectId)
-    ..addArgument(result, argDatabasePrefix);
+    ..addArgument(result, argDifferentiator);
 
   return testArgs;
 }
@@ -308,11 +308,12 @@ Future<void> setupBaas() async {
   final apiKey = arguments[argBaasApiKey];
   final privateApiKey = arguments[argBaasPrivateApiKey];
   final projectId = arguments[argBaasProjectId];
-  final databasePrefix = arguments[argDatabasePrefix];
+  final differentiator = arguments[argDifferentiator];
 
   final client = await (cluster == null
-      ? BaasClient.docker(baasUrl, databasePrefix)
-      : BaasClient.atlas(baasUrl, cluster, apiKey!, privateApiKey!, projectId!, databasePrefix));
+      ? BaasClient.docker(baasUrl, differentiator)
+      : BaasClient.atlas(baasUrl, cluster, apiKey!, privateApiKey!, projectId!, differentiator));
+
   var apps = await client.getOrCreateApps();
   baasApps.addAll(apps);
 }


### PR DESCRIPTION
This modifies the PR workflow to use a single cluster with multiple applications. Each application uses its own database, so they should not be clashing with each other.