### PR TITLE
Add Custom JWT Authentication to Credentials

### DIFF
--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -35,6 +35,7 @@ enum AuthProviderType {
   
   /// For authenticating with an email and a password.
   emailPassword,
+  jwt,
 
   _function,
   _userApiKey,
@@ -61,6 +62,12 @@ class Credentials {
   Credentials.emailPassword(String email, String password)
       : _handle = realmCore.createAppCredentialsEmailPassword(email, password),
         provider = AuthProviderType.emailPassword;
+
+  /// Returns a [Credentials] object that can be used to authenticate a user with a custom JWT.
+  /// [Custom-JWT Authentication Docs](https://docs.mongodb.com/realm/authentication/custom-jwt)
+  Credentials.jwt(String token)
+      : _handle = realmCore.createAppCredentialsJwt(token),
+        provider = AuthProviderType.jwt;
 }
 
 /// @nodoc

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -930,6 +930,13 @@ class _RealmCore {
     });
   }
 
+  RealmAppCredentialsHandle createAppCredentialsJwt(String token) {
+    return using((arena) {
+      final tokenPtr = token.toCharPtr(arena);
+      return RealmAppCredentialsHandle._(_realmLib.realm_app_credentials_new_jwt(tokenPtr));
+    });
+  }
+
   RealmHttpTransportHandle _createHttpTransport(HttpClient httpClient) {
     final requestCallback = Pointer.fromFunction<Void Function(Handle, realm_http_request, Pointer<Void>)>(_request_callback);
     final requestCallbackUserdata = _realmLib.realm_dart_userdata_async_new(httpClient, requestCallback.cast(), scheduler.handle._pointer);


### PR DESCRIPTION
Hooked JWT Credentials into realm_bindings.dart in a fashion consistent with JS library. Needed for connecting to Firebase Authentication.