### PR TITLE
Add support for migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
           model: 'iPhone 8'
           os: 'iOS'
           os_version: '>= 14.0'
-      
+
       # This will be a no-op under normal circumstances since the cluster would have been deployed
       # in deploy-cluster. It is needed in case we want to re-run the job after the cluster has been reaped.
       - name: Create cluster
@@ -430,6 +430,12 @@ jobs:
         run: |
           dart pub get
           dart run build_runner build --delete-conflicting-outputs
+
+      - name: Run generator in realm-dart/example
+        run: |
+          dart pub get
+          dart run build_runner build --delete-conflicting-outputs
+        working-directory: ./example/
 
       - name: Run generator in realm_flutter/example
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
     }
 
     if (oldSchemaVersion == 2) {
-      // Between v2 and v3 we fixed a typo where someone had mispelled the 'Foo.name' property.
+      // Between v2 and v3 we fixed a typo where someone had mispelled the 'Person.name' property.
       migration.renameProperty('Person', 'nmae', 'name');
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
   final config = Configuration.local([Person.schema], schemaVersion: 4, migrationCallback: (migration, oldSchemaVersion) {
     if (oldSchemaVersion == 1) {
       // Between v1 and v2 we removed the Bar type
-      migration.removeType('Bar');
+      migration.deleteType('Bar');
     }
 
     if (oldSchemaVersion == 2) {
-      // Between v2 and v3 we fixed a typo where someone had mispelled the 'Person.name' property.
+      // Between v2 and v3 we fixed a typo in the 'Person.name' property.
       migration.renameProperty('Person', 'nmae', 'name');
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Enhancements
 * Added support for "frozen objects" - these are objects, queries, lists, or Realms that have been "frozen" at a specific version. All frozen objects can be accessed and queried as normal, but attempting to mutate them or add change listeners will throw an exception. `Realm`, `RealmObject`, `RealmList`, and `RealmResults` now have a method `freeze()` which returns an immutable version of the object, as well as an `isFrozen` property which can be used to check whether an object is frozen. (Issue [#56](https://github.com/realm/realm-dart/issues/56))
-* Added support for migrations for local Realms. You can now construct a configuration with a migration callback that will be invoked if the schema version of the file on disk is lower than the schema version supplied by the callback. A minimal example looks like this:
+* Added support for migrations for local Realms. You can now construct a configuration with a migration callback that will be invoked if the schema version of the file on disk is lower than the schema version supplied by the callback. (Issue [#70](https://github.com/realm/realm-dart/issues/70))
+
+  A minimal example looks like this:
   ```dart
   final config = Configuration.local([Person.schema], schemaVersion: 4, migrationCallback: (migration, oldSchemaVersion) {
     if (oldSchemaVersion == 1) {

--- a/flutter/realm_flutter/tests/test_driver/realm_test.dart
+++ b/flutter/realm_flutter/tests/test_driver/realm_test.dart
@@ -16,6 +16,7 @@ import '../test/app_test.dart' as app_tests;
 import '../test/user_test.dart' as user_tests;
 import '../test/subscription_test.dart' as subscription_test;
 import '../test/session_test.dart' as session_test;
+import '../test/migration_test.dart' as migration_test;
 
 Future<String> main(List<String> args) async {
   final Completer<String> completer = Completer<String>();
@@ -33,6 +34,7 @@ Future<String> main(List<String> args) async {
     await user_tests.main(args);
     await subscription_test.main(args);
     await session_test.main(args);
+    await migration_test.main(args);
 
     tearDown(() {
       if (Invoker.current?.liveTest.state.result == test_api.Result.error || Invoker.current?.liveTest.state.result == test_api.Result.failure) {

--- a/generator/lib/src/class_element_ex.dart
+++ b/generator/lib/src/class_element_ex.dart
@@ -15,9 +15,9 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:realm_generator/src/expanded_context_span.dart';
 import 'package:source_gen/source_gen.dart';
 import 'annotation_value.dart';
 import 'error.dart';
@@ -29,15 +29,13 @@ import 'realm_model_info.dart';
 import 'type_checkers.dart';
 import 'session.dart';
 
-final _validIdentifier = RegExp(r'^[a-zA-Z]\w*$');
-
 extension on Iterable<FieldElement> {
   Iterable<RealmFieldInfo> get realmInfo sync* {
     final primaryKeys = <RealmFieldInfo>[];
     for (final f in this) {
       final info = f.realmInfo;
       if (info == null) continue;
-      if (info.primaryKey) {
+      if (info.isPrimaryKey) {
         primaryKeys.add(info);
       }
       yield info;

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -214,7 +214,7 @@ extension FieldElementEx on FieldElement {
       return RealmFieldInfo(
         fieldElement: this,
         indexed: indexed != null,
-        primaryKey: primaryKey != null,
+        isPrimaryKey: primaryKey != null,
         mapTo: remappedRealmName,
         realmType: realmType,
       );

--- a/generator/lib/src/realm_field_info.dart
+++ b/generator/lib/src/realm_field_info.dart
@@ -26,14 +26,14 @@ import 'element.dart';
 class RealmFieldInfo {
   final FieldElement fieldElement;
   final String? mapTo;
-  final bool primaryKey;
+  final bool isPrimaryKey;
   final bool indexed;
   final RealmPropertyType realmType;
 
   RealmFieldInfo({
     required this.fieldElement,
     required this.mapTo,
-    required this.primaryKey,
+    required this.isPrimaryKey,
     required this.indexed,
     required this.realmType,
   });
@@ -63,12 +63,12 @@ class RealmFieldInfo {
   Iterable<String> toCode() sync* {
     yield '@override';
     yield "$mappedTypeName get $name => RealmObject.get<$basicMappedTypeName>(this, '$realmName') as $mappedTypeName;";
-    bool generateSetter = !isFinal && !primaryKey && !isRealmCollection;
+    bool generateSetter = !isFinal && !isRealmCollection;
     if (generateSetter) {
       yield '@override';
       yield "set $name(${mappedTypeName != modelTypeName ? 'covariant ' : ''}$mappedTypeName value) => RealmObject.set(this, '$realmName', value);";
     } else {
-      bool generateThrowError = isLate || primaryKey || isRealmCollection;
+      bool generateThrowError = isLate || isRealmCollection;
       if (generateThrowError) {
         yield '@override';
         yield "set $name(${mappedTypeName != modelTypeName ? 'covariant ' : ''}$mappedTypeName value) => throw RealmUnsupportedSetError();";

--- a/generator/lib/src/realm_model_info.dart
+++ b/generator/lib/src/realm_model_info.dart
@@ -43,10 +43,10 @@ class RealmModelInfo {
 
       yield '$name(';
       {
-        final required = allExceptCollections.where((f) => f.isRequired || f.primaryKey);
+        final required = allExceptCollections.where((f) => f.isRequired || f.isPrimaryKey);
         yield* required.map((f) => '${f.mappedTypeName} ${f.name},');
 
-        final notRequired = allExceptCollections.where((f) => !f.isRequired && !f.primaryKey);
+        final notRequired = allExceptCollections.where((f) => !f.isRequired && !f.isPrimaryKey);
         final collections = fields.where((f) => f.type.isRealmCollection).toList();
         if (notRequired.isNotEmpty || collections.isNotEmpty) {
           yield '{';
@@ -98,11 +98,11 @@ class RealmModelInfo {
             final namedArgs = {
               if (f.name != f.realmName) 'mapTo': f.realmName,
               if (f.optional) 'optional': f.optional,
-              if (f.primaryKey) 'primaryKey': f.primaryKey,
+              if (f.isPrimaryKey) 'primaryKey': f.isPrimaryKey,
               if (f.realmType == RealmPropertyType.object) 'linkTarget': f.basicRealmTypeName,
               if (f.realmCollectionType != RealmCollectionType.none) 'collectionType': f.realmCollectionType,
             };
-            return "SchemaProperty('${f.realmName}', ${f.realmType}${namedArgs.isNotEmpty ? ', ' + namedArgs.toArgsString() : ''}),";
+            return "SchemaProperty('${f.realmName}', ${f.realmType}${namedArgs.isNotEmpty ? ', ${namedArgs.toArgsString()}' : ''}),";
           });
         }
         yield ']);';

--- a/generator/test/good_test_data/all_types.expected
+++ b/generator/test/good_test_data/all_types.expected
@@ -76,7 +76,7 @@ class Bar extends _Bar with RealmEntity, RealmObject {
   @override
   String get id => RealmObject.get<String>(this, 'id') as String;
   @override
-  set id(String value) => throw RealmUnsupportedSetError();
+  set id(String value) => RealmObject.set(this, 'id', value);
 
   @override
   bool get aBool => RealmObject.get<bool>(this, 'aBool') as bool;

--- a/generator/test/good_test_data/primary_key.expected
+++ b/generator/test/good_test_data/primary_key.expected
@@ -14,7 +14,7 @@ class IntPK extends _IntPK with RealmEntity, RealmObject {
   @override
   int get id => RealmObject.get<int>(this, 'id') as int;
   @override
-  set id(int value) => throw RealmUnsupportedSetError();
+  set id(int value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<IntPK>> get changes =>
@@ -42,7 +42,7 @@ class NullableIntPK extends _NullableIntPK with RealmEntity, RealmObject {
   @override
   int? get id => RealmObject.get<int>(this, 'id') as int?;
   @override
-  set id(int? value) => throw RealmUnsupportedSetError();
+  set id(int? value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<NullableIntPK>> get changes =>
@@ -71,7 +71,7 @@ class StringPK extends _StringPK with RealmEntity, RealmObject {
   @override
   String get id => RealmObject.get<String>(this, 'id') as String;
   @override
-  set id(String value) => throw RealmUnsupportedSetError();
+  set id(String value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<StringPK>> get changes =>
@@ -99,7 +99,7 @@ class NullableStringPK extends _NullableStringPK with RealmEntity, RealmObject {
   @override
   String? get id => RealmObject.get<String>(this, 'id') as String?;
   @override
-  set id(String? value) => throw RealmUnsupportedSetError();
+  set id(String? value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<NullableStringPK>> get changes =>
@@ -128,7 +128,7 @@ class ObjectIdPK extends _ObjectIdPK with RealmEntity, RealmObject {
   @override
   ObjectId get id => RealmObject.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(ObjectId value) => throw RealmUnsupportedSetError();
+  set id(ObjectId value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<ObjectIdPK>> get changes =>
@@ -156,7 +156,7 @@ class NullableObjectIdPK extends _NullableObjectIdPK with RealmEntity, RealmObje
   @override
   ObjectId? get id => RealmObject.get<ObjectId>(this, 'id') as ObjectId?;
   @override
-  set id(ObjectId? value) => throw RealmUnsupportedSetError();
+  set id(ObjectId? value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<NullableObjectIdPK>> get changes =>
@@ -185,7 +185,7 @@ class UuidPK extends _UuidPK with RealmEntity, RealmObject {
   @override
   Uuid get id => RealmObject.get<Uuid>(this, 'id') as Uuid;
   @override
-  set id(Uuid value) => throw RealmUnsupportedSetError();
+  set id(Uuid value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<UuidPK>> get changes =>
@@ -213,7 +213,7 @@ class NullableUuidPK extends _NullableUuidPK with RealmEntity, RealmObject {
   @override
   Uuid? get id => RealmObject.get<Uuid>(this, 'id') as Uuid?;
   @override
-  set id(Uuid? value) => throw RealmUnsupportedSetError();
+  set id(Uuid? value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<NullableUuidPK>> get changes =>

--- a/generator/test/good_test_data/required_argument.expected
+++ b/generator/test/good_test_data/required_argument.expected
@@ -14,7 +14,7 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   String get name => RealmObject.get<String>(this, 'name') as String;
   @override
-  set name(String value) => throw RealmUnsupportedSetError();
+  set name(String value) => RealmObject.set(this, 'name', value);
 
   @override
   Stream<RealmObjectChanges<Person>> get changes => RealmObject.getChanges<Person>(this);

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -48,7 +48,8 @@ typedef ShouldCompactCallback = bool Function(int totalSize, int usedSize);
 /// Realms, even if all objects in the Realm are deleted.
 typedef InitialDataCallback = void Function(Realm realm);
 
-/// the signature of a callback that will be executed when the schema of the Realm changes.
+/// The signature of a callback that will be executed when the schema of the Realm changes.
+///
 /// The `oldSchemaVersion` argument indicates the version from which the Realm migrates while
 /// the `migration` argument contains references to the Realm just before and just after the migration.
 typedef MigrationCallback = void Function(Migration migration, int oldSchemaVersion);
@@ -241,7 +242,7 @@ enum SessionStopPolicy {
   afterChangesUploaded, // Once all Realms/Sessions go out of scope, wait for uploads to complete and stop.
 }
 
-///The signature of a callback that will be invoked whenever a [SyncError] occurs for the synchronized Realm.
+/// The signature of a callback that will be invoked whenever a [SyncError] occurs for the synchronized Realm.
 ///
 /// Client reset errors will not be reported through this callback as they are handled by [SyncClientResetErrorHandler].
 typedef SyncErrorHandler = void Function(SyncError);

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -50,8 +50,8 @@ typedef InitialDataCallback = void Function(Realm realm);
 
 /// The signature of a callback that will be executed when the schema of the Realm changes.
 ///
+/// The `migration` argument contains references to the Realm just before and just after the migration.
 /// The `oldSchemaVersion` argument indicates the version from which the Realm migrates while
-/// the `migration` argument contains references to the Realm just before and just after the migration.
 typedef MigrationCallback = void Function(Migration migration, int oldSchemaVersion);
 
 /// Configuration used to create a [Realm] instance

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -25,6 +25,7 @@ import 'native/realm_core.dart';
 import 'realm_class.dart';
 import 'init.dart';
 import 'user.dart';
+import 'migration.dart';
 
 /// The signature of a callback used to determine if compaction
 /// should be attempted.
@@ -46,6 +47,11 @@ typedef ShouldCompactCallback = bool Function(int totalSize, int usedSize);
 /// add some initial data that your app needs. The function will not execute for existing
 /// Realms, even if all objects in the Realm are deleted.
 typedef InitialDataCallback = void Function(Realm realm);
+
+/// the signature of a callback that will be executed when the schema of the Realm changes.
+/// The `oldSchemaVersion` argument indicates the version from which the Realm migrates while
+/// the `migration` argument contains references to the Realm just before and just after the migration.
+typedef MigrationCallback = void Function(Migration migration, int oldSchemaVersion);
 
 /// Configuration used to create a [Realm] instance
 /// {@category Configuration}
@@ -122,6 +128,7 @@ abstract class Configuration implements Finalizable {
     bool disableFormatUpgrade = false,
     bool isReadOnly = false,
     ShouldCompactCallback? shouldCompactCallback,
+    MigrationCallback? migrationCallback,
   }) =>
       LocalConfiguration._(
         schemaObjects,
@@ -132,6 +139,7 @@ abstract class Configuration implements Finalizable {
         disableFormatUpgrade: disableFormatUpgrade,
         isReadOnly: isReadOnly,
         shouldCompactCallback: shouldCompactCallback,
+        migrationCallback: migrationCallback,
       );
 
   /// Constructs a [InMemoryConfiguration]
@@ -190,6 +198,7 @@ class LocalConfiguration extends Configuration {
     this.disableFormatUpgrade = false,
     this.isReadOnly = false,
     this.shouldCompactCallback,
+    this.migrationCallback,
   }) : super._();
 
   /// The schema version used to open the [Realm]. If omitted, the default value is `0`.
@@ -220,6 +229,9 @@ class LocalConfiguration extends Configuration {
 
   /// Called when opening a [Realm] for the very first time, when db file is created.
   final InitialDataCallback? initialDataCallback;
+
+  /// Called when opening a [Realm] with a schema version that is newer than the one used to create the file.
+  final MigrationCallback? migrationCallback;
 }
 
 /// @nodoc

--- a/lib/src/migration.dart
+++ b/lib/src/migration.dart
@@ -66,8 +66,10 @@ class Migration {
   /// will be removed from the Realm.
   ///
   /// If you don't call this, the data will not be deleted, even if the type is not present in the new schema.
-  void removeType(String className) {
-    realmCore.removeType(newRealm, className);
+  ///
+  /// Returns `true` if the table was present in the old Realm and was deleted. Returns `false` if it didn't exist.
+  bool removeType(String className) {
+    return realmCore.removeType(newRealm, className);
   }
 }
 

--- a/lib/src/migration.dart
+++ b/lib/src/migration.dart
@@ -24,13 +24,14 @@ import './realm_object.dart';
 /// to another. It contains the properties for the Realm before and after the migration.
 /// After the migration is complete, [newRealm] will become the authoritative version of
 /// the file.
+///
+/// {@category Realm}
 class Migration {
   final SchemaHandle _schema;
 
   /// The Realm as it existed just before the migration. Since the models have changed,
-  /// this Realm can only be accessed via the dynamic API (i.e. [Realm.dynamic] and
-  /// [RealmObject.dynamic]).
-  final Realm oldRealm;
+  /// this Realm can only be accessed via the dynamic API.
+  final MigrationRealm oldRealm;
 
   /// The Realm as it exists after the migration. Before the end of the callback, you need
   /// to make sure that all relevant data has been migrated from [oldRealm] into [newRealm].
@@ -75,7 +76,7 @@ class Migration {
 
 /// @nodoc
 extension MigrationInternal on Migration {
-  static Migration create(Realm oldRealm, Realm newRealm, SchemaHandle schema) {
+  static Migration create(MigrationRealm oldRealm, Realm newRealm, SchemaHandle schema) {
     return Migration._(oldRealm, newRealm, schema);
   }
 }

--- a/lib/src/migration.dart
+++ b/lib/src/migration.dart
@@ -46,6 +46,10 @@ class Migration {
   void renameProperty(String className, String oldPropertyName, String newPropertyName) {
     realmCore.renameProperty(newRealm, className, oldPropertyName, newPropertyName, _schema);
   }
+
+  void removeType(String className) {
+    realmCore.removeType(newRealm, className);
+  }
 }
 
 /// @nodoc

--- a/lib/src/migration.dart
+++ b/lib/src/migration.dart
@@ -62,13 +62,13 @@ class Migration {
     realmCore.renameProperty(newRealm, className, oldPropertyName, newPropertyName, _schema);
   }
 
-  /// Removes a type during a migration. All the data associated with the type, as well as its schema,
-  /// will be removed from the Realm.
+  /// Deletes a type during a migration. All the data associated with the type, as well as its schema,
+  /// will be deleted from the Realm.
   ///
   /// If you don't call this, the data will not be deleted, even if the type is not present in the new schema.
   ///
   /// Returns `true` if the table was present in the old Realm and was deleted. Returns `false` if it didn't exist.
-  bool removeType(String className) {
+  bool deleteType(String className) {
     return realmCore.removeType(newRealm, className);
   }
 }

--- a/lib/src/migration.dart
+++ b/lib/src/migration.dart
@@ -1,0 +1,56 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import 'realm_class.dart';
+import 'native/realm_core.dart';
+import './realm_object.dart';
+
+class Migration {
+  final SchemaHandle _schema;
+  final Realm oldRealm;
+  final Realm newRealm;
+
+  Migration._(this.oldRealm, this.newRealm, this._schema);
+
+  T? findInNewRealm<T extends RealmObject>(RealmObject oldObject) {
+    if (!oldObject.isManaged) {
+      throw UnsupportedError('Only managed RealmObject instances can be looked up in the new Realm');
+    }
+
+    final metadata = newRealm.metadata.getByType(T);
+    final handle = realmCore.findExisting(newRealm, metadata.classKey, oldObject.handle);
+    if (handle == null) {
+      return null;
+    }
+
+    final accessor = RealmCoreAccessor(metadata, true);
+    var object = RealmObjectInternal.create(T, newRealm, handle, accessor);
+    return object as T;
+  }
+
+  void renameProperty(String className, String oldPropertyName, String newPropertyName) {
+    realmCore.renameProperty(newRealm, className, oldPropertyName, newPropertyName, _schema);
+  }
+}
+
+/// @nodoc
+extension MigrationInternal on Migration {
+  static Migration create(Realm oldRealm, Realm newRealm, SchemaHandle schema) {
+    return Migration._(oldRealm, newRealm, schema);
+  }
+}

--- a/lib/src/migration.dart
+++ b/lib/src/migration.dart
@@ -70,7 +70,7 @@ class Migration {
   ///
   /// Returns `true` if the table was present in the old Realm and was deleted. Returns `false` if it didn't exist.
   bool deleteType(String className) {
-    return realmCore.removeType(newRealm, className);
+    return realmCore.deleteType(newRealm, className);
   }
 }
 

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3845,6 +3845,26 @@ class RealmLibrary {
   late final _realm_dictionary_size = _realm_dictionary_sizePtr.asFunction<
       bool Function(ffi.Pointer<realm_dictionary_t>, ffi.Pointer<ffi.Size>)>();
 
+  /// Convert a dictionary to results.
+  ///
+  /// @return A non-null pointer if no exception occurred.
+  ffi.Pointer<realm_results_t> realm_dictionary_to_results(
+    ffi.Pointer<realm_dictionary_t> arg0,
+  ) {
+    return _realm_dictionary_to_results(
+      arg0,
+    );
+  }
+
+  late final _realm_dictionary_to_resultsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<realm_results_t> Function(
+              ffi.Pointer<realm_dictionary_t>)>>('realm_dictionary_to_results');
+  late final _realm_dictionary_to_results =
+      _realm_dictionary_to_resultsPtr.asFunction<
+          ffi.Pointer<realm_results_t> Function(
+              ffi.Pointer<realm_dictionary_t>)>();
+
   /// Return true if two API objects refer to the same underlying data. Objects
   /// with different types are never equal.
   ///
@@ -4926,6 +4946,36 @@ class RealmLibrary {
   late final _realm_list_erase = _realm_list_erasePtr
       .asFunction<bool Function(ffi.Pointer<realm_list_t>, int)>();
 
+  /// Find the value in the list passed as parameter.
+  /// @param value to search in the list
+  /// @param out_index the index in the list where the value has been found or realm::not_found.
+  /// @param out_found boolean that indicates whether the value is found or not
+  /// @return true if no exception occurred.
+  bool realm_list_find(
+    ffi.Pointer<realm_list_t> arg0,
+    ffi.Pointer<realm_value_t> value,
+    ffi.Pointer<ffi.Size> out_index,
+    ffi.Pointer<ffi.Bool> out_found,
+  ) {
+    return _realm_list_find(
+      arg0,
+      value,
+      out_index,
+      out_found,
+    );
+  }
+
+  late final _realm_list_findPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(
+              ffi.Pointer<realm_list_t>,
+              ffi.Pointer<realm_value_t>,
+              ffi.Pointer<ffi.Size>,
+              ffi.Pointer<ffi.Bool>)>>('realm_list_find');
+  late final _realm_list_find = _realm_list_findPtr.asFunction<
+      bool Function(ffi.Pointer<realm_list_t>, ffi.Pointer<realm_value_t>,
+          ffi.Pointer<ffi.Size>, ffi.Pointer<ffi.Bool>)>();
+
   /// Get an list from a thread-safe reference, potentially originating in a
   /// different `realm_t` instance
   ffi.Pointer<realm_list_t> realm_list_from_thread_safe_reference(
@@ -5190,6 +5240,24 @@ class RealmLibrary {
               ffi.Pointer<ffi.Size>)>>('realm_list_size');
   late final _realm_list_size = _realm_list_sizePtr.asFunction<
       bool Function(ffi.Pointer<realm_list_t>, ffi.Pointer<ffi.Size>)>();
+
+  /// Convert a list to results.
+  ///
+  /// @return A non-null pointer if no exception occurred.
+  ffi.Pointer<realm_results_t> realm_list_to_results(
+    ffi.Pointer<realm_list_t> arg0,
+  ) {
+    return _realm_list_to_results(
+      arg0,
+    );
+  }
+
+  late final _realm_list_to_resultsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<realm_results_t> Function(
+              ffi.Pointer<realm_list_t>)>>('realm_list_to_results');
+  late final _realm_list_to_results = _realm_list_to_resultsPtr.asFunction<
+      ffi.Pointer<realm_results_t> Function(ffi.Pointer<realm_list_t>)>();
 
   /// Implement aggregate for mongodb collection
   /// @param collection ptr to the collection to fetch from
@@ -6147,6 +6215,26 @@ class RealmLibrary {
           ffi.Pointer<realm_object_t> Function(ffi.Pointer<realm_t>, int,
               realm_value_t, ffi.Pointer<ffi.Bool>)>();
 
+  /// Get the parent object for the object passed as argument. Only works for embedded objects.
+  /// @return true, if no errors occurred.
+  bool realm_object_get_parent(
+    ffi.Pointer<realm_object_t> object,
+    ffi.Pointer<realm_object_t> parent,
+  ) {
+    return _realm_object_get_parent(
+      object,
+      parent,
+    );
+  }
+
+  late final _realm_object_get_parentPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<realm_object_t>,
+              ffi.Pointer<realm_object_t>)>>('realm_object_get_parent');
+  late final _realm_object_get_parent = _realm_object_get_parentPtr.asFunction<
+      bool Function(
+          ffi.Pointer<realm_object_t>, ffi.Pointer<realm_object_t>)>();
+
   /// Get the table for this object.
   ///
   /// This function cannot fail.
@@ -6599,6 +6687,30 @@ class RealmLibrary {
           'realm_release');
   late final _realm_release =
       _realm_releasePtr.asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  /// Find and delete the table passed as parementer for the realm instance passed to this function.
+  /// @param table_name for the table the user wants to delete
+  /// @param table_deleted in order to indicate if the table was actually deleted from realm
+  /// @return true if no error has occured, false otherwise
+  bool realm_remove_table(
+    ffi.Pointer<realm_t> arg0,
+    ffi.Pointer<ffi.Char> table_name,
+    ffi.Pointer<ffi.Bool> table_deleted,
+  ) {
+    return _realm_remove_table(
+      arg0,
+      table_name,
+      table_deleted,
+    );
+  }
+
+  late final _realm_remove_tablePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<realm_t>, ffi.Pointer<ffi.Char>,
+              ffi.Pointer<ffi.Bool>)>>('realm_remove_table');
+  late final _realm_remove_table = _realm_remove_tablePtr.asFunction<
+      bool Function(ffi.Pointer<realm_t>, ffi.Pointer<ffi.Char>,
+          ffi.Pointer<ffi.Bool>)>();
 
   ffi.Pointer<realm_notification_token_t>
       realm_results_add_notification_callback(
@@ -7640,6 +7752,24 @@ class RealmLibrary {
               ffi.Pointer<ffi.Size>)>>('realm_set_size');
   late final _realm_set_size = _realm_set_sizePtr.asFunction<
       bool Function(ffi.Pointer<realm_set_t>, ffi.Pointer<ffi.Size>)>();
+
+  /// Convert a set to results.
+  ///
+  /// @return A non-null pointer if no exception occurred.
+  ffi.Pointer<realm_results_t> realm_set_to_results(
+    ffi.Pointer<realm_set_t> arg0,
+  ) {
+    return _realm_set_to_results(
+      arg0,
+    );
+  }
+
+  late final _realm_set_to_resultsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<realm_results_t> Function(
+              ffi.Pointer<realm_set_t>)>>('realm_set_to_results');
+  late final _realm_set_to_results = _realm_set_to_resultsPtr.asFunction<
+      ffi.Pointer<realm_results_t> Function(ffi.Pointer<realm_set_t>)>();
 
   /// Set the value for a property.
   ///
@@ -10521,8 +10651,9 @@ typedef realm_schema_t = realm_schema;
 
 abstract class realm_schema_validation_mode {
   static const int RLM_SCHEMA_VALIDATION_BASIC = 0;
-  static const int RLM_SCHEMA_VALIDATION_SYNC = 1;
+  static const int RLM_SCHEMA_VALIDATION_SYNC_PBS = 1;
   static const int RLM_SCHEMA_VALIDATION_REJECT_EMBEDDED_ORPHANS = 2;
+  static const int RLM_SCHEMA_VALIDATION_SYNC_FLX = 4;
 }
 
 class realm_set extends ffi.Opaque {}

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -448,7 +448,7 @@ class _RealmCore {
 
       final newRealm = RealmInternal.getUnowned(config, RealmHandle._unowned(newRealmHandle), isInMigration: true);
 
-      final migration = MigrationInternal.create(oldRealm, newRealm, SchemaHandle.unowned(schema));
+      final migration = MigrationInternal.create(oldRealm.getMigrationRealm(), newRealm, SchemaHandle.unowned(schema));
       config.migrationCallback!(migration, oldSchemaVersion);
       return true;
     } catch (ex) {

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -693,6 +693,12 @@ class _RealmCore {
     });
   }
 
+  void removeType(Realm realm, String objectType) {
+    using((Arena arena) {
+      // TODO: this does not work since there's no Core API to remove types. https://github.com/realm/realm-core/issues/5766
+    });
+  }
+
   void deleteRealmObject(RealmObject object) {
     _realmLib.invokeGetBool(() => _realmLib.realm_object_delete(object.handle._pointer));
   }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -448,7 +448,7 @@ class _RealmCore {
 
       final newRealm = RealmInternal.getUnowned(config, RealmHandle._unowned(newRealmHandle), isInMigration: true);
 
-      final migration = MigrationInternal.create(oldRealm.getMigrationRealm(), newRealm, SchemaHandle.unowned(schema));
+      final migration = MigrationInternal.create(RealmInternal.getMigrationRealm(oldRealm), newRealm, SchemaHandle.unowned(schema));
       config.migrationCallback!(migration, oldSchemaVersion);
       return true;
     } catch (ex) {
@@ -698,7 +698,7 @@ class _RealmCore {
     });
   }
 
-  bool removeType(Realm realm, String objectType) {
+  bool deleteType(Realm realm, String objectType) {
     return using((Arena arena) {
       final deletedPtr = arena<Bool>();
       _realmLib.invokeGetBool(() => _realmLib.realm_remove_table(realm.handle._pointer, objectType.toCharPtr(arena), deletedPtr));

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -42,6 +42,7 @@ import '../subscription.dart';
 import '../user.dart';
 import '../session.dart';
 import 'realm_bindings.dart';
+import '../migration.dart';
 
 late RealmLibrary _realmLib;
 
@@ -80,14 +81,23 @@ class _RealmCore {
     }
 
     final message = error.ref.message.cast<Utf8>().toRealmDartString();
+    Object? userError;
+    if (error.ref.usercode_error != nullptr) {
+      userError = error.ref.usercode_error.toObject(isPersistent: true);
+      _realmLib.realm_dart_delete_persistent_handle(error.ref.usercode_error);
+    }
 
-    return LastError(error.ref.error, message);
+    return LastError(error.ref.error, message, userError);
   }
 
   void throwLastError([String? errorMessage]) {
     using((Arena arena) {
       final lastError = getLastError(arena);
-      throw RealmException('${errorMessage != null ? errorMessage + ". " : ""}${lastError ?? ""}');
+      if (lastError?.userError != null) {
+        throw UserCallbackException(lastError!.userError!);
+      }
+
+      throw RealmException('${errorMessage != null ? "$errorMessage. " : ""}${lastError ?? ""}');
     });
   }
 
@@ -186,6 +196,9 @@ class _RealmCore {
             config.toWeakHandle(),
             nullptr,
           );
+        }
+        if (config.migrationCallback != null) {
+          _realmLib.realm_config_set_migration_function(configHandle._pointer, Pointer.fromFunction(migration_callback, false), config.toWeakHandle(), nullptr);
         }
       } else if (config is InMemoryConfiguration) {
         _realmLib.realm_config_set_in_memory(configHandle._pointer, true);
@@ -416,6 +429,29 @@ class _RealmCore {
     return config.shouldCompactCallback!(totalSize, usedSize);
   }
 
+  static bool migration_callback(
+      Pointer<Void> userdata, Pointer<shared_realm> oldRealmHandle, Pointer<shared_realm> newRealmHandle, Pointer<realm_schema> schema) {
+    try {
+      final LocalConfiguration? config = userdata.toObject();
+      if (config == null) {
+        return false;
+      }
+
+      final oldSchemaVersion = _realmLib.realm_get_schema_version(oldRealmHandle);
+      final oldConfig = Configuration.local([], path: config.path, isReadOnly: true, schemaVersion: oldSchemaVersion);
+      final oldRealm = RealmInternal.getUnowned(oldConfig, RealmHandle._unowned(oldRealmHandle), isInMigration: true);
+
+      final newRealm = RealmInternal.getUnowned(config, RealmHandle._unowned(newRealmHandle), isInMigration: true);
+
+      final migration = MigrationInternal.create(oldRealm, newRealm, SchemaHandle.unowned(schema));
+      config.migrationCallback!(migration, oldSchemaVersion);
+      return true;
+    } catch (ex) {
+      _realmLib.realm_register_user_code_callback_error(ex.toPersistentHandle());
+    }
+    return false;
+  }
+
   static void _syncErrorHandlerCallback(Object userdata, Pointer<realm_sync_session> session, realm_sync_error error) {
     final syncConfig = userdata as FlexibleSyncConfiguration;
 
@@ -551,11 +587,11 @@ class _RealmCore {
       }
 
       final primaryKey = classInfo.ref.primary_key.cast<Utf8>().toRealmDartString(treatEmptyAsNull: true);
-      return RealmObjectMetadata(className, classType, primaryKey, classInfo.ref.key, _getPropertyMetadata(realm, classInfo.ref.key));
+      return RealmObjectMetadata(className, classType, primaryKey, classInfo.ref.key, _getPropertyMetadata(realm, classInfo.ref.key, primaryKey));
     });
   }
 
-  Map<String, RealmPropertyMetadata> _getPropertyMetadata(Realm realm, int classKey) {
+  Map<String, RealmPropertyMetadata> _getPropertyMetadata(Realm realm, int classKey, String? primaryKeyName) {
     return using((Arena arena) {
       final propertyCountPtr = arena<Size>();
       _realmLib.invokeGetBool(
@@ -573,8 +609,9 @@ class _RealmCore {
         final propertyName = property.ref.name.cast<Utf8>().toRealmDartString()!;
         final objectType = property.ref.link_target.cast<Utf8>().toRealmDartString(treatEmptyAsNull: true);
         final isNullable = property.ref.flags & realm_property_flags.RLM_PROPERTY_NULLABLE != 0;
+        final isPrimaryKey = propertyName == primaryKeyName;
         final propertyMeta = RealmPropertyMetadata(property.ref.key, objectType, RealmPropertyType.values.elementAt(property.ref.type), isNullable,
-            RealmCollectionType.values.elementAt(property.ref.collection_type));
+            isPrimaryKey, RealmCollectionType.values.elementAt(property.ref.collection_type));
         result[propertyName] = propertyMeta;
       }
       return result;
@@ -640,6 +677,19 @@ class _RealmCore {
       }
 
       return RealmObjectHandle._(pointer);
+    });
+  }
+
+  RealmObjectHandle? findExisting(Realm realm, int classKey, RealmObjectHandle other) {
+    final key = _realmLib.realm_object_get_key(other._pointer);
+    final pointer = _realmLib.invokeGetPointer(() => _realmLib.realm_get_object(realm.handle._pointer, classKey, key));
+    return RealmObjectHandle._(pointer);
+  }
+
+  void renameProperty(Realm realm, String objectType, String oldName, String newName, SchemaHandle schema) {
+    using((Arena arena) {
+      _realmLib.invokeGetBool(() => _realmLib.realm_schema_rename_property(
+          realm.handle._pointer, schema._pointer, objectType.toCharPtr(arena), oldName.toCharPtr(arena), newName.toCharPtr(arena)));
     });
   }
 
@@ -1747,8 +1797,9 @@ class _RealmCore {
 class LastError {
   final int code;
   final String? message;
+  final Object? userError;
 
-  LastError(this.code, [this.message]);
+  LastError(this.code, [this.message, this.userError]);
 
   @override
   String toString() {
@@ -1804,6 +1855,8 @@ abstract class HandleBase<T extends NativeType> implements Finalizable {
 
 class SchemaHandle extends HandleBase<realm_schema> {
   SchemaHandle._(Pointer<realm_schema> pointer) : super(pointer, 24);
+
+  SchemaHandle.unowned(Pointer<realm_schema> pointer) : super.unowned(pointer);
 }
 
 class ConfigHandle extends HandleBase<realm_config> {
@@ -1832,15 +1885,15 @@ class RealmLinkHandle {
         classKey = link.target_table;
 }
 
-class RealmResultsHandle extends HandleBase<realm_results> {
+class RealmResultsHandle extends ReleasableHandle<realm_results> {
   RealmResultsHandle._(Pointer<realm_results> pointer) : super(pointer, 872);
 }
 
-class RealmListHandle extends HandleBase<realm_list> {
+class RealmListHandle extends ReleasableHandle<realm_list> {
   RealmListHandle._(Pointer<realm_list> pointer) : super(pointer, 88);
 }
 
-class RealmQueryHandle extends HandleBase<realm_query> {
+class RealmQueryHandle extends ReleasableHandle<realm_query> {
   RealmQueryHandle._(Pointer<realm_query> pointer) : super(pointer, 256);
 }
 

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -698,9 +698,11 @@ class _RealmCore {
     });
   }
 
-  void removeType(Realm realm, String objectType) {
-    using((Arena arena) {
-      // TODO: this does not work since there's no Core API to remove types. https://github.com/realm/realm-core/issues/5766
+  bool removeType(Realm realm, String objectType) {
+    return using((Arena arena) {
+      final deletedPtr = arena<Bool>();
+      _realmLib.invokeGetBool(() => _realmLib.realm_remove_table(realm.handle._pointer, objectType.toCharPtr(arena), deletedPtr));
+      return deletedPtr.value;
     });
   }
 

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -448,7 +448,7 @@ extension RealmInternal on Realm {
 
     final metadata = (object.accessor as RealmCoreAccessor).metadata;
 
-    return RealmObjectInternal.create(T, this, handle, RealmCoreAccessor(metadata)) as T;
+    return RealmObjectInternal.create(T, this, handle, RealmCoreAccessor(metadata, _isInMigration)) as T;
   }
 
   RealmList<T>? resolveList<T extends Object?>(ManagedRealmList<T> list) {
@@ -464,6 +464,8 @@ extension RealmInternal on Realm {
     final handle = realmCore.resolveResults(results, this);
     return RealmResultsInternal.create<T>(handle, this, results.metadata);
   }
+
+  MigrationRealm getMigrationRealm() => MigrationRealm._(this);
 }
 
 /// @nodoc
@@ -615,4 +617,20 @@ class DynamicRealm {
     final accessor = RealmCoreAccessor(metadata, _realm._isInMigration);
     return RealmObjectInternal.create(RealmObject, _realm, handle, accessor);
   }
+}
+
+/// A class used during a migration callback. It exposes a set of dynamic API as
+/// well as the Realm config and schema.
+///
+/// {@category Realm}
+class MigrationRealm extends DynamicRealm {
+  /// The [Configuration] object used to open this [Realm]
+  Configuration get config => _realm.config;
+
+  /// The schema of this [Realm]. If the [Configuration] was created with a
+  /// non-empty list of schemas, this will match the collection. Otherwise,
+  /// the schema will be read from the file.
+  RealmSchema get schema => _realm.schema;
+
+  MigrationRealm._(Realm realm) : super._(realm);
 }

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -465,7 +465,7 @@ extension RealmInternal on Realm {
     return RealmResultsInternal.create<T>(handle, this, results.metadata);
   }
 
-  MigrationRealm getMigrationRealm() => MigrationRealm._(this);
+  static MigrationRealm getMigrationRealm(Realm realm) => MigrationRealm._(realm);
 }
 
 /// @nodoc

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -381,7 +381,10 @@ class RealmException implements Exception {
   }
 }
 
+/// An exception throws during execution of a user callback - e.g. during migration or initial data population.
+/// {@category Realm}
 class UserCallbackException extends RealmException {
+  /// The error that was thrown while executing the callback.
   final Object userException;
 
   UserCallbackException(this.userException)

--- a/test/migration_test.dart
+++ b/test/migration_test.dart
@@ -364,14 +364,14 @@ Future<void> main([List<String>? args]) async {
 
     v2DynamicRealm.close();
 
-    // Verify that calling removeType removes the table
+    // Verify that calling deleteType deletes the table and its data
 
     final v3Config = Configuration.local([Person.schema], schemaVersion: 3, migrationCallback: ((migration, oldSchemaVersion) {
       expect(migration.oldRealm.schema.length, 2);
       expect(migration.newRealm.schema.length, 1);
 
-      expect(migration.removeType('Dog'), true);
-      expect(migration.removeType('i-dont-exist'), false);
+      expect(migration.deleteType('Dog'), true);
+      expect(migration.deleteType('i-dont-exist'), false);
     }));
 
     final v3Realm = getRealm(v3Config);

--- a/test/migration_test.dart
+++ b/test/migration_test.dart
@@ -1,0 +1,283 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// ignore_for_file: unused_local_variable
+
+import 'dart:async';
+import 'dart:io';
+import 'package:test/test.dart' hide test, throws;
+import '../lib/realm.dart';
+import 'test.dart';
+import '../lib/src/results.dart';
+
+part 'migration_test.g.dart';
+
+@RealmModel()
+@MapTo("Person")
+class _PersonIntName {
+  late int name;
+}
+
+@RealmModel()
+@MapTo('Student')
+class _StudentV1 {
+  // See test.dart/_Student for how v2 looks like.
+  // In v1, the name is a PK, in v2, name is optional and the PK
+  // is an int number.
+
+  @PrimaryKey()
+  late String name;
+  late int? yearOfBirth;
+}
+
+@RealmModel()
+@MapTo('MyObject')
+class _MyObjectWithTypo {
+  late String nmae;
+
+  late int vlaue;
+}
+
+@RealmModel()
+@MapTo('MyObject')
+class _MyObjectWithoutTypo {
+  late String name;
+
+  late int value;
+}
+
+Future<void> main([List<String>? args]) async {
+  print("Current PID $pid");
+
+  await setupTests(args);
+
+  test('Configuration.migrationCallback executed when schema version changes', () {
+    final config1 = Configuration.local([PersonIntName.schema], schemaVersion: 1);
+    getRealm(config1).close();
+
+    var invoked = false;
+    final config2 = Configuration.local([PersonIntName.schema], schemaVersion: 2, migrationCallback: (migration, oldVersion) {
+      invoked = true;
+      expect(oldVersion, 1);
+    });
+
+    getRealm(config2);
+    expect(invoked, true);
+  });
+
+  test('Configuration.migrationCallback executed when schema changes', () {
+    final config1 = Configuration.local([PersonIntName.schema], schemaVersion: 1);
+    getRealm(config1).close();
+
+    var invoked = false;
+    final config2 = Configuration.local([Person.schema], schemaVersion: 2, migrationCallback: (migration, oldVersion) {
+      invoked = true;
+      expect(oldVersion, 1);
+    });
+
+    getRealm(config2);
+    expect(invoked, true);
+  });
+
+  test('Configuration.migrationCallback not invoked when schemaVersion is the same', () {
+    final config1 = Configuration.local([PersonIntName.schema], schemaVersion: 1);
+    getRealm(config1).close();
+
+    var invoked = false;
+    // Keep schema version the same
+    final config2 = Configuration.local([Person.schema], schemaVersion: 1, migrationCallback: (migration, oldVersion) {
+      invoked = true;
+    });
+
+    expect(() => getRealm(config2), throws<RealmException>('Migration is required due to the following errors'));
+    expect(invoked, false);
+  });
+
+  test('Migration can change primary key type', () {
+    final v1Config = Configuration.local([PersonIntName.schema], schemaVersion: 1);
+    final v1Realm = getRealm(v1Config);
+
+    for (var i = 0; i < 10; i++) {
+      v1Realm.write(() {
+        v1Realm.add(PersonIntName(i));
+      });
+    }
+
+    v1Realm.close();
+
+    final v2Config = Configuration.local([Person.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
+      expect(oldSchemaVersion, 1);
+
+      final oldPeople = migration.oldRealm.dynamic.all('Person');
+      final newPeople = migration.newRealm.all<Person>();
+
+      for (var i = 0; i < oldPeople.length; i++) {
+        final oldPerson = oldPeople[i];
+        final newPerson = newPeople[i];
+
+        newPerson.name = oldPerson.dynamic.get<int>('name').toString();
+      }
+    });
+
+    final v2Realm = getRealm(v2Config);
+    final peopleNames = v2Realm.all<Person>().map((e) => e.name);
+    final expectedNames = [for (var i = 0; i < 10; i += 1) i.toString()];
+
+    expect(peopleNames, expectedNames);
+  });
+
+  test('Migration can change primary key to another property', () {
+    final v1Config = Configuration.local([StudentV1.schema], schemaVersion: 1);
+    final v1Realm = getRealm(v1Config);
+    v1Realm.write(() {
+      v1Realm.add(StudentV1('Peter'));
+      v1Realm.add(StudentV1('Alice'));
+      v1Realm.add(StudentV1('John'));
+    });
+
+    v1Realm.close();
+
+    final v2Config = Configuration.local([Student.schema, School.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
+      expect(oldSchemaVersion, 1);
+
+      // We want to assign numbers in ascending order
+      final oldStudents = migration.oldRealm.dynamic.all('Student').query('TRUEPREDICATE SORT(name ASC)');
+      final newStudents = migration.newRealm.all<Student>().query('TRUEPREDICATE sort(name ASC)');
+
+      for (var i = 0; i < oldStudents.length; i++) {
+        final oldStudent = oldStudents[i];
+        final newStudent = newStudents[i];
+
+        newStudent.number = i;
+      }
+
+      // TODO: this is a hack to get the test working until https://github.com/realm/realm-dart/issues/527 is
+      // implemented. The issue is that the results are not released at the end of the migration, which will
+      // trigger the notification mechanics when the write transaction is committed. This will cause the queries
+      // to be reevaluated, which is no longer possible since the tables have changed and the columns don't match.
+      oldStudents.handle.release();
+    });
+
+    final v2Realm = getRealm(v2Config);
+    final students = v2Realm.all<Student>().query('TRUEPREDICATE sort(number ASC)');
+
+    expect(students[0].name, 'Alice');
+    expect(students[0].number, 0);
+
+    expect(students[1].name, 'John');
+    expect(students[1].number, 1);
+
+    expect(students[2].name, 'Peter');
+    expect(students[2].number, 2);
+  });
+
+  test('Migration can find old object in new realm', () {
+    final v1Config = Configuration.local([StudentV1.schema], schemaVersion: 1);
+    final v1Realm = getRealm(v1Config);
+
+    for (var i = 0; i < 10; i++) {
+      v1Realm.write(() {
+        v1Realm.add(StudentV1(i.toString(), yearOfBirth: 2000 + i));
+      });
+    }
+
+    v1Realm.close();
+
+    final v2Config = Configuration.local([Student.schema, School.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
+      expect(oldSchemaVersion, 1);
+
+      final oldStudents = migration.oldRealm.dynamic.all('Student');
+
+      var number = 0;
+      for (final student in oldStudents) {
+        final newStudent = migration.findInNewRealm<Student>(student);
+        expect(newStudent, isNotNull);
+        expect(newStudent!.name, student.dynamic.get<String>('name'));
+        expect(newStudent.yearOfBirth, student.dynamic.get<int?>('yearOfBirth'));
+
+        newStudent.number = number++;
+      }
+    });
+
+    final v2Realm = getRealm(v2Config);
+    final studentNumbers = v2Realm.all<Student>().map((e) => e.number);
+    final expectedNumbers = [for (var i = 0; i < 10; i += 1) i];
+
+    expect(studentNumbers, expectedNumbers);
+  });
+
+  test('Migration can rename property', () {
+    final v1Config = Configuration.local([MyObjectWithTypo.schema], schemaVersion: 1);
+    final v1Realm = getRealm(v1Config);
+
+    v1Realm.write(() {
+      v1Realm.add(MyObjectWithTypo('Peter', 123));
+      v1Realm.add(MyObjectWithTypo('George', 456));
+    });
+
+    v1Realm.close();
+
+    final v2Config = Configuration.local([MyObjectWithoutTypo.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
+      expect(oldSchemaVersion, 1);
+
+      migration.renameProperty('MyObject', 'nmae', 'name');
+    });
+
+    final v2Realm = getRealm(v2Config);
+
+    // We renamed nmae to name, but don't rename vlaue to value so we expect
+    // the names to have been preserved, but the values - not.
+    final names = v2Realm.all<MyObjectWithoutTypo>().map((e) => e.name);
+    final values = v2Realm.all<MyObjectWithoutTypo>().map((e) => e.value);
+
+    expect(names, ['Peter', 'George']);
+    expect(values, [0, 0]);
+  });
+
+  test('Migration renameProperty with invalid argumetns', () {
+    final v1Config = Configuration.local([MyObjectWithTypo.schema], schemaVersion: 1);
+    final v1Realm = getRealm(v1Config);
+    v1Realm.close();
+
+    final renameToNonExistentConfig = Configuration.local([MyObjectWithoutTypo.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
+      expect(oldSchemaVersion, 1);
+
+      migration.renameProperty('MyObject', 'nmae', 'non-existent');
+    });
+
+    expect(() => getRealm(renameToNonExistentConfig), throws<RealmException>("Renamed property 'MyObject.non-existent' does not exist"));
+
+    final renameFromNonExistentConfig = Configuration.local([MyObjectWithoutTypo.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
+      expect(oldSchemaVersion, 1);
+
+      migration.renameProperty('MyObject', 'non-existent', 'name');
+    });
+
+    expect(
+        () => getRealm(renameFromNonExistentConfig), throws<UserCallbackException>("Cannot rename property 'MyObject.non-existent' because it does not exist"));
+
+    final renameNonExistentClassClass = Configuration.local([MyObjectWithoutTypo.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
+      expect(oldSchemaVersion, 1);
+
+      migration.renameProperty('non-existent', 'foo', 'bar');
+    });
+
+    expect(() => getRealm(renameNonExistentClassClass),
+        throws<UserCallbackException>("Cannot rename properties for type 'non-existent' because it does not exist"));
+  });
+}

--- a/test/migration_test.dart
+++ b/test/migration_test.dart
@@ -129,7 +129,7 @@ Future<void> main([List<String>? args]) async {
     final v2Config = Configuration.local([Person.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
       expect(oldSchemaVersion, 1);
 
-      final oldPeople = migration.oldRealm.dynamic.all('Person');
+      final oldPeople = migration.oldRealm.all('Person');
       final newPeople = migration.newRealm.all<Person>();
 
       for (var i = 0; i < oldPeople.length; i++) {
@@ -162,7 +162,7 @@ Future<void> main([List<String>? args]) async {
       expect(oldSchemaVersion, 1);
 
       // We want to assign numbers in ascending order
-      final oldStudents = migration.oldRealm.dynamic.all('Student').query('TRUEPREDICATE SORT(name ASC)');
+      final oldStudents = migration.oldRealm.all('Student').query('TRUEPREDICATE SORT(name ASC)');
       final newStudents = migration.newRealm.all<Student>().query('TRUEPREDICATE sort(name ASC)');
 
       for (var i = 0; i < oldStudents.length; i++) {
@@ -207,7 +207,7 @@ Future<void> main([List<String>? args]) async {
     final v2Config = Configuration.local([Student.schema, School.schema], schemaVersion: 2, migrationCallback: (migration, oldSchemaVersion) {
       expect(oldSchemaVersion, 1);
 
-      final oldStudents = migration.oldRealm.dynamic.all('Student');
+      final oldStudents = migration.oldRealm.all('Student');
 
       var number = 0;
       for (final student in oldStudents) {

--- a/test/migration_test.dart
+++ b/test/migration_test.dart
@@ -246,7 +246,7 @@ Future<void> main([List<String>? args]) async {
 
     final v2Realm = getRealm(v2Config);
 
-    // We renamed nmae to name, but don't rename vlaue to value so we expect
+    // We renamed 'nmae' to 'name', but don't rename 'vlaue' to 'value' so we expect
     // the names to have been preserved, but the values - not.
     final names = v2Realm.all<MyObjectWithoutTypo>().map((e) => e.name);
     final values = v2Realm.all<MyObjectWithoutTypo>().map((e) => e.value);

--- a/test/migration_test.g.dart
+++ b/test/migration_test.g.dart
@@ -1,0 +1,144 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'migration_test.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class PersonIntName extends _PersonIntName with RealmEntity, RealmObject {
+  PersonIntName(
+    int name,
+  ) {
+    RealmObject.set(this, 'name', name);
+  }
+
+  PersonIntName._();
+
+  @override
+  int get name => RealmObject.get<int>(this, 'name') as int;
+  @override
+  set name(int value) => RealmObject.set(this, 'name', value);
+
+  @override
+  Stream<RealmObjectChanges<PersonIntName>> get changes =>
+      RealmObject.getChanges<PersonIntName>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(PersonIntName._);
+    return const SchemaObject(PersonIntName, 'Person', [
+      SchemaProperty('name', RealmPropertyType.int),
+    ]);
+  }
+}
+
+class StudentV1 extends _StudentV1 with RealmEntity, RealmObject {
+  StudentV1(
+    String name, {
+    int? yearOfBirth,
+  }) {
+    RealmObject.set(this, 'name', name);
+    RealmObject.set(this, 'yearOfBirth', yearOfBirth);
+  }
+
+  StudentV1._();
+
+  @override
+  String get name => RealmObject.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => RealmObject.set(this, 'name', value);
+
+  @override
+  int? get yearOfBirth => RealmObject.get<int>(this, 'yearOfBirth') as int?;
+  @override
+  set yearOfBirth(int? value) => RealmObject.set(this, 'yearOfBirth', value);
+
+  @override
+  Stream<RealmObjectChanges<StudentV1>> get changes =>
+      RealmObject.getChanges<StudentV1>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(StudentV1._);
+    return const SchemaObject(StudentV1, 'Student', [
+      SchemaProperty('name', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('yearOfBirth', RealmPropertyType.int, optional: true),
+    ]);
+  }
+}
+
+class MyObjectWithTypo extends _MyObjectWithTypo with RealmEntity, RealmObject {
+  MyObjectWithTypo(
+    String nmae,
+    int vlaue,
+  ) {
+    RealmObject.set(this, 'nmae', nmae);
+    RealmObject.set(this, 'vlaue', vlaue);
+  }
+
+  MyObjectWithTypo._();
+
+  @override
+  String get nmae => RealmObject.get<String>(this, 'nmae') as String;
+  @override
+  set nmae(String value) => RealmObject.set(this, 'nmae', value);
+
+  @override
+  int get vlaue => RealmObject.get<int>(this, 'vlaue') as int;
+  @override
+  set vlaue(int value) => RealmObject.set(this, 'vlaue', value);
+
+  @override
+  Stream<RealmObjectChanges<MyObjectWithTypo>> get changes =>
+      RealmObject.getChanges<MyObjectWithTypo>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(MyObjectWithTypo._);
+    return const SchemaObject(MyObjectWithTypo, 'MyObject', [
+      SchemaProperty('nmae', RealmPropertyType.string),
+      SchemaProperty('vlaue', RealmPropertyType.int),
+    ]);
+  }
+}
+
+class MyObjectWithoutTypo extends _MyObjectWithoutTypo
+    with RealmEntity, RealmObject {
+  MyObjectWithoutTypo(
+    String name,
+    int value,
+  ) {
+    RealmObject.set(this, 'name', name);
+    RealmObject.set(this, 'value', value);
+  }
+
+  MyObjectWithoutTypo._();
+
+  @override
+  String get name => RealmObject.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => RealmObject.set(this, 'name', value);
+
+  @override
+  int get value => RealmObject.get<int>(this, 'value') as int;
+  @override
+  set value(int value) => RealmObject.set(this, 'value', value);
+
+  @override
+  Stream<RealmObjectChanges<MyObjectWithoutTypo>> get changes =>
+      RealmObject.getChanges<MyObjectWithoutTypo>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(MyObjectWithoutTypo._);
+    return const SchemaObject(MyObjectWithoutTypo, 'MyObject', [
+      SchemaProperty('name', RealmPropertyType.string),
+      SchemaProperty('value', RealmPropertyType.int),
+    ]);
+  }
+}

--- a/test/migration_test.g.dart
+++ b/test/migration_test.g.dart
@@ -24,6 +24,9 @@ class PersonIntName extends _PersonIntName with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<PersonIntName>> get changes =>
       RealmObject.getChanges<PersonIntName>(this);
 
+  @override
+  PersonIntName freeze() => RealmObject.freezeObject<PersonIntName>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -58,6 +61,9 @@ class StudentV1 extends _StudentV1 with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<StudentV1>> get changes =>
       RealmObject.getChanges<StudentV1>(this);
+
+  @override
+  StudentV1 freeze() => RealmObject.freezeObject<StudentV1>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -94,6 +100,9 @@ class MyObjectWithTypo extends _MyObjectWithTypo with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<MyObjectWithTypo>> get changes =>
       RealmObject.getChanges<MyObjectWithTypo>(this);
+
+  @override
+  MyObjectWithTypo freeze() => RealmObject.freezeObject<MyObjectWithTypo>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -132,6 +141,10 @@ class MyObjectWithoutTypo extends _MyObjectWithoutTypo
   Stream<RealmObjectChanges<MyObjectWithoutTypo>> get changes =>
       RealmObject.getChanges<MyObjectWithoutTypo>(this);
 
+  @override
+  MyObjectWithoutTypo freeze() =>
+      RealmObject.freezeObject<MyObjectWithoutTypo>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -161,6 +174,10 @@ class MyObjectWithoutValue extends _MyObjectWithoutValue
   @override
   Stream<RealmObjectChanges<MyObjectWithoutValue>> get changes =>
       RealmObject.getChanges<MyObjectWithoutValue>(this);
+
+  @override
+  MyObjectWithoutValue freeze() =>
+      RealmObject.freezeObject<MyObjectWithoutValue>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/test/migration_test.g.dart
+++ b/test/migration_test.g.dart
@@ -142,3 +142,32 @@ class MyObjectWithoutTypo extends _MyObjectWithoutTypo
     ]);
   }
 }
+
+class MyObjectWithoutValue extends _MyObjectWithoutValue
+    with RealmEntity, RealmObject {
+  MyObjectWithoutValue(
+    String name,
+  ) {
+    RealmObject.set(this, 'name', name);
+  }
+
+  MyObjectWithoutValue._();
+
+  @override
+  String get name => RealmObject.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => RealmObject.set(this, 'name', value);
+
+  @override
+  Stream<RealmObjectChanges<MyObjectWithoutValue>> get changes =>
+      RealmObject.getChanges<MyObjectWithoutValue>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(MyObjectWithoutValue._);
+    return const SchemaObject(MyObjectWithoutValue, 'MyObject', [
+      SchemaProperty('name', RealmPropertyType.string),
+    ]);
+  }
+}

--- a/test/realm_object_test.dart
+++ b/test/realm_object_test.dart
@@ -133,7 +133,14 @@ Future<void> main([List<String>? args]) async {
       realm.write(() {
         car.make = "Audi";
       });
-    }, throws<RealmUnsupportedSetError>());
+    }, throws<RealmException>("Primary key cannot be changed (original value: 'Tesla', supplied value: 'Audi'"));
+
+    // If we don't change the PK, setting it is a no-op
+    expect(() {
+      realm.write(() {
+        car.make = 'Tesla';
+      });
+    }, returnsNormally);
   });
 
   test('RealmObject set object type property (link)', () {
@@ -564,7 +571,7 @@ Future<void> main([List<String>? args]) async {
   test('get/set all property types', () {
     final config = Configuration.local([AllTypes.schema]);
     final realm = getRealm(config);
-    
+
     var date = DateTime.now().toUtc();
     var objectId = ObjectId();
     var uuid = Uuid.v4();

--- a/test/realm_object_test.dart
+++ b/test/realm_object_test.dart
@@ -609,4 +609,24 @@ Future<void> main([List<String>? args]) async {
     expect(object.uuidProp, uuid);
     expect(object.intProp, 5);
   });
+
+  test('Update primary key on unmanaged object', () {
+    final obj = StringPrimaryKey('abc');
+    obj.id = 'cde';
+
+    expect(obj.id, 'cde');
+
+    final realm = getRealm(Configuration.local([StringPrimaryKey.schema]));
+    realm.write(() {
+      realm.add(obj);
+    });
+
+    expect(realm.find<StringPrimaryKey>('cde'), isNotNull);
+    expect(realm.find<StringPrimaryKey>('abc'), isNull);
+
+    realm.write(() {
+      expect(() => obj.id = 'cde', returnsNormally);
+      expect(() => obj.id = 'abc', throws<RealmException>('Primary key cannot be changed'));
+    });
+  });
 }

--- a/test/realm_object_test.g.dart
+++ b/test/realm_object_test.g.dart
@@ -19,7 +19,7 @@ class ObjectIdPrimaryKey extends _ObjectIdPrimaryKey
   @override
   ObjectId get id => RealmObject.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(ObjectId value) => throw RealmUnsupportedSetError();
+  set id(ObjectId value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<ObjectIdPrimaryKey>> get changes =>
@@ -48,7 +48,7 @@ class NullableObjectIdPrimaryKey extends _NullableObjectIdPrimaryKey
   @override
   ObjectId? get id => RealmObject.get<ObjectId>(this, 'id') as ObjectId?;
   @override
-  set id(ObjectId? value) => throw RealmUnsupportedSetError();
+  set id(ObjectId? value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<NullableObjectIdPrimaryKey>> get changes =>
@@ -78,7 +78,7 @@ class IntPrimaryKey extends _IntPrimaryKey with RealmEntity, RealmObject {
   @override
   int get id => RealmObject.get<int>(this, 'id') as int;
   @override
-  set id(int value) => throw RealmUnsupportedSetError();
+  set id(int value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<IntPrimaryKey>> get changes =>
@@ -107,7 +107,7 @@ class NullableIntPrimaryKey extends _NullableIntPrimaryKey
   @override
   int? get id => RealmObject.get<int>(this, 'id') as int?;
   @override
-  set id(int? value) => throw RealmUnsupportedSetError();
+  set id(int? value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<NullableIntPrimaryKey>> get changes =>
@@ -136,7 +136,7 @@ class StringPrimaryKey extends _StringPrimaryKey with RealmEntity, RealmObject {
   @override
   String get id => RealmObject.get<String>(this, 'id') as String;
   @override
-  set id(String value) => throw RealmUnsupportedSetError();
+  set id(String value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<StringPrimaryKey>> get changes =>
@@ -165,7 +165,7 @@ class NullableStringPrimaryKey extends _NullableStringPrimaryKey
   @override
   String? get id => RealmObject.get<String>(this, 'id') as String?;
   @override
-  set id(String? value) => throw RealmUnsupportedSetError();
+  set id(String? value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<NullableStringPrimaryKey>> get changes =>
@@ -195,7 +195,7 @@ class UuidPrimaryKey extends _UuidPrimaryKey with RealmEntity, RealmObject {
   @override
   Uuid get id => RealmObject.get<Uuid>(this, 'id') as Uuid;
   @override
-  set id(Uuid value) => throw RealmUnsupportedSetError();
+  set id(Uuid value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<UuidPrimaryKey>> get changes =>
@@ -224,7 +224,7 @@ class NullableUuidPrimaryKey extends _NullableUuidPrimaryKey
   @override
   Uuid? get id => RealmObject.get<Uuid>(this, 'id') as Uuid?;
   @override
-  set id(Uuid? value) => throw RealmUnsupportedSetError();
+  set id(Uuid? value) => RealmObject.set(this, 'id', value);
 
   @override
   Stream<RealmObjectChanges<NullableUuidPrimaryKey>> get changes =>
@@ -291,7 +291,7 @@ class BoolValue extends _BoolValue with RealmEntity, RealmObject {
   @override
   int get key => RealmObject.get<int>(this, 'key') as int;
   @override
-  set key(int value) => throw RealmUnsupportedSetError();
+  set key(int value) => RealmObject.set(this, 'key', value);
 
   @override
   bool get value => RealmObject.get<bool>(this, 'value') as bool;

--- a/test/test.g.dart
+++ b/test/test.g.dart
@@ -18,7 +18,7 @@ class Car extends _Car with RealmEntity, RealmObject {
   @override
   String get make => RealmObject.get<String>(this, 'make') as String;
   @override
-  set make(String value) => throw RealmUnsupportedSetError();
+  set make(String value) => RealmObject.set(this, 'make', value);
 
   @override
   Stream<RealmObjectChanges<Car>> get changes =>
@@ -78,7 +78,7 @@ class Dog extends _Dog with RealmEntity, RealmObject {
   @override
   String get name => RealmObject.get<String>(this, 'name') as String;
   @override
-  set name(String value) => throw RealmUnsupportedSetError();
+  set name(String value) => RealmObject.set(this, 'name', value);
 
   @override
   int? get age => RealmObject.get<int>(this, 'age') as int?;
@@ -176,7 +176,7 @@ class Student extends _Student with RealmEntity, RealmObject {
   @override
   int get number => RealmObject.get<int>(this, 'number') as int;
   @override
-  set number(int value) => throw RealmUnsupportedSetError();
+  set number(int value) => RealmObject.set(this, 'number', value);
 
   @override
   String? get name => RealmObject.get<String>(this, 'name') as String?;
@@ -233,7 +233,7 @@ class School extends _School with RealmEntity, RealmObject {
   @override
   String get name => RealmObject.get<String>(this, 'name') as String;
   @override
-  set name(String value) => throw RealmUnsupportedSetError();
+  set name(String value) => RealmObject.set(this, 'name', value);
 
   @override
   String? get city => RealmObject.get<String>(this, 'city') as String?;
@@ -340,7 +340,7 @@ class Task extends _Task with RealmEntity, RealmObject {
   @override
   ObjectId get id => RealmObject.get<ObjectId>(this, '_id') as ObjectId;
   @override
-  set id(ObjectId value) => throw RealmUnsupportedSetError();
+  set id(ObjectId value) => RealmObject.set(this, '_id', value);
 
   @override
   Stream<RealmObjectChanges<Task>> get changes =>
@@ -371,7 +371,7 @@ class Schedule extends _Schedule with RealmEntity, RealmObject {
   @override
   ObjectId get id => RealmObject.get<ObjectId>(this, '_id') as ObjectId;
   @override
-  set id(ObjectId value) => throw RealmUnsupportedSetError();
+  set id(ObjectId value) => RealmObject.set(this, '_id', value);
 
   @override
   RealmList<Task> get tasks =>
@@ -571,7 +571,7 @@ class LinksClass extends _LinksClass with RealmEntity, RealmObject {
   @override
   Uuid get id => RealmObject.get<Uuid>(this, 'id') as Uuid;
   @override
-  set id(Uuid value) => throw RealmUnsupportedSetError();
+  set id(Uuid value) => RealmObject.set(this, 'id', value);
 
   @override
   LinksClass? get link =>
@@ -732,7 +732,7 @@ class NullableTypes extends _NullableTypes with RealmEntity, RealmObject {
   @override
   ObjectId get id => RealmObject.get<ObjectId>(this, '_id') as ObjectId;
   @override
-  set id(ObjectId value) => throw RealmUnsupportedSetError();
+  set id(ObjectId value) => RealmObject.set(this, '_id', value);
 
   @override
   ObjectId get differentiator =>
@@ -825,7 +825,7 @@ class Event extends _Event with RealmEntity, RealmObject {
   @override
   ObjectId get id => RealmObject.get<ObjectId>(this, '_id') as ObjectId;
   @override
-  set id(ObjectId value) => throw RealmUnsupportedSetError();
+  set id(ObjectId value) => RealmObject.set(this, '_id', value);
 
   @override
   String? get name =>
@@ -960,7 +960,7 @@ class Friend extends _Friend with RealmEntity, RealmObject {
   @override
   String get name => RealmObject.get<String>(this, 'name') as String;
   @override
-  set name(String value) => throw RealmUnsupportedSetError();
+  set name(String value) => RealmObject.set(this, 'name', value);
 
   @override
   int get age => RealmObject.get<int>(this, 'age') as int;


### PR DESCRIPTION
Adds support for providing a migration callback in local configs.

- [x] Callback executed when schema needs migration
- [x] Support `migration.findInNewRealm`
- [x] Support `migration.renameProperty`
- [x] Support `migration.removeType`. Blocked on https://github.com/realm/realm-core/issues/5766
- [x] Migration correctly propagates user exceptions through Core

Supersedes https://github.com/realm/realm-dart/pull/494.

Fixes https://github.com/realm/realm-dart/issues/70