### PR TITLE
Fix flutter test path to realm_dart.dll

### DIFF
--- a/flutter/realm_flutter/example/test/widget_test.dart
+++ b/flutter/realm_flutter/example/test/widget_test.dart
@@ -1,0 +1,18 @@
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility in the flutter_test package. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:realm_example/main.dart';
+
+void main() {
+  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(MyApp());
+  });
+}

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -17,6 +17,12 @@ void _debugWrite(String message) {
   }());
 }
 
+bool get isInDebugMode {
+  bool inDebugMode = false;
+  assert(inDebugMode = true);
+  return inDebugMode;
+}
+
 /// @nodoc
 // Initializes Realm library
 DynamicLibrary initRealm() {
@@ -55,7 +61,11 @@ DynamicLibrary initRealm() {
       return "${File(Platform.resolvedExecutable).parent.absolute.path}/Frameworks/realm_dart.framework/realm_dart";
     } else if (Platform.isWindows) {
       if (isFlutterPlatform) {
-        return "$binaryName.dll";
+        if (Platform.resolvedExecutable.startsWith(Directory.current.path)) {
+          return "$binaryName.dll";
+        } else {
+          return "./build/windows/runner/${isInDebugMode ? "Debug" : "Release"}/$binaryName.dll";
+        }
       }
 
       return "binary/windows/$binaryName.dll";


### PR DESCRIPTION
When running flutter tests on windows an error appears that realm_dart.dll can not be loaded. 
It is because executable path for flutter tests is not in the local app directory.
The same problem exists also on Linux and MacOS.
Task: #791