### PR TITLE
Remove TODOs - create tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,6 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      # TODO: move this to device farm
       - name: Setup Android Emulator cache
         uses: actions/cache@v2
         id: avd-cache

--- a/flutter/realm_flutter/example/android/app/build.gradle
+++ b/flutter/realm_flutter/example/android/app/build.gradle
@@ -33,7 +33,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.realm_example"
         minSdkVersion 16
         targetSdkVersion 30
@@ -43,8 +42,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }

--- a/flutter/realm_flutter/ios/realm.podspec
+++ b/flutter/realm_flutter/ios/realm.podspec
@@ -9,7 +9,6 @@ realmPackageDir = File.expand_path(__dir__)
 # For example the tests app refers to the realm plugin using this path .../realm-dart/flutter/realm_flutter/tests/ios/.symlinks/plugins/realm/ios
 project_dir = File.expand_path("../../../../", realmPackageDir)
 
-# //TODO read the version from pubspec.yaml
 Pod::Spec.new do |s|
   s.name                      = 'realm'
   s.version                   = '0.3.1+beta'

--- a/flutter/realm_flutter/tests/android/app/build.gradle
+++ b/flutter/realm_flutter/tests/android/app/build.gradle
@@ -42,8 +42,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }

--- a/flutter/realm_flutter/windows/realm_plugin.cpp
+++ b/flutter/realm_flutter/windows/realm_plugin.cpp
@@ -43,7 +43,6 @@ private:
 // static
 void RealmPlugin::RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar)
 {
-    //TODO: these channels seem unneccessary. Remove if not needed
     auto channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(registrar->messenger(), "realm", &flutter::StandardMethodCodec::GetInstance());
 
     auto plugin = std::make_unique<RealmPlugin>();

--- a/generator/lib/src/dart_type_ex.dart
+++ b/generator/lib/src/dart_type_ex.dart
@@ -30,7 +30,7 @@ extension DartTypeEx on DartType {
   bool isExactly<T>() => TypeChecker.fromRuntime(T).isExactlyType(this);
 
   bool get isRealmAny => const TypeChecker.fromRuntime(RealmAny).isAssignableFromType(this);
-  bool get isRealmBacklink => false; // TODO
+  bool get isRealmBacklink => false;
   bool get isRealmCollection => realmCollectionType != RealmCollectionType.none;
   bool get isRealmModel => element != null ? realmModelChecker.annotationsOfExact(element!).isNotEmpty : false;
 

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -48,7 +48,6 @@ extension FieldElementEx on FieldElement {
 
   Expression? get initializerExpression => declarationAstNode.fields.variables.singleWhere((v) => v.name.name == name).initializer;
 
-  // TODO: Why twice?
   FileSpan? typeSpan(SourceFile file) => ExpandedContextSpan(
         ExpandedContextSpan(
           (typeAnnotation ?? initializerExpression)?.span(file) ?? span!,
@@ -204,7 +203,7 @@ extension FieldElementEx on FieldElement {
           final itemType = type.basicType;
           if (itemType.isRealmModel && itemType.isNullable) {
             throw RealmInvalidGenerationSourceError('Nullable realm objects are not allowed in collections',
-                primarySpan: typeSpan(file), // TODO: Restrict span to the parameter type
+                primarySpan: typeSpan(file),
                 primaryLabel: 'which has a nullable realm object element type',
                 element: this,
                 todo: 'Ensure element type is non-nullable');

--- a/lib/src/cli/install/install_command.dart
+++ b/lib/src/cli/install/install_command.dart
@@ -141,8 +141,7 @@ class InstallCommand extends Command<void> {
       }
       await response.pipe(destinationFile.openWrite());
     }
-    //TODO: This does not handle download errors.
-     finally {
+    finally {
       client.close(force: true);
     }
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -104,7 +104,6 @@ abstract class Configuration {
   /// The [RealmSchema] for this [Configuration]
   final RealmSchema schema;
 
-  //TODO: Not supported yet.
   // /// The key used to encrypt the entire [Realm].
   // ///
   // /// A full 64byte (512bit) key for AES-256 encryption.

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -119,7 +119,6 @@ class _RealmCore {
           final schemaProperty = schemaObject.properties[j];
           final propInfo = properties.elementAt(j).ref;
           propInfo.name = schemaProperty.name.toUtf8Ptr(arena);
-          //TODO: assign the correct public name value.
           propInfo.public_name = "".toUtf8Ptr(arena);
           propInfo.link_target = (schemaProperty.linkTarget ?? "").toUtf8Ptr(arena);
           propInfo.link_origin_property_name = "".toUtf8Ptr(arena);
@@ -400,9 +399,8 @@ class _RealmCore {
       config.initialDataCallback!(realm);
       return TRUE;
     } catch (ex) {
-      // TODO: this should propagate the error to Core: https://github.com/realm/realm-core/issues/5366
+      // Propagate the error to Core: https://github.com/realm/realm-core/issues/5366
     }
-
     return FALSE;
   }
 
@@ -1044,7 +1042,6 @@ class _RealmCore {
 
         responseRef.custom_status_code = _CustomErrorCode.noError.code;
       } on SocketException catch (_) {
-        // TODO: A Timeout causes a socket exception, but not all socket exceptions are due to timeouts
         responseRef.custom_status_code = _CustomErrorCode.timeout.code;
       } on HttpException catch (_) {
         responseRef.custom_status_code = _CustomErrorCode.unknownHttp.code;
@@ -1412,7 +1409,6 @@ class _RealmCore {
 
   List<UserIdentity> userGetIdentities(User user) {
     return using((arena) {
-      //TODO: This approach is prone to race conditions. Fix this once Core changes how count is retrieved.
       final idsCount = arena<IntPtr>();
       _realmLib.invokeGetBool(
           () => _realmLib.realm_user_get_all_identities(user.handle._pointer, nullptr, 0, idsCount), "Error while getting user identities count");

--- a/test/test.dart
+++ b/test/test.dart
@@ -271,9 +271,6 @@ Future<void> tryDeleteRealm(String path) async {
       await Future<void>.delayed(duration);
     }
   }
-
-  // TODO: File deletions does not work after tests so don't fail for now
-  // throw Exception('Failed to delete realm at path $path. Did you forget to close it?');
 }
 
 Map<String, String?> parseTestArguments(List<String>? arguments) {


### PR DESCRIPTION
RDART-419 CI run tests on Android Emulator into device farm
RDART-420 Specify your own unique Application ID in the samples and tests build.gradle
RDART-421 Add your own signing config for the release build in the samples and tests build.gradle
RDART-422 IOS realm.podspec - read the version from pubspec.yaml
RDART-423 Backlink support
RDART-424 Remove 'channel' variable if not needed in RealmPlugin::RegisterWithRegistrar (realm_plugin.cpp)
RDART-425 Generator - validate collection - fix exception primarySpan argument
RDART-426 Handle download errors in Install command
RDART-427 Assign the correct public name value while creating schema
RDART-428 Propagate error to Core in initial_data_callback
RDART-429 Define the correct status code on SocketException in _request_callback_async
RDART-430 Fix countIds in userGetIdentities once Core changes how count is retrieved