### PR TITLE
Fix the ReserveCache error in the native-build job matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,8 @@ jobs:
         uses: friendlyanon/setup-vcpkg@v1
         with:
           path: src/realm-core/tools/vcpkg/ports
-          cache-key: ${{ matrix.preset }}
-          cache-restore-keys: ${{ matrix.preset }}
+          cache-key: vcpkg-${{ matrix.preset }}-${{ hashFiles('./src/realm-core/tools/vcpkg/**') }}
+          cache-restore-keys: vcpkg-${{ matrix.preset }}-
 
       - name: Setup Android NDK
         if: startsWith(matrix.preset, 'android-')


### PR DESCRIPTION
The cache keys used by the `setup-vcpkg` action were not definite enough and this caused a ReserveCache error when two jobs tried to reserve the same cache at the same time.