### PR TITLE
Add support for string based/dynamic API on RealmObject

### DIFF
--- a/lib/src/cli/common/archive.dart
+++ b/lib/src/cli/common/archive.dart
@@ -24,7 +24,7 @@ class Archive {
 // Create an archive of files
   Future<void> archive(Directory sourceDir, File outputFile) async {
     if (!await sourceDir.exists()) {
-      throw Exception("Source directory $sourceDir does not exists");
+      throw Exception("Source directory $sourceDir does not exist");
     }
 
     await findEntries(sourceDir).transform(tarWriter).transform(gzip.encoder).pipe(outputFile.openWrite());

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -30,7 +30,7 @@ import 'results.dart';
 /// added to or deleted from the collection or from the Realm.
 ///
 /// {@category Realm}
-abstract class RealmList<T extends Object> with RealmEntity implements List<T>, Finalizable {
+abstract class RealmList<T extends Object?> with RealmEntity implements List<T>, Finalizable {
   late final RealmObjectMetadata? _metadata;
 
   /// Gets a value indicating whether this collection is still valid to use.
@@ -44,7 +44,7 @@ abstract class RealmList<T extends Object> with RealmEntity implements List<T>, 
   factory RealmList(Iterable<T> items) => UnmanagedRealmList(items);
 }
 
-class ManagedRealmList<T extends Object> extends collection.ListBase<T> with RealmEntity implements RealmList<T> {
+class ManagedRealmList<T extends Object?> extends collection.ListBase<T> with RealmEntity implements RealmList<T> {
   final RealmListHandle _handle;
 
   @override
@@ -97,7 +97,7 @@ class ManagedRealmList<T extends Object> extends collection.ListBase<T> with Rea
   bool get isValid => realmCore.listIsValid(this);
 }
 
-class UnmanagedRealmList<T extends Object> extends collection.ListBase<T> with RealmEntity implements RealmList<T> {
+class UnmanagedRealmList<T extends Object?> extends collection.ListBase<T> with RealmEntity implements RealmList<T> {
   final _unmanaged = <T?>[]; // use T? for length=
 
   UnmanagedRealmList([Iterable<T>? items]) {
@@ -156,7 +156,7 @@ extension RealmListOfObject<T extends RealmObject> on RealmList<T> {
 }
 
 /// @nodoc
-extension RealmListInternal<T extends Object> on RealmList<T> {
+extension RealmListInternal<T extends Object?> on RealmList<T> {
   @pragma('vm:never-inline')
   void keepAlive() {
     final self = this;
@@ -170,7 +170,7 @@ extension RealmListInternal<T extends Object> on RealmList<T> {
 
   RealmListHandle get handle => asManaged()._handle;
 
-  static RealmList<T> create<T extends Object>(RealmListHandle handle, Realm realm, RealmObjectMetadata? metadata) => RealmList<T>._(handle, realm, metadata);
+  static RealmList<T> create<T extends Object?>(RealmListHandle handle, Realm realm, RealmObjectMetadata? metadata) => RealmList<T>._(handle, realm, metadata);
 
   static void setValue(RealmListHandle handle, Realm realm, int index, Object? value, {bool update = false}) {
     if (index < 0) {

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -572,7 +572,9 @@ class _RealmCore {
         final property = propertiesPtr.elementAt(i);
         final propertyName = property.ref.name.cast<Utf8>().toRealmDartString()!;
         final objectType = property.ref.link_target.cast<Utf8>().toRealmDartString(treatEmptyAsNull: true);
-        final propertyMeta = RealmPropertyMetadata(property.ref.key, objectType, RealmCollectionType.values.elementAt(property.ref.collection_type));
+        final isNullable = property.ref.flags & realm_property_flags.RLM_PROPERTY_NULLABLE != 0;
+        final propertyMeta = RealmPropertyMetadata(property.ref.key, objectType, RealmPropertyType.values.elementAt(property.ref.type), isNullable,
+            RealmCollectionType.values.elementAt(property.ref.collection_type));
         result[propertyName] = propertyMeta;
       }
       return result;
@@ -2053,7 +2055,7 @@ extension on Pointer<realm_value_t> {
       case realm_value_type.RLM_TYPE_INT:
         return ref.values.integer;
       case realm_value_type.RLM_TYPE_BOOL:
-        return ref.values.boolean != 0;
+        return ref.values.boolean;
       case realm_value_type.RLM_TYPE_STRING:
         return ref.values.string.data.cast<Utf8>().toRealmDartString(length: ref.values.string.size)!;
       case realm_value_type.RLM_TYPE_FLOAT:

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -76,7 +76,7 @@ export "configuration.dart"
 
 export 'credentials.dart' show Credentials, AuthProviderType, EmailPasswordAuthProvider;
 export 'list.dart' show RealmList, RealmListOfObject, RealmListChanges;
-export 'realm_object.dart' show RealmEntity, RealmException, RealmObject, RealmObjectChanges;
+export 'realm_object.dart' show RealmEntity, RealmException, RealmObject, RealmObjectChanges, DynamicRealmObject;
 export 'realm_property.dart';
 export 'results.dart' show RealmResults, RealmResultsChanges;
 export 'subscription.dart' show Subscription, SubscriptionSet, SubscriptionSetState, MutableSubscriptionSet;

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -389,8 +389,8 @@ extension RealmInternal on Realm {
     return RealmObjectInternal.create(type, this, handle, accessor);
   }
 
-  RealmList<T> createList<T extends Object>(RealmListHandle handle, RealmObjectMetadata? metadata) {
-    return RealmListInternal.create(handle, this, metadata);
+  RealmList<T> createList<T extends Object?>(RealmListHandle handle, RealmObjectMetadata? metadata) {
+    return RealmListInternal.create<T>(handle, this, metadata);
   }
 
   List<String> getPropertyNames(Type type, List<int> propertyKeys) {

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -290,9 +290,11 @@ mixin RealmObject on RealmEntity implements Finalizable {
   }
 
   // invocation.memberName in noSuchMethod is a Symbol, which hides its _name field. The idiomatic
-  // way to obtain it is via Mirrors, which is not not available in Flutter. Symbol.toString returns
-  // Symbole("name"), so we use a simple regex to extract the symbol name. This is a bit fragile, but
-  // is the approach used by the Flutter team as well: https://github.com/dart-lang/sdk/issues/28372
+  // way to obtain it is via Mirrors, which is not available in Flutter. Symbol.toString returns
+  // Symbol("name"), so we use a simple regex to extract the symbol name. This is a bit fragile, but
+  // is the approach used by the Flutter team as well: https://github.com/dart-lang/sdk/issues/28372.
+  // If it turns out not to be reliable, we can instead construct symbols from the property names in
+  // the Accessor metadata and compare symbols directly.
   static final RegExp _symbolRegex = RegExp('Symbol\\("(?<symbolName>.*)"\\)');
 
   @override

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -107,7 +107,7 @@ class RealmObjectMetadata {
   RealmObjectMetadata(this.name, this.type, this.primaryKey, this.classKey, this._propertyKeys);
 
   RealmPropertyMetadata operator [](String propertyName) =>
-      _propertyKeys[propertyName] ?? (throw RealmException("Property $propertyName does not exists on class $_realmObjectTypeName"));
+      _propertyKeys[propertyName] ?? (throw RealmException("Property $propertyName does not exist on class $_realmObjectTypeName"));
 
   String? getPropertyName(int propertyKey) {
     for (final entry in _propertyKeys.entries) {

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -18,13 +18,16 @@
 
 import 'dart:async';
 import 'dart:ffi';
+import 'dart:mirrors';
 
 import 'list.dart';
 import 'native/realm_core.dart';
 import 'realm_class.dart';
 
+typedef DartDynamic = dynamic;
+
 abstract class RealmAccessor {
-  Object? get<T extends Object>(RealmObject object, String name);
+  Object? get<T extends Object?>(RealmObject object, String name);
   void set(RealmObject object, String name, Object? value, {bool isDefault = false, bool update = false});
 
   static final Map<Type, Map<String, Object?>> _defaultValues = <Type, Map<String, Object?>>{};
@@ -60,7 +63,7 @@ class RealmValuesAccessor implements RealmAccessor {
   final Map<String, Object?> _values = <String, Object?>{};
 
   @override
-  Object? get<T extends Object>(RealmObject object, String name) {
+  Object? get<T extends Object?>(RealmObject object, String name) {
     if (!_values.containsKey(name)) {
       return RealmAccessor.getDefaultValue(object.runtimeType, name);
     }
@@ -119,8 +122,10 @@ class RealmObjectMetadata {
 class RealmPropertyMetadata {
   final int key;
   final RealmCollectionType collectionType;
+  final RealmPropertyType propertyType;
+  final bool isNullable;
   final String? objectType;
-  const RealmPropertyMetadata(this.key, this.objectType, [this.collectionType = RealmCollectionType.none]);
+  const RealmPropertyMetadata(this.key, this.objectType, this.propertyType, this.isNullable, [this.collectionType = RealmCollectionType.none]);
 }
 
 class RealmCoreAccessor implements RealmAccessor {
@@ -129,12 +134,16 @@ class RealmCoreAccessor implements RealmAccessor {
   RealmCoreAccessor(this.metadata);
 
   @override
-  Object? get<T extends Object>(RealmObject object, String name) {
+  Object? get<T extends Object?>(RealmObject object, String name) {
     try {
       final propertyMeta = metadata[name];
       if (propertyMeta.collectionType == RealmCollectionType.list) {
         final handle = realmCore.getListProperty(object, propertyMeta.key);
         final listMetadata = propertyMeta.objectType == null ? null : object.realm.metadata.getByName(propertyMeta.objectType!);
+        if (listMetadata != null && _isTypeGenericObject<T>()) {
+          return object.realm.createList<RealmObject>(handle, listMetadata);
+        }
+
         return object.realm.createList<T>(handle, listMetadata);
       }
 
@@ -142,6 +151,10 @@ class RealmCoreAccessor implements RealmAccessor {
 
       if (value is RealmObjectHandle) {
         final targetMetadata = propertyMeta.objectType != null ? object.realm.metadata.getByName(propertyMeta.objectType!) : object.realm.metadata.getByType(T);
+        if (_isTypeGenericObject<T>()) {
+          return object.realm.createObject(RealmObject, value, targetMetadata);
+        }
+
         return object.realm.createObject(T, value, targetMetadata);
       }
 
@@ -199,11 +212,12 @@ mixin RealmObject on RealmEntity implements Finalizable {
   RealmObjectHandle? _handle;
   RealmAccessor _accessor = RealmValuesAccessor();
   static final Map<Type, RealmObject Function()> _factories = <Type, RealmObject Function()>{
-    RealmObject: () => DynamicRealmObject._(),
+    RealmObject: () => ConcreteRealmObject._(),
+    _typeOf<RealmObject?>(): () => ConcreteRealmObject._(),
   };
 
   /// @nodoc
-  static Object? get<T extends Object>(RealmObject object, String name) {
+  static Object? get<T extends Object?>(RealmObject object, String name) {
     return object._accessor.get<T>(object, name);
   }
 
@@ -213,7 +227,10 @@ mixin RealmObject on RealmEntity implements Finalizable {
   }
 
   /// @nodoc
-  static void registerFactory<T extends RealmObject>(T Function() factory) => _factories.putIfAbsent(T, () => factory);
+  static void registerFactory<T extends RealmObject>(T Function() factory) {
+    _factories.putIfAbsent(T, () => factory);
+    _factories.putIfAbsent(_typeOf<T?>(), () => factory);
+  }
 
   /// @nodoc
   static T create<T extends RealmObject>() {
@@ -261,6 +278,18 @@ mixin RealmObject on RealmEntity implements Finalizable {
     final controller = RealmObjectNotificationsController<T>(object);
     return controller.createStream();
   }
+
+  @override
+  DartDynamic noSuchMethod(Invocation invocation) {
+    if (invocation.isGetter) {
+      final name = MirrorSystem.getName(invocation.memberName);
+      return get(this, name);
+    }
+
+    return super.noSuchMethod(invocation);
+  }
+
+  late final DynamicRealmObject dynamic = DynamicRealmObject._(this);
 }
 
 /// @nodoc
@@ -379,6 +408,79 @@ class RealmObjectNotificationsController<T extends RealmObject> extends Notifica
 }
 
 /// @nodoc
-class DynamicRealmObject with RealmEntity, RealmObject {
-  DynamicRealmObject._();
+class ConcreteRealmObject with RealmEntity, RealmObject {
+  ConcreteRealmObject._();
+}
+
+Type _typeOf<T>() => T;
+
+bool _isTypeGenericObject<T>() => T == Object || T == _typeOf<Object?>();
+
+class DynamicRealmObject {
+  final RealmObject _obj;
+
+  DynamicRealmObject._(this._obj);
+
+  T get<T extends Object?>(String name) {
+    _validatePropertyType<T>(name, RealmCollectionType.none);
+    return RealmObject.get<T>(_obj, name) as T;
+  }
+
+  List<T> getList<T extends Object?>(String name) {
+    _validatePropertyType<T>(name, RealmCollectionType.list);
+    return RealmObject.get<T>(_obj, name) as List<T>;
+  }
+
+  RealmPropertyMetadata? _validatePropertyType<T extends Object?>(String name, RealmCollectionType expectedCollectionType) {
+    final accessor = _obj.accessor;
+    if (accessor is RealmCoreAccessor) {
+      final prop = accessor.metadata._propertyKeys[name];
+      if (prop == null) {
+        throw RealmException("Property '$name' does not exist on class '${accessor.metadata.name}'");
+      }
+
+      if (prop.collectionType != expectedCollectionType) {
+        throw RealmException(
+            "Property '$name' on class '${accessor.metadata.name}' is '${prop.collectionType}' but the method used to access it expected '$expectedCollectionType'.");
+      }
+
+      // If the user passed in a type argument, we should validate its nullability; if they invoked
+      // the method without a type arg, we don't
+      if (T != _typeOf<Object?>() && prop.isNullable != null is T) {
+        throw RealmException(
+            "Property '$name' on class '${accessor.metadata.name}' is ${prop.isNullable ? 'nullable' : 'required'} but the generic argument passed to get<T> is $T.");
+      }
+
+      final targetType = _getPropertyType<T>();
+      if (targetType != null && targetType != prop.propertyType) {
+        throw RealmException(
+            "Property '$name' on class '${accessor.metadata.name}' is not the correct type. Expected '$targetType', got '${prop.propertyType}'.");
+      }
+
+      return prop;
+    }
+
+    return null;
+  }
+
+  static final _propertyTypeMap = <Type, RealmPropertyType>{
+    int: RealmPropertyType.int,
+    _typeOf<int?>(): RealmPropertyType.int,
+    double: RealmPropertyType.double,
+    _typeOf<double?>(): RealmPropertyType.double,
+    String: RealmPropertyType.string,
+    _typeOf<String?>(): RealmPropertyType.string,
+    bool: RealmPropertyType.bool,
+    _typeOf<bool?>(): RealmPropertyType.bool,
+    DateTime: RealmPropertyType.timestamp,
+    _typeOf<DateTime?>(): RealmPropertyType.timestamp,
+    ObjectId: RealmPropertyType.objectid,
+    _typeOf<ObjectId?>(): RealmPropertyType.objectid,
+    Uuid: RealmPropertyType.uuid,
+    _typeOf<Uuid?>(): RealmPropertyType.uuid,
+    RealmObject: RealmPropertyType.object,
+    _typeOf<RealmObject?>(): RealmPropertyType.object,
+  };
+
+  RealmPropertyType? _getPropertyType<T extends Object?>() => _propertyTypeMap[T];
 }

--- a/test/dynamic_realm_test.dart
+++ b/test/dynamic_realm_test.dart
@@ -69,8 +69,117 @@ Future<void> main([List<String>? args]) async {
     expect(dynamic1, same(dynamic2));
   });
 
+  final date = DateTime.now().toUtc();
+  final objectId = ObjectId();
+  final uuid = Uuid.v4();
+
+  AllTypes _getPopulatedAllTypes() => AllTypes('abc', true, date, -123.456, objectId, uuid, -987,
+      nullableStringProp: 'def',
+      nullableBoolProp: true,
+      nullableDateProp: date,
+      nullableDoubleProp: -123.456,
+      nullableObjectIdProp: objectId,
+      nullableUuidProp: uuid,
+      nullableIntProp: 123);
+
+  AllTypes _getEmptyAllTypes() => AllTypes('', false, DateTime(0).toUtc(), 0, objectId, uuid, 0);
+
+  AllCollections _getPopulatedAllCollections() => AllCollections(
+      strings: ['abc', 'def'],
+      bools: [true, false],
+      dates: [date, DateTime(0).toUtc()],
+      doubles: [-123.456, 555.666],
+      objectIds: [objectId, objectId],
+      uuids: [uuid, uuid],
+      ints: [-987, 123]);
+
+  void _validateDynamic(RealmObject actual, AllTypes expected) {
+    expect(actual.dynamic.get<String>('stringProp'), expected.stringProp);
+    expect(actual.dynamic.get('stringProp'), expected.stringProp);
+    expect(actual.dynamic.get<String?>('nullableStringProp'), expected.nullableStringProp);
+    expect(actual.dynamic.get('nullableStringProp'), expected.nullableStringProp);
+
+    expect(actual.dynamic.get<bool>('boolProp'), expected.boolProp);
+    expect(actual.dynamic.get('boolProp'), expected.boolProp);
+    expect(actual.dynamic.get<bool?>('nullableBoolProp'), expected.nullableBoolProp);
+    expect(actual.dynamic.get('nullableBoolProp'), expected.nullableBoolProp);
+
+    expect(actual.dynamic.get<DateTime>('dateProp'), expected.dateProp);
+    expect(actual.dynamic.get('dateProp'), expected.dateProp);
+    expect(actual.dynamic.get<DateTime?>('nullableDateProp'), expected.nullableDateProp);
+    expect(actual.dynamic.get('nullableDateProp'), expected.nullableDateProp);
+
+    expect(actual.dynamic.get<double>('doubleProp'), expected.doubleProp);
+    expect(actual.dynamic.get('doubleProp'), expected.doubleProp);
+    expect(actual.dynamic.get<double?>('nullableDoubleProp'), expected.nullableDoubleProp);
+    expect(actual.dynamic.get('nullableDoubleProp'), expected.nullableDoubleProp);
+
+    expect(actual.dynamic.get<ObjectId>('objectIdProp'), expected.objectIdProp);
+    expect(actual.dynamic.get('objectIdProp'), expected.objectIdProp);
+    expect(actual.dynamic.get<ObjectId?>('nullableObjectIdProp'), expected.nullableObjectIdProp);
+    expect(actual.dynamic.get('nullableObjectIdProp'), expected.nullableObjectIdProp);
+
+    expect(actual.dynamic.get<Uuid>('uuidProp'), expected.uuidProp);
+    expect(actual.dynamic.get('uuidProp'), expected.uuidProp);
+    expect(actual.dynamic.get<Uuid?>('nullableUuidProp'), expected.nullableUuidProp);
+    expect(actual.dynamic.get('nullableUuidProp'), expected.nullableUuidProp);
+
+    expect(actual.dynamic.get<int>('intProp'), expected.intProp);
+    expect(actual.dynamic.get('intProp'), expected.intProp);
+    expect(actual.dynamic.get<int?>('nullableIntProp'), expected.nullableIntProp);
+    expect(actual.dynamic.get('nullableIntProp'), expected.nullableIntProp);
+
+    dynamic actualDynamic = actual;
+    expect(actualDynamic.stringProp, expected.stringProp);
+    expect(actualDynamic.nullableStringProp, expected.nullableStringProp);
+    expect(actualDynamic.boolProp, expected.boolProp);
+    expect(actualDynamic.nullableBoolProp, expected.nullableBoolProp);
+    expect(actualDynamic.dateProp, expected.dateProp);
+    expect(actualDynamic.nullableDateProp, expected.nullableDateProp);
+    expect(actualDynamic.doubleProp, expected.doubleProp);
+    expect(actualDynamic.nullableDoubleProp, expected.nullableDoubleProp);
+    expect(actualDynamic.objectIdProp, expected.objectIdProp);
+    expect(actualDynamic.nullableObjectIdProp, expected.nullableObjectIdProp);
+    expect(actualDynamic.uuidProp, expected.uuidProp);
+    expect(actualDynamic.nullableUuidProp, expected.nullableUuidProp);
+    expect(actualDynamic.intProp, expected.intProp);
+    expect(actualDynamic.nullableIntProp, expected.nullableIntProp);
+  }
+
+  void _validateDynamicLists(RealmObject actual, AllCollections expected) {
+    expect(actual.dynamic.getList<String>('strings'), expected.strings);
+    expect(actual.dynamic.getList('strings'), expected.strings);
+
+    expect(actual.dynamic.getList<bool>('bools'), expected.bools);
+    expect(actual.dynamic.getList('bools'), expected.bools);
+
+    expect(actual.dynamic.getList<DateTime>('dates'), expected.dates);
+    expect(actual.dynamic.getList('dates'), expected.dates);
+
+    expect(actual.dynamic.getList<double>('doubles'), expected.doubles);
+    expect(actual.dynamic.getList('doubles'), expected.doubles);
+
+    expect(actual.dynamic.getList<ObjectId>('objectIds'), expected.objectIds);
+    expect(actual.dynamic.getList('objectIds'), expected.objectIds);
+
+    expect(actual.dynamic.getList<Uuid>('uuids'), expected.uuids);
+    expect(actual.dynamic.getList('uuids'), expected.uuids);
+
+    expect(actual.dynamic.getList<int>('ints'), expected.ints);
+    expect(actual.dynamic.getList('ints'), expected.ints);
+
+    dynamic actualDynamic = actual;
+    expect(actualDynamic.strings, expected.strings);
+    expect(actualDynamic.bools, expected.bools);
+    expect(actualDynamic.dates, expected.dates);
+    expect(actualDynamic.doubles, expected.doubles);
+    expect(actualDynamic.objectIds, expected.objectIds);
+    expect(actualDynamic.uuids, expected.uuids);
+    expect(actualDynamic.ints, expected.ints);
+  }
+
   for (var isDynamic in [true, false]) {
-    Realm getDynamicRealm(Realm original) {
+    Realm _getDynamicRealm(Realm original) {
       if (isDynamic) {
         original.close();
         return getRealm(Configuration.local([]));
@@ -79,119 +188,400 @@ Future<void> main([List<String>? args]) async {
       return original;
     }
 
-    test('dynamic.all (dynamic=$isDynamic) returns empty collection', () {
-      final config = Configuration.local([Car.schema]);
-      final staticRealm = getRealm(config);
+    group('Realm.dynamic when isDynamic=$isDynamic', () {
+      test('all returns empty collection', () {
+        final config = Configuration.local([Car.schema]);
+        final staticRealm = getRealm(config);
 
-      final realm = getDynamicRealm(staticRealm);
-      final allCars = realm.dynamic.all(Car.schema.name);
-      expect(allCars.length, 0);
-    });
-
-    test('dynamic.all (dynamic=$isDynamic) returns non-empty collection', () {
-      final config = Configuration.local([Car.schema]);
-      final staticRealm = getRealm(config);
-      staticRealm.write(() {
-        staticRealm.add(Car('Honda'));
+        final realm = _getDynamicRealm(staticRealm);
+        final allCars = realm.dynamic.all(Car.schema.name);
+        expect(allCars.length, 0);
       });
 
-      final realm = getDynamicRealm(staticRealm);
-      final allCars = realm.dynamic.all(Car.schema.name);
-      expect(allCars.length, 1);
+      test('all returns non-empty collection', () {
+        final config = Configuration.local([Car.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(Car('Honda'));
+        });
 
-      final car = allCars[0];
-      expect(RealmObject.get<String>(car, 'make'), 'Honda');
-    });
+        final realm = _getDynamicRealm(staticRealm);
+        final allCars = realm.dynamic.all(Car.schema.name);
+        expect(allCars.length, 1);
 
-    test('dynamic.all (dynamic=$isDynamic) throws for non-existent type', () {
-      final config = Configuration.local([Car.schema]);
-      final staticRealm = getRealm(config);
-
-      final dynamicRealm = getDynamicRealm(staticRealm);
-
-      expect(() => dynamicRealm.dynamic.all('i-dont-exist'), throws<RealmError>("Object type i-dont-exist not configured in the current Realm's schema"));
-    });
-
-    test('dynamic.all (dynamic=$isDynamic) can follow links', () {
-      final config = Configuration.local([LinksClass.schema]);
-      final staticRealm = getRealm(config);
-
-      final id1 = Uuid.v4();
-      final id2 = Uuid.v4();
-      final id3 = Uuid.v4();
-
-      staticRealm.write(() {
-        final obj1 = staticRealm.add(LinksClass(id1));
-        final obj2 = staticRealm.add(LinksClass(id2));
-        final obj3 = staticRealm.add(LinksClass(id3));
-
-        obj1.link = obj2;
-        obj2.link = obj3;
-
-        obj1.list.addAll([obj1, obj2, obj3]);
+        final car = allCars[0];
+        expect(car.dynamic.get<String>('make'), 'Honda');
       });
 
-      final dynamicRealm = getDynamicRealm(staticRealm);
+      test('all throws for non-existent type', () {
+        final config = Configuration.local([Car.schema]);
+        final staticRealm = getRealm(config);
 
-      final objects = dynamicRealm.dynamic.all(LinksClass.schema.name);
-      final obj1 = objects.singleWhere((o) => RealmObject.get<Uuid>(o, 'id') as Uuid == id1);
-      final obj2 = objects.singleWhere((o) => RealmObject.get<Uuid>(o, 'id') as Uuid == id2);
-      final obj3 = objects.singleWhere((o) => RealmObject.get<Uuid>(o, 'id') as Uuid == id3);
+        final dynamicRealm = _getDynamicRealm(staticRealm);
 
-      expect(RealmObject.get<RealmObject>(obj1, 'link'), obj2);
-      expect(RealmObject.get<RealmObject>(obj2, 'link'), obj3);
-
-      final list = RealmObject.get<RealmObject>(obj1, 'list') as List<RealmObject>;
-
-      expect(list[0], obj1);
-      expect(list[1], obj2);
-      expect(list[2], obj3);
-    });
-
-    test('dynamic.all (dynamic=$isDynamic) can be filtered', () {
-      final config = Configuration.local([Car.schema]);
-      final staticRealm = getRealm(config);
-
-      staticRealm.write(() {
-        staticRealm.add(Car('Honda'));
-        staticRealm.add(Car('Hyundai'));
-        staticRealm.add(Car('Suzuki'));
-        staticRealm.add(Car('Toyota'));
+        expect(() => dynamicRealm.dynamic.all('i-dont-exist'), throws<RealmError>("Object type i-dont-exist not configured in the current Realm's schema"));
       });
 
-      final dynamicRealm = getDynamicRealm(staticRealm);
+      test('all can follow links', () {
+        final config = Configuration.local([LinksClass.schema]);
+        final staticRealm = getRealm(config);
 
-      final carsWithH = dynamicRealm.dynamic.all(Car.schema.name).query('make BEGINSWITH "H"');
-      expect(carsWithH.length, 2);
-    });
+        final id1 = Uuid.v4();
+        final id2 = Uuid.v4();
+        final id3 = Uuid.v4();
 
-    test('dynamic.find (dynamic=$isDynamic) can find by primary key', () {
-      final config = Configuration.local([Car.schema]);
-      final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          final obj1 = staticRealm.add(LinksClass(id1));
+          final obj2 = staticRealm.add(LinksClass(id2));
+          final obj3 = staticRealm.add(LinksClass(id3));
 
-      staticRealm.write(() {
-        staticRealm.add(Car('Honda'));
-        staticRealm.add(Car('Hyundai'));
+          obj1.link = obj2;
+          obj2.link = obj3;
+
+          obj1.list.addAll([obj1, obj2, obj3]);
+        });
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final objects = dynamicRealm.dynamic.all(LinksClass.schema.name);
+        final obj1 = objects.singleWhere((o) => o.dynamic.get<Uuid>('id') == id1);
+        final obj2 = objects.singleWhere((o) => o.dynamic.get<Uuid>('id') == id2);
+        final obj3 = objects.singleWhere((o) => o.dynamic.get<Uuid>('id') == id3);
+
+        expect(obj1.dynamic.get<RealmObject?>('link'), obj2);
+        expect(obj2.dynamic.get<RealmObject?>('link'), obj3);
+
+        final list = obj1.dynamic.getList<RealmObject>('list');
+
+        expect(list[0], obj1);
+        expect(list[1], obj2);
+        expect(list[2], obj3);
       });
 
-      final dynamicRealm = getDynamicRealm(staticRealm);
+      test('all can be filtered', () {
+        final config = Configuration.local([Car.schema]);
+        final staticRealm = getRealm(config);
 
-      final car = dynamicRealm.dynamic.find(Car.schema.name, 'Honda');
-      expect(car, isNotNull);
-      expect(RealmObject.get<String>(car!, 'make'), 'Honda');
+        staticRealm.write(() {
+          staticRealm.add(Car('Honda'));
+          staticRealm.add(Car('Hyundai'));
+          staticRealm.add(Car('Suzuki'));
+          staticRealm.add(Car('Toyota'));
+        });
 
-      final nonExistent = dynamicRealm.dynamic.find(Car.schema.name, 'i-dont-exist');
-      expect(nonExistent, isNull);
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final carsWithH = dynamicRealm.dynamic.all(Car.schema.name).query('make BEGINSWITH "H"');
+        expect(carsWithH.length, 2);
+      });
+
+      test('find can find by primary key', () {
+        final config = Configuration.local([Car.schema]);
+        final staticRealm = getRealm(config);
+
+        staticRealm.write(() {
+          staticRealm.add(Car('Honda'));
+          staticRealm.add(Car('Hyundai'));
+        });
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final car = dynamicRealm.dynamic.find(Car.schema.name, 'Honda');
+        expect(car, isNotNull);
+        expect(car!.dynamic.get<String>('make'), 'Honda');
+
+        final nonExistent = dynamicRealm.dynamic.find(Car.schema.name, 'i-dont-exist');
+        expect(nonExistent, isNull);
+      });
+
+      test('find fails to find non-existent type', () {
+        final config = Configuration.local([Car.schema]);
+        final staticRealm = getRealm(config);
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        expect(() => dynamicRealm.dynamic.find('i-dont-exist', 'i-dont-exist'),
+            throws<RealmError>("Object type i-dont-exist not configured in the current Realm's schema"));
+      });
     });
 
-    test('dynamic.find (dynamic=$isDynamic) fails to find non-existent type', () {
-      final config = Configuration.local([Car.schema]);
-      final staticRealm = getRealm(config);
+    group('RealmObject.dynamic.get when isDynamic=$isDynamic', () {
+      test('gets all property types', () {
+        final config = Configuration.local([AllTypes.schema]);
+        final staticRealm = getRealm(config);
 
-      final dynamicRealm = getDynamicRealm(staticRealm);
+        final nonEmpty = _getPopulatedAllTypes();
+        final empty = _getEmptyAllTypes();
 
-      expect(() => dynamicRealm.dynamic.find('i-dont-exist', 'i-dont-exist'),
-          throws<RealmError>("Object type i-dont-exist not configured in the current Realm's schema"));
+        staticRealm.write(() {
+          staticRealm.add(_getPopulatedAllTypes());
+          staticRealm.add(_getEmptyAllTypes());
+        });
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+        final objects = dynamicRealm.dynamic.all(AllTypes.schema.name);
+
+        final obj1 = objects.singleWhere((o) => o.dynamic.get<String>('stringProp') == nonEmpty.stringProp);
+        final obj2 = objects.singleWhere((o) => o.dynamic.get<String>('stringProp') == empty.stringProp);
+
+        _validateDynamic(obj1, _getPopulatedAllTypes());
+        _validateDynamic(obj2, _getEmptyAllTypes());
+      });
+
+      test('gets normal links', () {
+        final config = Configuration.local([LinksClass.schema]);
+        final staticRealm = getRealm(config);
+
+        final uuid1 = Uuid.v4();
+        final uuid2 = Uuid.v4();
+
+        staticRealm.write(() {
+          final obj1 = staticRealm.add(LinksClass(uuid1));
+          staticRealm.add(LinksClass(uuid2, link: obj1));
+        });
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj1 = dynamicRealm.dynamic.find(LinksClass.schema.name, uuid1)!;
+        final obj2 = dynamicRealm.dynamic.find(LinksClass.schema.name, uuid2)!;
+
+        expect(obj1.dynamic.get<RealmObject?>('link'), isNull);
+        expect(obj1.dynamic.get('link'), isNull);
+
+        expect(obj2.dynamic.get<RealmObject?>('link'), obj1);
+        expect(obj2.dynamic.get('link'), obj1);
+        expect(obj2.dynamic.get<RealmObject?>('link')?.dynamic.get<Uuid>('id'), uuid1);
+      });
+
+      test('fails with non-existent property', () {
+        final config = Configuration.local([AllTypes.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(_getEmptyAllTypes());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllTypes.schema.name).single;
+        expect(() => obj.dynamic.get('i-dont-exist'), throws<RealmException>("Property 'i-dont-exist' does not exist on class 'AllTypes'"));
+      });
+
+      test('fails with wrong type', () {
+        final config = Configuration.local([AllTypes.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(_getEmptyAllTypes());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllTypes.schema.name).single;
+
+        expect(
+            () => obj.dynamic.get<int>('stringProp'),
+            throws<RealmException>(
+                "Property 'stringProp' on class 'AllTypes' is not the correct type. Expected 'RealmPropertyType.int', got 'RealmPropertyType.string'."));
+
+        expect(
+            () => obj.dynamic.get<int?>('nullableStringProp'),
+            throws<RealmException>(
+                "Property 'nullableStringProp' on class 'AllTypes' is not the correct type. Expected 'RealmPropertyType.int', got 'RealmPropertyType.string'."));
+
+        expect(() => obj.dynamic.get<int>('nullableIntProp'),
+            throws<RealmException>("Property 'nullableIntProp' on class 'AllTypes' is nullable but the generic argument passed to get<T> is int."));
+
+        expect(() => obj.dynamic.get<int?>('intProp'),
+            throws<RealmException>("Property 'intProp' on class 'AllTypes' is required but the generic argument passed to get<T> is int?."));
+      });
+
+      test('fails on collection properties', () {
+        final config = Configuration.local([AllCollections.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(AllCollections());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllCollections.schema.name).single;
+        expect(
+            () => obj.dynamic.get<String>('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
+
+        expect(
+            () => obj.dynamic.get('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
+
+        expect(
+            () => obj.dynamic.get<String?>('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is 'RealmCollectionType.list' but the method used to access it expected 'RealmCollectionType.none'."));
+      });
+    });
+
+    group('RealmObject.dynamic.getList', () {
+      test('gets all list types', () {
+        final config = Configuration.local([AllCollections.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(_getPopulatedAllCollections());
+          staticRealm.add(AllCollections());
+        });
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+        final objects = dynamicRealm.dynamic.all(AllCollections.schema.name);
+        final obj1 = objects.singleWhere((element) => element.dynamic.getList('strings').isNotEmpty);
+        final obj2 = objects.singleWhere((element) => element.dynamic.getList('strings').isEmpty);
+
+        _validateDynamicLists(obj1, _getPopulatedAllCollections());
+        _validateDynamicLists(obj2, AllCollections());
+      });
+
+      test('gets collections of objects', () {
+        final config = Configuration.local([LinksClass.schema]);
+        final staticRealm = getRealm(config);
+
+        final uuid1 = Uuid.v4();
+        final uuid2 = Uuid.v4();
+
+        staticRealm.write(() {
+          final obj1 = staticRealm.add(LinksClass(uuid1));
+          staticRealm.add(LinksClass(uuid2, list: [obj1, obj1]));
+        });
+
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj1 = dynamicRealm.dynamic.find(LinksClass.schema.name, uuid1)!;
+        final obj2 = dynamicRealm.dynamic.find(LinksClass.schema.name, uuid2)!;
+
+        expect(obj1.dynamic.getList<RealmObject>('list'), isEmpty);
+        expect(obj1.dynamic.getList('list'), isEmpty);
+
+        expect(obj2.dynamic.getList<RealmObject>('list'), [obj1, obj1]);
+        expect(obj2.dynamic.getList('list'), [obj1, obj1]);
+        expect(obj2.dynamic.getList<RealmObject>('list')[0].dynamic.get<Uuid>('id'), uuid1);
+      });
+
+      test('fails with non-existent property', () {
+        final config = Configuration.local([AllCollections.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(AllCollections());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllCollections.schema.name).single;
+        expect(() => obj.dynamic.getList('i-dont-exist'), throws<RealmException>("Property 'i-dont-exist' does not exist on class 'AllCollections'"));
+      });
+
+      test('fails with wrong type', () {
+        final config = Configuration.local([AllCollections.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(AllCollections());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllCollections.schema.name).single;
+
+        expect(
+            () => obj.dynamic.getList<int>('strings'),
+            throws<RealmException>(
+                "Property 'strings' on class 'AllCollections' is not the correct type. Expected 'RealmPropertyType.int', got 'RealmPropertyType.string'"));
+      });
+
+      test('fails on non-collection properties', () {
+        final config = Configuration.local([AllTypes.schema]);
+        final staticRealm = getRealm(config);
+        staticRealm.write(() {
+          staticRealm.add(_getEmptyAllTypes());
+        });
+        final dynamicRealm = _getDynamicRealm(staticRealm);
+
+        final obj = dynamicRealm.dynamic.all(AllTypes.schema.name).single;
+        expect(
+            () => obj.dynamic.getList('intProp'),
+            throws<RealmException>(
+                "Property 'intProp' on class 'AllTypes' is 'RealmCollectionType.none' but the method used to access it expected 'RealmCollectionType.list'."));
+      });
     });
   }
+
+  test('RealmObject.dynamic.get when static can get all property types', () {
+    final config = Configuration.local([AllTypes.schema]);
+    final staticRealm = getRealm(config);
+
+    final objectId = ObjectId();
+    final uuid = Uuid.v4();
+    final date = DateTime.now();
+
+    staticRealm.write(() {
+      staticRealm.add(_getPopulatedAllTypes());
+      staticRealm.add(_getEmptyAllTypes());
+    });
+
+    for (var obj in staticRealm.all<AllTypes>()) {
+      _validateDynamic(obj, obj);
+    }
+  });
+
+  test('RealmObject.dynamic.getList when static can get all list types', () {
+    final config = Configuration.local([AllCollections.schema]);
+    final realm = getRealm(config);
+
+    realm.write(() {
+      realm.add(_getPopulatedAllCollections());
+
+      realm.add(AllCollections());
+    });
+
+    for (final obj in realm.all<AllCollections>()) {
+      _validateDynamicLists(obj, obj);
+    }
+  });
+
+  test('RealmObject.dynamic.get when static can get links', () {
+    final config = Configuration.local([LinksClass.schema]);
+    final realm = getRealm(config);
+
+    final uuid1 = Uuid.v4();
+    final uuid2 = Uuid.v4();
+
+    realm.write(() {
+      final obj1 = realm.add(LinksClass(uuid1));
+      realm.add(LinksClass(uuid2, link: obj1));
+    });
+
+    final obj1 = realm.find<LinksClass>(uuid1)!;
+    final obj2 = realm.find<LinksClass>(uuid2)!;
+
+    expect(obj1.dynamic.get<RealmObject?>('link'), isNull);
+    expect(obj1.dynamic.get('link'), isNull);
+
+    expect(obj2.dynamic.get<RealmObject?>('link'), obj1);
+    expect(obj2.dynamic.get('link'), obj1);
+    expect(obj2.dynamic.get<RealmObject?>('link')?.dynamic.get<Uuid>('id'), uuid1);
+  });
+
+  test('RealmObject.dynamic.getList when static can get links', () {
+    final config = Configuration.local([LinksClass.schema]);
+    final realm = getRealm(config);
+
+    final uuid1 = Uuid.v4();
+    final uuid2 = Uuid.v4();
+
+    realm.write(() {
+      final obj1 = realm.add(LinksClass(uuid1));
+      realm.add(LinksClass(uuid2, list: [obj1, obj1]));
+    });
+
+    final obj1 = realm.find<LinksClass>(uuid1)!;
+    final obj2 = realm.find<LinksClass>(uuid2)!;
+
+    expect(obj1.dynamic.getList<RealmObject>('list'), isEmpty);
+    expect(obj1.dynamic.getList('list'), isEmpty);
+
+    expect(obj2.dynamic.getList<RealmObject>('list'), [obj1, obj1]);
+    expect(obj2.dynamic.getList('list'), [obj1, obj1]);
+    expect(obj2.dynamic.getList<RealmObject>('list')[0].dynamic.get<Uuid>('id'), uuid1);
+  });
 }

--- a/test/dynamic_realm_test.dart
+++ b/test/dynamic_realm_test.dart
@@ -351,6 +351,14 @@ Future<void> main([List<String>? args]) async {
         expect(obj2.dynamic.get<RealmObject?>('link'), obj1);
         expect(obj2.dynamic.get('link'), obj1);
         expect(obj2.dynamic.get<RealmObject?>('link')?.dynamic.get<Uuid>('id'), uuid1);
+
+        dynamic dynamicObj1 = obj1;
+        dynamic dynamicObj2 = obj2;
+
+        expect(dynamicObj1.link, isNull);
+
+        expect(dynamicObj2.link, obj1);
+        expect(dynamicObj2.link.id, uuid1);
       });
 
       test('fails with non-existent property', () {
@@ -362,7 +370,9 @@ Future<void> main([List<String>? args]) async {
         final dynamicRealm = _getDynamicRealm(staticRealm);
 
         final obj = dynamicRealm.dynamic.all(AllTypes.schema.name).single;
+        dynamic dynamicObj = obj;
         expect(() => obj.dynamic.get('i-dont-exist'), throws<RealmException>("Property 'i-dont-exist' does not exist on class 'AllTypes'"));
+        expect(() => dynamicObj.idontexist, throws<RealmException>("Property idontexist does not exist on class AllTypes"));
       });
 
       test('fails with wrong type', () {
@@ -459,6 +469,14 @@ Future<void> main([List<String>? args]) async {
         expect(obj2.dynamic.getList<RealmObject>('list'), [obj1, obj1]);
         expect(obj2.dynamic.getList('list'), [obj1, obj1]);
         expect(obj2.dynamic.getList<RealmObject>('list')[0].dynamic.get<Uuid>('id'), uuid1);
+
+        dynamic dynamicObj1 = obj1;
+        dynamic dynamicObj2 = obj2;
+
+        expect(dynamicObj1.list, isEmpty);
+
+        expect(dynamicObj2.list, [obj1, obj1]);
+        expect(dynamicObj2.list[0].id, uuid1);
       });
 
       test('fails with non-existent property', () {
@@ -510,10 +528,6 @@ Future<void> main([List<String>? args]) async {
     final config = Configuration.local([AllTypes.schema]);
     final staticRealm = getRealm(config);
 
-    final objectId = ObjectId();
-    final uuid = Uuid.v4();
-    final date = DateTime.now();
-
     staticRealm.write(() {
       staticRealm.add(_getPopulatedAllTypes());
       staticRealm.add(_getEmptyAllTypes());
@@ -560,6 +574,14 @@ Future<void> main([List<String>? args]) async {
     expect(obj2.dynamic.get<RealmObject?>('link'), obj1);
     expect(obj2.dynamic.get('link'), obj1);
     expect(obj2.dynamic.get<RealmObject?>('link')?.dynamic.get<Uuid>('id'), uuid1);
+
+    dynamic dynamicObj1 = obj1;
+    dynamic dynamicObj2 = obj2;
+
+    expect(dynamicObj1.link, isNull);
+
+    expect(dynamicObj2.link, obj1);
+    expect(dynamicObj2.link.id, uuid1);
   });
 
   test('RealmObject.dynamic.getList when static can get links', () {
@@ -583,5 +605,13 @@ Future<void> main([List<String>? args]) async {
     expect(obj2.dynamic.getList<RealmObject>('list'), [obj1, obj1]);
     expect(obj2.dynamic.getList('list'), [obj1, obj1]);
     expect(obj2.dynamic.getList<RealmObject>('list')[0].dynamic.get<Uuid>('id'), uuid1);
+
+    dynamic dynamicObj1 = obj1;
+    dynamic dynamicObj2 = obj2;
+
+    expect(dynamicObj1.list, isEmpty);
+
+    expect(dynamicObj2.list, [obj1, obj1]);
+    expect(dynamicObj2.list[0].id, uuid1);
   });
 }


### PR DESCRIPTION
Adds a string-based API to read properties of a RealmObject. Right now we only support reading as that's required to get migrations working, but it can be extended in the future to also support setting.

```dart
final obj = realm.dynamic.find("Foo", 123);

// Get simple primitive
final str = obj.dynamic.get<String>("stringProp");

// Get another object
final bar = obj.dynamic.get<RealmObject>("bar");
final barString = bar.dynamic.get<String>("stringProp");

// Get a list of objects
final bars = obj.dynamic.getList<RealmObject>("bars");

// Iterate the list as normal
for (final bar in bars) {
  print(bar.dynamic.get<DateTime>("dateProp");
}
```

Additionally, implements `noSuchMethod` on `RealmObject` in order to support dynamic invocation:

```dart
dynamic obj = realm.dynamic.find("Foo", 123);

// Get simple primitive
String str = obj.stringProp;

// Get another object
dynamic bar = obj.bar;
String barString = bar.stringProp;

// Get a list of objects
final bars = obj.bars;

// Iterate the list as normal
for (final bar in bars) {
  print(bar.dateProp);
}
```

Part of #70.

**Note**: This only adds support for reading properties, but not for setting them. It won't be difficult to extend the API and support setting of properties, but is out of scope for this PR.