### PR TITLE
Use a matrix to deploy and cleanup apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,15 @@ jobs:
     outputs:
       clusterName: ${{ steps.cluster-name.outputs.clusterName }}
     steps:
-      - name: Get cluster suffix
-        id: cluster-name
-        run: echo "::set-output name=clusterName::dart$(date +'%d%p')"
-
       - uses: realm/ci-actions/mdb-realm/deployApps@916d1585f7e066431830b195cdb8cf7855747c2a
-        id: deploy-mdb-apps
         with:
           realmUrl: ${{ env.BAAS_URL }}
           atlasUrl: ${{ secrets.ATLAS_QA_URL }}
           projectId: ${{ env.BAAS_PROJECT_ID }}
           apiKey: ${{ env.BAAS_API_KEY }}
           privateApiKey: ${{ env.BAAS_PRIVATE_API_KEY }}
-          differentiator: ${{ steps.cluster-name.outputs.clusterName }}
-          clusterName: ${{ steps.cluster-name.outputs.clusterName }}
+          differentiator: dart
+          clusterName: dart
           useExistingCluster: true
 
   build-native:
@@ -246,6 +241,7 @@ jobs:
     needs:
       - deploy-cluster
       - build-native
+      - baas-matrix
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -294,6 +290,7 @@ jobs:
     needs:
       - deploy-cluster
       - build-native
+      - baas-matrix
     steps:
 
       - name: Checkout
@@ -341,6 +338,7 @@ jobs:
     needs:
       - deploy-cluster
       - build-ios-xcframework
+      - baas-matrix
     steps:
 
       - name: Checkout
@@ -386,6 +384,7 @@ jobs:
     needs:
       - deploy-cluster
       - build-android-combined
+      - baas-matrix
     steps:
 
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy Cluster
     outputs:
-      clusterName: ${{ steps.cluster-name.outputs.clusterName }}
+      clusterName: ${{ steps.deploy-atlas-cluster.outputs.clusterName }}
     steps:
       - uses: realm/ci-actions/mdb-realm/deployApps@916d1585f7e066431830b195cdb8cf7855747c2a
+        id: deploy-atlas-cluster
         with:
           realmUrl: ${{ env.BAAS_URL }}
           atlasUrl: ${{ secrets.ATLAS_QA_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy Cluster
     outputs:
-      clusterName: ${{ steps.deploy-atlas-cluster.outputs.clusterName }}
+      clusterName: ${{ steps.cluster-name.outputs.clusterName }}
     steps:
+      - name: Get cluster suffix
+        id: cluster-name
+        run: echo "::set-output name=clusterName::dart$(date +'%d%p')"
+
       - uses: realm/ci-actions/mdb-realm/deployApps@916d1585f7e066431830b195cdb8cf7855747c2a
-        id: deploy-atlas-cluster
         with:
           realmUrl: ${{ env.BAAS_URL }}
           atlasUrl: ${{ secrets.ATLAS_QA_URL }}
           projectId: ${{ env.BAAS_PROJECT_ID }}
           apiKey: ${{ env.BAAS_API_KEY }}
           privateApiKey: ${{ env.BAAS_PRIVATE_API_KEY }}
-          differentiator: dart
-          clusterName: dart
+          clusterName: ${{ steps.cluster-name.outputs.clusterName }}
           useExistingCluster: true
 
   build-native:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,115 @@ jobs:
     needs: build-native
     uses: ./.github/workflows/binary-combine-ios.yml
 
-# Linux jobs
+  baas-matrix:
+    needs:
+      - deploy-cluster
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: dm
+            description: dart macos
+          - app: dma
+            description: dart macos-arm
+          - app: dl
+            description: dart linux
+          - app: dw
+            description: dart windows
+          - app: fm
+            description: flutter macos
+          - app: fl
+            description: flutter linux
+          - app: fw
+            description: flutter windows
+          - app: fa
+            description: flutter android
+          - app: fi
+            description: flutter iOS
+    runs-on: ubuntu-latest
+    name: Deploy apps for ${{ matrix.description }}
+    timeout-minutes: 20
+    env:
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DIFFERENTIATOR: ${{ matrix.app }}${{ github.run_id }}${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+
+      - name : Setup Dart SDK
+        uses: dart-lang/setup-dart@main
+        with:
+          sdk: stable
+
+      - name: Deploy Apps
+        run: |
+          dart run realm_dart deploy-apps \
+            --baas-url ${{ env.BAAS_URL }} \
+            --atlas-cluster ${{ env.BAAS_CLUSTER }} \
+            --api-key ${{ env.BAAS_API_KEY }} \
+            --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} \
+            --project-id ${{ env.BAAS_PROJECT_ID }} \
+            --differentiator "${{ env.BAAS_DIFFERENTIATOR }}"
+
+  cleanup-matrix:
+    needs:
+      - dart-tests
+      - flutter-desktop-tests
+      - flutter-ios
+      - flutter-android
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: dm
+            description: dart macos
+          - app: dma
+            description: dart macos-arm
+          - app: dl
+            description: dart linux
+          - app: dw
+            description: dart windows
+          - app: fm
+            description: flutter macos
+          - app: fl
+            description: flutter linux
+          - app: fw
+            description: flutter windows
+          - app: fa
+            description: flutter android
+          - app: fi
+            description: flutter iOS
+    runs-on: ubuntu-latest
+    name: Cleanup apps for ${{ matrix.description }}
+    timeout-minutes: 20
+    if: always()
+    env:
+      BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
+      BAAS_DIFFERENTIATOR: ${{ matrix.app }}${{ github.run_id }}${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+
+      - name : Setup Dart SDK
+        uses: dart-lang/setup-dart@main
+        with:
+          sdk: stable
+
+      - name: Cleanup apps
+        run: |
+          dart run realm_dart delete-apps \
+            --baas-url ${{ env.BAAS_URL }} \
+            --atlas-cluster ${{ env.BAAS_CLUSTER }} \
+            --api-key ${{ env.BAAS_API_KEY }} \
+            --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} \
+            --project-id ${{ env.BAAS_PROJECT_ID }} \
+            --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
+
+# Dart jobs
 
   dart-tests:
     strategy:
@@ -139,7 +247,6 @@ jobs:
       - deploy-cluster
       - build-native
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -160,19 +267,13 @@ jobs:
           sdk: stable
           architecture: ${{ matrix.architecture == 'arm' && 'arm64' || 'x64'}}
 
-      - name: Deploy Apps for Dart tests on ${{ matrix.os }}
-        id: deploy-apps
-        run: dart run realm_dart deploy-apps --baas-url ${{ env.BAAS_URL }} --atlas-cluster ${{ env.BAAS_CLUSTER }} --api-key ${{ env.BAAS_API_KEY }} --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} --project-id ${{ env.BAAS_PROJECT_ID }} --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
-
       - name: Install dependencies
         run: dart pub get
 
       - name: Run tests
         run: ${{ matrix.architecture == 'arm' && 'arch -arm64 ' || '' }}dart test -r expanded -j 1 --test-randomize-ordering-seed random
 
-      - name: Cleanup apps
-        if: always()
-        run: dart run realm_dart delete-apps --baas-url ${{ env.BAAS_URL }} --atlas-cluster ${{ env.BAAS_CLUSTER }} --api-key ${{ env.BAAS_API_KEY }} --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} --project-id ${{ env.BAAS_PROJECT_ID }} --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
+# Flutter jobs
 
   flutter-desktop-tests:
     strategy:
@@ -190,7 +291,6 @@ jobs:
     env:
       BAAS_CLUSTER: ${{ needs.deploy-cluster.outputs.clusterName }}
       BAAS_DIFFERENTIATOR:  ${{ matrix.app }}${{ github.run_id }}${{ github.run_attempt }}
-
     needs:
       - deploy-cluster
       - build-native
@@ -222,10 +322,6 @@ jobs:
         with:
           channel: 'stable'
 
-      - name: Deploy Apps for Flutter tests on ${{ matrix.os }}
-        id: deploy-apps
-        run: dart run realm_dart deploy-apps --baas-url ${{ env.BAAS_URL }} --atlas-cluster ${{ env.BAAS_CLUSTER }} --api-key ${{ env.BAAS_API_KEY }} --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} --project-id ${{ env.BAAS_PROJECT_ID }} --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
-
       - name: Enable Flutter Desktop support
         run: flutter config --enable-${{ matrix.os }}-desktop
 
@@ -235,12 +331,6 @@ jobs:
       - name: Run tests
         run: ${{ matrix.os == 'linux' && 'xvfb-run' || '' }} flutter drive -d ${{ matrix.os }} --target=test_driver/app.dart --suppress-analytics --dart-entrypoint-args="" #--verbose #-a="Some test name"
         working-directory: ./flutter/realm_flutter/tests
-
-      - name: Cleanup apps
-        if: always()
-        run: dart run realm_dart delete-apps --baas-url ${{ env.BAAS_URL }} --atlas-cluster ${{ env.BAAS_CLUSTER }} --api-key ${{ env.BAAS_API_KEY }} --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} --project-id ${{ env.BAAS_PROJECT_ID }} --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
-
-# iOS jobs
 
   flutter-ios:
     runs-on: macos-latest
@@ -272,10 +362,6 @@ jobs:
         with:
           channel: 'stable'
 
-      - name: Deploy Apps for Flutter IOS tests on ${{ matrix.os }}
-        id: deploy-apps
-        run: dart run realm_dart deploy-apps --baas-url ${{ env.BAAS_URL }} --atlas-cluster ${{ env.BAAS_CLUSTER }} --api-key ${{ env.BAAS_API_KEY }} --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} --project-id ${{ env.BAAS_PROJECT_ID }} --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
-
       - name: Install dependencies
         run: flutter pub get
 
@@ -290,12 +376,6 @@ jobs:
         run: |
           flutter drive --target=test_driver/app.dart --dart-define=testName="" --suppress-analytics
         working-directory: ./flutter/realm_flutter/tests
-
-      - name: Cleanup apps
-        if: always()
-        run: dart run realm_dart delete-apps --baas-url ${{ env.BAAS_URL }} --atlas-cluster ${{ env.BAAS_CLUSTER }} --api-key ${{ env.BAAS_API_KEY }} --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} --project-id ${{ env.BAAS_PROJECT_ID }} --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
-
-# Android jobs
 
   flutter-android:
     runs-on: macos-latest
@@ -323,10 +403,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-
-      - name: Deploy Apps for Flutter Android tests on ${{ matrix.os }}
-        id: deploy-apps
-        run: dart run realm_dart deploy-apps --baas-url ${{ env.BAAS_URL }} --atlas-cluster ${{ env.BAAS_CLUSTER }} --api-key ${{ env.BAAS_API_KEY }} --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} --project-id ${{ env.BAAS_PROJECT_ID }} --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
 
       - name: Install dependencies
         run: flutter pub get
@@ -366,10 +442,6 @@ jobs:
           cmake: 3.10.2.4988404
           script: flutter drive --target=test_driver/app.dart --dart-define=testName="" --suppress-analytics
           working-directory: ./flutter/realm_flutter/tests
-
-      - name: Cleanup apps
-        if: always()
-        run: dart run realm_dart delete-apps --baas-url ${{ env.BAAS_URL }} --atlas-cluster ${{ env.BAAS_CLUSTER }} --api-key ${{ env.BAAS_API_KEY }} --private-api-key ${{ env.BAAS_PRIVATE_API_KEY }} --project-id ${{ env.BAAS_PROJECT_ID }} --differentiator '${{ env.BAAS_DIFFERENTIATOR }}'
 
 # Generator jobs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
       - flutter-desktop-tests
       - flutter-ios
       - flutter-android
+      - deploy-cluster
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This is building on top of https://github.com/realm/realm-dart/pull/663 by moving the deploy/cleanup steps to separate jobs. This shaves 45-60 seconds from the test jobs and those typically complete by the time the build-native job completes, so tests are ready to run in about a  minute.

The reason why this works is twofold:
1. We can split the deploy-apps job because our tests do not rely on it. The test runner will import the apps if necessary, so in the event of a re-run of the failed job, the test runner will fail to find the apps and import them itself.
2. We can split the cleanup-apps job because re-running a failed job will also re-run its dependents. In the event of a re-run, the cleanup will still be executed with the run attempt, so it will delete apps created by the test runner.