### PR TITLE
Add support for frozen Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **This project is in the Beta stage. The API should be quite stable, but occasional breaking changes may be made.**
 
 ### Enhancements
-* None
+* Added support for "frozen objects" - these are objects, queries, lists, or Realms that have been "frozen" at a specific version. All frozen objects can be accessed and queried as normal, but attempting to mutate them or add change listeners will throw an exception. `Realm`, `RealmObject`, `RealmList`, and `RealmResults` now have a method `freeze()` which returns an immutable version of the object, as well as an `isFrozen` property which can be used to check whether an object is frozen. (Issue [#56](https://github.com/realm/realm-dart/issues/56))
 
 ### Fixed
 * Allow null arguments on query. ([#872](https://github.com/realm/realm-dart/pull/872)). Fixes [#871](https://github.com/realm/realm-dart/issues/871)

--- a/example/bin/myapp.g.dart
+++ b/example/bin/myapp.g.dart
@@ -52,6 +52,9 @@ class Car extends _Car with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<Car>> get changes =>
       RealmObject.getChanges<Car>(this);
 
+  @override
+  Car freeze() => RealmObject.freezeObject<Car>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -97,6 +100,9 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
       RealmObject.getChanges<Person>(this);
+
+  @override
+  Person freeze() => RealmObject.freezeObject<Person>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/flutter/realm_flutter/example/lib/main.g.dart
+++ b/flutter/realm_flutter/example/lib/main.g.dart
@@ -52,6 +52,9 @@ class Car extends _Car with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<Car>> get changes =>
       RealmObject.getChanges<Car>(this);
 
+  @override
+  Car freeze() => RealmObject.freezeObject<Car>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -97,6 +100,9 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
       RealmObject.getChanges<Person>(this);
+
+  @override
+  Person freeze() => RealmObject.freezeObject<Person>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/generator/lib/src/realm_model_info.dart
+++ b/generator/lib/src/realm_model_info.dart
@@ -87,6 +87,10 @@ class RealmModelInfo {
       yield 'Stream<RealmObjectChanges<$name>> get changes => RealmObject.getChanges<$name>(this);';
       yield '';
 
+      yield '@override';
+      yield '$name freeze() => RealmObject.freezeObject<$name>(this);';
+      yield '';
+
       yield 'static SchemaObject get schema => _schema ??= _initSchema();';
       yield 'static SchemaObject? _schema;';
       yield 'static SchemaObject _initSchema() {';

--- a/generator/test/good_test.dart
+++ b/generator/test/good_test.dart
@@ -66,6 +66,9 @@ class MappedToo extends _MappedToo with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<MappedToo>> get changes =>
       RealmObject.getChanges<MappedToo>(this);
 
+  @override
+  MappedToo freeze() => RealmObject.freezeObject<MappedToo>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {

--- a/generator/test/good_test_data/all_types.expected
+++ b/generator/test/good_test_data/all_types.expected
@@ -27,6 +27,9 @@ class Foo extends _Foo with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<Foo>> get changes =>
       RealmObject.getChanges<Foo>(this);
 
+  @override
+  Foo freeze() => RealmObject.freezeObject<Foo>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -132,6 +135,9 @@ class Bar extends _Bar with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<Bar>> get changes =>
       RealmObject.getChanges<Bar>(this);
 
+  @override
+  Bar freeze() => RealmObject.freezeObject<Bar>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -205,6 +211,9 @@ class PrimitiveTypes extends _PrimitiveTypes with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<PrimitiveTypes>> get changes =>
       RealmObject.getChanges<PrimitiveTypes>(this);
+
+  @override
+  PrimitiveTypes freeze() => RealmObject.freezeObject<PrimitiveTypes>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/generator/test/good_test_data/list_initialization.expected
+++ b/generator/test/good_test_data/list_initialization.expected
@@ -19,6 +19,9 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Person>> get changes => RealmObject.getChanges<Person>(this);
 
+  @override
+  Person freeze() => RealmObject.freezeObject<Person>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {

--- a/generator/test/good_test_data/mapto.expected
+++ b/generator/test/good_test_data/mapto.expected
@@ -48,6 +48,9 @@ class Original extends $Original with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<Original>> get changes =>
       RealmObject.getChanges<Original>(this);
 
+  @override
+  Original freeze() => RealmObject.freezeObject<Original>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {

--- a/generator/test/good_test_data/optional_argument.expected
+++ b/generator/test/good_test_data/optional_argument.expected
@@ -19,6 +19,9 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Person>> get changes => RealmObject.getChanges<Person>(this);
 
+  @override
+  Person freeze() => RealmObject.freezeObject<Person>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {

--- a/generator/test/good_test_data/pinhole.expected
+++ b/generator/test/good_test_data/pinhole.expected
@@ -26,6 +26,9 @@ class Foo extends _Foo with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Foo>> get changes => RealmObject.getChanges<Foo>(this);
 
+  @override
+  Foo freeze() => RealmObject.freezeObject<Foo>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {

--- a/generator/test/good_test_data/primary_key.expected
+++ b/generator/test/good_test_data/primary_key.expected
@@ -20,6 +20,9 @@ class IntPK extends _IntPK with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<IntPK>> get changes =>
       RealmObject.getChanges<IntPK>(this);
 
+  @override
+  IntPK freeze() => RealmObject.freezeObject<IntPK>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -47,6 +50,9 @@ class NullableIntPK extends _NullableIntPK with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<NullableIntPK>> get changes =>
       RealmObject.getChanges<NullableIntPK>(this);
+
+  @override
+  NullableIntPK freeze() => RealmObject.freezeObject<NullableIntPK>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -77,6 +83,9 @@ class StringPK extends _StringPK with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<StringPK>> get changes =>
       RealmObject.getChanges<StringPK>(this);
 
+  @override
+  StringPK freeze() => RealmObject.freezeObject<StringPK>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -104,6 +113,9 @@ class NullableStringPK extends _NullableStringPK with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<NullableStringPK>> get changes =>
       RealmObject.getChanges<NullableStringPK>(this);
+
+  @override
+  NullableStringPK freeze() => RealmObject.freezeObject<NullableStringPK>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -134,6 +146,9 @@ class ObjectIdPK extends _ObjectIdPK with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<ObjectIdPK>> get changes =>
       RealmObject.getChanges<ObjectIdPK>(this);
 
+  @override
+  ObjectIdPK freeze() => RealmObject.freezeObject<ObjectIdPK>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -161,6 +176,9 @@ class NullableObjectIdPK extends _NullableObjectIdPK with RealmEntity, RealmObje
   @override
   Stream<RealmObjectChanges<NullableObjectIdPK>> get changes =>
       RealmObject.getChanges<NullableObjectIdPK>(this);
+
+  @override
+  NullableObjectIdPK freeze() => RealmObject.freezeObject<NullableObjectIdPK>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -191,6 +209,9 @@ class UuidPK extends _UuidPK with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<UuidPK>> get changes =>
       RealmObject.getChanges<UuidPK>(this);
 
+  @override
+  UuidPK freeze() => RealmObject.freezeObject<UuidPK>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -218,6 +239,9 @@ class NullableUuidPK extends _NullableUuidPK with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<NullableUuidPK>> get changes =>
       RealmObject.getChanges<NullableUuidPK>(this);
+
+  @override
+  NullableUuidPK freeze() => RealmObject.freezeObject<NullableUuidPK>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/generator/test/good_test_data/required_argument.expected
+++ b/generator/test/good_test_data/required_argument.expected
@@ -19,6 +19,9 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Person>> get changes => RealmObject.getChanges<Person>(this);
 
+  @override
+  Person freeze() => RealmObject.freezeObject<Person>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {

--- a/generator/test/good_test_data/required_argument_with_default_value.expected
+++ b/generator/test/good_test_data/required_argument_with_default_value.expected
@@ -26,6 +26,9 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Person>> get changes => RealmObject.getChanges<Person>(this);
 
+  @override
+  Person freeze() => RealmObject.freezeObject<Person>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {

--- a/generator/test/good_test_data/user_defined_getter.expected
+++ b/generator/test/good_test_data/user_defined_getter.expected
@@ -19,6 +19,9 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Person>> get changes => RealmObject.getChanges<Person>(this);
 
+  @override
+  Person freeze() => RealmObject.freezeObject<Person>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -106,8 +106,7 @@ class ManagedRealmList<T extends Object?> extends collection.ListBase<T> with Re
     }
 
     final frozenRealm = realm.freeze();
-    final frozenHandle = realmCore.resolveList(this, frozenRealm)!;
-    return ManagedRealmList._(frozenHandle, frozenRealm, _metadata);
+    return frozenRealm.resolveList(this)!;
   }
 }
 
@@ -190,6 +189,8 @@ extension RealmListInternal<T extends Object?> on RealmList<T> {
   ManagedRealmList<T> asManaged() => this is ManagedRealmList<T> ? this as ManagedRealmList<T> : throw RealmStateError('$this is not managed');
 
   RealmListHandle get handle => asManaged()._handle;
+
+  RealmObjectMetadata? get metadata => asManaged()._metadata;
 
   static RealmList<T> create<T extends Object?>(RealmListHandle handle, Realm realm, RealmObjectMetadata? metadata) => RealmList<T>._(handle, realm, metadata);
 

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -145,7 +145,7 @@ class UnmanagedRealmList<T extends Object?> extends collection.ListBase<T> with 
   bool get isValid => true;
 
   @override
-  RealmList<T> freeze() => throw RealmException("Unmanaged lists can't be frozen");
+  RealmList<T> freeze() => throw RealmStateError("Unmanaged lists can't be frozen");
 }
 
 // The query operations on lists, as well as the ability to subscribe for notifications,

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1768,6 +1768,18 @@ class _RealmCore {
       return null;
     });
   }
+
+  RealmListHandle? resolveList(ManagedRealmList list, Realm frozenRealm) {
+    return using((Arena arena) {
+      final resultPtr = arena<Pointer<realm_list>>();
+      _realmLib.invokeGetBool(() => _realmLib.realm_list_resolve_in(list.handle._pointer, frozenRealm.handle._pointer, resultPtr));
+      if (resultPtr != nullptr) {
+        return RealmListHandle._(resultPtr.value);
+      }
+
+      return null;
+    });
+  }
 }
 
 class LastError {

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1742,6 +1742,32 @@ class _RealmCore {
         "Delete user failed");
     return completer.future;
   }
+
+  bool isFrozen(Realm realm) {
+    return _realmLib.realm_is_frozen(realm.handle._pointer.cast());
+  }
+
+  RealmHandle freeze(Realm realm) {
+    final ptr = _realmLib.invokeGetPointer(() => _realmLib.realm_freeze(realm.handle._pointer));
+    return RealmHandle._(ptr);
+  }
+
+  RealmResultsHandle resolveResults(RealmResults realmResults, Realm frozenRealm) {
+    final ptr = _realmLib.invokeGetPointer(() => _realmLib.realm_results_resolve_in(realmResults.handle._pointer, frozenRealm.handle._pointer));
+    return RealmResultsHandle._(ptr);
+  }
+
+  RealmObjectHandle? resolveObject(RealmObject object, Realm frozenRealm) {
+    return using((Arena arena) {
+      final resultPtr = arena<Pointer<realm_object>>();
+      _realmLib.invokeGetBool(() => _realmLib.realm_object_resolve_in(object.handle._pointer, frozenRealm.handle._pointer, resultPtr));
+      if (resultPtr != nullptr) {
+        return RealmObjectHandle._(resultPtr.value);
+      }
+
+      return null;
+    });
+  }
 }
 
 class LastError {

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -302,14 +302,13 @@ class Realm implements Finalizable {
   ///
   /// A frozen Realm is an immutable snapshot view of a particular version of a
   /// Realm's data. Unlike normal [Realm] instances, it does not live-update to
-  /// reflect writes made to the Realm, and can be accessed from any thread. Writing
-  /// to a frozen Realm is not allowed, and attempting to begin a write transaction
-  /// will throw an exception.
+  /// reflect writes made to the Realm. Writing to a frozen Realm is not allowed,
+  /// and attempting to begin a write transaction will throw an exception.
   ///
   /// All objects and collections read from a frozen Realm will also be frozen.
   ///
-  /// Note: Keeping a large number of frozen Realms with different versions alive can have a negative impact on the filesize
-  /// of the underlying database.
+  /// Note: Keeping a large number of frozen Realms with different versions alive can
+  /// have a negative impact on the file size of the underlying database.
   Realm freeze() {
     if (isFrozen) {
       return this;
@@ -433,6 +432,14 @@ extension RealmInternal on Realm {
   RealmMetadata get metadata => _metadata;
 
   T? resolveObject<T extends RealmObject>(T object) {
+    if (!object.isManaged) {
+      throw RealmStateError("Can't resolve unmanaged objects");
+    }
+
+    if (!object.isValid) {
+      throw RealmStateError("Can't resolve invalidated (deleted) objects");
+    }
+
     final handle = realmCore.resolveObject(object, this);
     if (handle == null) {
       return null;

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -431,6 +431,31 @@ extension RealmInternal on Realm {
   }
 
   RealmMetadata get metadata => _metadata;
+
+  T? resolveObject<T extends RealmObject>(T object) {
+    final handle = realmCore.resolveObject(object, this);
+    if (handle == null) {
+      return null;
+    }
+
+    final metadata = (object.accessor as RealmCoreAccessor).metadata;
+
+    return RealmObjectInternal.create(T, this, handle, RealmCoreAccessor(metadata)) as T;
+  }
+
+  RealmList<T>? resolveList<T extends Object?>(ManagedRealmList<T> list) {
+    final handle = realmCore.resolveList(list, this);
+    if (handle == null) {
+      return null;
+    }
+
+    return createList<T>(handle, list.metadata);
+  }
+
+  RealmResults<T> resolveResults<T extends RealmObject>(RealmResults<T> results) {
+    final handle = realmCore.resolveResults(results, this);
+    return RealmResultsInternal.create<T>(handle, this, results.metadata);
+  }
 }
 
 /// @nodoc

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -198,8 +198,11 @@ mixin RealmEntity {
   /// The [Realm] instance this object belongs to.
   Realm get realm => _realm ?? (throw RealmStateError('$this not managed'));
 
-  /// True if the object belongs to a realm.
+  /// True if the object belongs to a [Realm].
   bool get isManaged => _realm != null;
+
+  /// True if the entity belongs to a frozen [Realm].
+  bool get isFrozen => _realm?.isFrozen == true;
 }
 
 extension RealmEntityInternal on RealmEntity {
@@ -256,6 +259,23 @@ mixin RealmObject on RealmEntity implements Finalizable {
     return true;
   }
 
+  static T freezeObject<T extends RealmObject>(T object) {
+    if (!object.isManaged) {
+      throw RealmError("Can't freeze unmanaged objects.");
+    }
+
+    if (object.isFrozen) {
+      return object;
+    }
+
+    final frozenRealm = object.realm.freeze();
+    final frozenHandle = realmCore.resolveObject(object, frozenRealm)!;
+
+    final metadata = (object.accessor as RealmCoreAccessor).metadata;
+
+    return RealmObjectInternal.create(T, frozenRealm, frozenHandle, RealmCoreAccessor(metadata)) as T;
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -285,6 +305,10 @@ mixin RealmObject on RealmEntity implements Finalizable {
       throw RealmStateError("Object is not managed");
     }
 
+    if (object.isFrozen) {
+      throw RealmStateError('Object is frozen and cannot emit changes.');
+    }
+
     final controller = RealmObjectNotificationsController<T>(object);
     return controller.createStream();
   }
@@ -295,7 +319,7 @@ mixin RealmObject on RealmEntity implements Finalizable {
   // is the approach used by the Flutter team as well: https://github.com/dart-lang/sdk/issues/28372.
   // If it turns out not to be reliable, we can instead construct symbols from the property names in
   // the Accessor metadata and compare symbols directly.
-  static final RegExp _symbolRegex = RegExp('Symbol\\("(?<symbolName>.*)"\\)');
+  static final RegExp _symbolRegex = RegExp('Symbol\\("(?<symbolName>.*?)=?"\\)');
 
   @override
   DartDynamic noSuchMethod(Invocation invocation) {
@@ -309,10 +333,22 @@ mixin RealmObject on RealmEntity implements Finalizable {
       return get(this, name);
     }
 
+    if (invocation.isSetter) {
+      final name = _symbolRegex.firstMatch(invocation.memberName.toString())?.namedGroup("symbolName");
+      if (name == null) {
+        throw RealmError(
+            "Could not find symbol name for ${invocation.memberName}. This is likely a bug in the Realm SDK - please file an issue at https://github.com/realm/realm-dart/issues");
+      }
+
+      return set(this, name, invocation.positionalArguments.single);
+    }
+
     return super.noSuchMethod(invocation);
   }
 
   late final DynamicRealmObject dynamic = DynamicRealmObject._(this);
+
+  RealmObject freeze() => freezeObject(this);
 }
 
 /// @nodoc
@@ -458,9 +494,9 @@ class DynamicRealmObject {
   /// Gets a list by the property name. If a generic type is specified, the property
   /// type will be validated against the type. Otherwise, a `List<Object>` will be
   /// returned.
-  List<T> getList<T extends Object?>(String name) {
+  RealmList<T> getList<T extends Object?>(String name) {
     _validatePropertyType<T>(name, RealmCollectionType.list);
-    return RealmObject.get<T>(_obj, name) as List<T>;
+    return RealmObject.get<T>(_obj, name) as RealmList<T>;
   }
 
   RealmPropertyMetadata? _validatePropertyType<T extends Object?>(String name, RealmCollectionType expectedCollectionType) {

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -346,8 +346,10 @@ mixin RealmObject on RealmEntity implements Finalizable {
     return super.noSuchMethod(invocation);
   }
 
+  /// An object exposing dynamic API for this [RealmObject] instance.
   late final DynamicRealmObject dynamic = DynamicRealmObject._(this);
 
+  /// Creates a frozen snapshot of this [RealmObject].
   RealmObject freeze() => freezeObject(this);
 }
 

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -270,11 +270,7 @@ mixin RealmObject on RealmEntity implements Finalizable {
     }
 
     final frozenRealm = object.realm.freeze();
-    final frozenHandle = realmCore.resolveObject(object, frozenRealm)!;
-
-    final metadata = (object.accessor as RealmCoreAccessor).metadata;
-
-    return RealmObjectInternal.create(T, frozenRealm, frozenHandle, RealmCoreAccessor(metadata)) as T;
+    return frozenRealm.resolveObject(object)!;
   }
 
   @override

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -259,9 +259,10 @@ mixin RealmObject on RealmEntity implements Finalizable {
     return true;
   }
 
+  /// @nodoc
   static T freezeObject<T extends RealmObject>(T object) {
     if (!object.isManaged) {
-      throw RealmError("Can't freeze unmanaged objects.");
+      throw RealmStateError("Can't freeze unmanaged objects.");
     }
 
     if (object.isFrozen) {

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -265,6 +265,10 @@ mixin RealmObject on RealmEntity implements Finalizable {
       throw RealmStateError("Can't freeze unmanaged objects.");
     }
 
+    if (!object.isValid) {
+      throw RealmStateError("Can't freeze invalidated (deleted) objects.");
+    }
+
     if (object.isFrozen) {
       return object;
     }

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -80,6 +80,10 @@ class RealmResults<T extends RealmObject> extends collection.IterableBase<T> imp
 
   /// Allows listening for changes when the contents of this collection changes.
   Stream<RealmResultsChanges<T>> get changes {
+    if (isFrozen) {
+      throw RealmStateError('Results are frozen and cannot emit changes');
+    }
+
     final controller = ResultsNotificationsController<T>(this);
     return controller.createStream();
   }

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -23,7 +23,7 @@ import 'dart:ffi';
 import 'collections.dart';
 import 'native/realm_core.dart';
 import 'realm_class.dart';
-import 'realm_object.dart' show RealmObjectMetadata, RealmEntityInternal;
+import 'realm_object.dart';
 
 /// Instances of this class are live collections and will update as new elements are either
 /// added to or deleted from the Realm that match the underlying query.

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -36,6 +36,10 @@ class RealmResults<T extends RealmObject> extends collection.IterableBase<T> imp
   /// The Realm instance this collection belongs to.
   final Realm realm;
 
+  /// Gets a value indicating whether this [Realm] is frozen. Frozen Realms are immutable
+  /// and will not update when writes are made to the database.
+  bool get isFrozen => realm.isFrozen;
+
   final _supportsSnapshot = <T>[] is List<RealmObject?>;
 
   RealmResults._(this._handle, this.realm, this._metadata);
@@ -78,6 +82,17 @@ class RealmResults<T extends RealmObject> extends collection.IterableBase<T> imp
   Stream<RealmResultsChanges<T>> get changes {
     final controller = ResultsNotificationsController<T>(this);
     return controller.createStream();
+  }
+
+  /// Creates a frozen snapshot of this query.
+  RealmResults<T> freeze() {
+    if (isFrozen) {
+      return this;
+    }
+
+    final frozenRealm = realm.freeze();
+    final frozenHandle = realmCore.resolveResults(this, frozenRealm);
+    return RealmResults._(frozenHandle, frozenRealm, _metadata);
   }
 }
 

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -400,4 +400,25 @@ Future<void> main([List<String>? args]) async {
 
     expect(() => frozenPlayers.changes, throws<RealmStateError>('List is frozen and cannot emit changes'));
   });
+
+  test('UnmanagedList.freeze throws', () {
+    final team = Team('team');
+
+    expect(() => team.players.freeze(), throws<RealmStateError>("Unmanaged lists can't be frozen"));
+  });
+
+  test('List.freeze when frozen returns same object', () {
+    final config = Configuration.local([Team.schema, Person.schema]);
+    final realm = getRealm(config);
+
+    final team = realm.write(() => realm.add(Team('Barcelona', players: [Person('Peter')])));
+
+    final frozenPlayers = team.players.freeze();
+    final deepFrozenPlayers = frozenPlayers.freeze();
+
+    expect(identical(frozenPlayers, deepFrozenPlayers), true);
+
+    final frozenPlayersAgain = team.players.freeze();
+    expect(identical(frozenPlayers, frozenPlayersAgain), false);
+  });
 }

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -370,7 +370,7 @@ Future<void> main([List<String>? args]) async {
       return realm.add(Team('team', players: [Person('Peter')], scores: [123]));
     }).players;
 
-    final frozenPlayers = livePlayers.freeze();
+    final frozenPlayers = freezeList(livePlayers);
 
     expect(frozenPlayers.length, 1);
     expect(frozenPlayers.isFrozen, true);
@@ -396,7 +396,7 @@ Future<void> main([List<String>? args]) async {
       realm.add(Team('team'));
     });
 
-    final frozenPlayers = realm.all<Team>().single.players.freeze();
+    final frozenPlayers = freezeList(realm.all<Team>().single.players);
 
     expect(() => frozenPlayers.changes, throws<RealmStateError>('List is frozen and cannot emit changes'));
   });
@@ -404,7 +404,7 @@ Future<void> main([List<String>? args]) async {
   test('UnmanagedList.freeze throws', () {
     final team = Team('team');
 
-    expect(() => team.players.freeze(), throws<RealmStateError>("Unmanaged lists can't be frozen"));
+    expect(() => freezeList(team.players), throws<RealmStateError>("Unmanaged lists can't be frozen"));
   });
 
   test('List.freeze when frozen returns same object', () {
@@ -413,12 +413,12 @@ Future<void> main([List<String>? args]) async {
 
     final team = realm.write(() => realm.add(Team('Barcelona', players: [Person('Peter')])));
 
-    final frozenPlayers = team.players.freeze();
-    final deepFrozenPlayers = frozenPlayers.freeze();
+    final frozenPlayers = freezeList(team.players);
+    final deepFrozenPlayers = freezeList(frozenPlayers);
 
     expect(identical(frozenPlayers, deepFrozenPlayers), true);
 
-    final frozenPlayersAgain = team.players.freeze();
+    final frozenPlayersAgain = freezeList(team.players);
     expect(identical(frozenPlayers, frozenPlayersAgain), false);
   });
 }

--- a/test/realm_object_test.dart
+++ b/test/realm_object_test.dart
@@ -670,4 +670,24 @@ Future<void> main([List<String>? args]) async {
 
     expect(frozenPeter.name, 'Peter');
   });
+
+  test('RealmObject.freeze when unmanaged throws', () {
+    final person = Person('Peter');
+    expect(() => person.freeze(), throws<RealmStateError>("Can't freeze unmanaged objects"));
+  });
+
+  test('RealmObject.freeze when frozen returns same object', () {
+    final config = Configuration.local([Person.schema]);
+    final realm = getRealm(config);
+
+    final liveObject = realm.write(() => realm.add(Person('Peter')));
+
+    final frozenObject = liveObject.freeze();
+    final deepFrozenObject = frozenObject.freeze();
+
+    expect(identical(frozenObject, deepFrozenObject), true);
+
+    final anotherFrozenObject = liveObject.freeze();
+    expect(identical(frozenObject, anotherFrozenObject), false);
+  });
 }

--- a/test/realm_object_test.dart
+++ b/test/realm_object_test.dart
@@ -614,6 +614,7 @@ Future<void> main([List<String>? args]) async {
 
     expect(frozenTeam.isFrozen, true);
     expect(frozenTeam.realm.isFrozen, true);
+    expect(frozenTeam.players.isFrozen, true);
     expect(frozenTeam.players.single.isFrozen, true);
 
     realm.write(() {

--- a/test/realm_object_test.dart
+++ b/test/realm_object_test.dart
@@ -610,7 +610,7 @@ Future<void> main([List<String>? args]) async {
     final liveTeam = realm.write(() {
       return realm.add(Team('team', players: [Person('Peter')], scores: [123]));
     });
-    final frozenTeam = liveTeam.freeze();
+    final frozenTeam = freezeObject(liveTeam);
 
     expect(frozenTeam.isFrozen, true);
     expect(frozenTeam.realm.isFrozen, true);
@@ -629,7 +629,7 @@ Future<void> main([List<String>? args]) async {
     final realm = getRealm(config);
 
     final peter = realm.write(() => realm.add(Person('Peter')));
-    final frozenPeter = peter.freeze();
+    final frozenPeter = freezeObject(peter);
 
     expect(() => frozenPeter.changes, throws<RealmStateError>('Object is frozen and cannot emit changes'));
   });
@@ -643,7 +643,7 @@ Future<void> main([List<String>? args]) async {
       return realm.add(Team('team', players: [Person('Peter')], scores: [123]));
     });
 
-    final frozenTeam = liveTeam.freeze();
+    final frozenTeam = freezeObject(liveTeam);
     expect(frozenTeam.runtimeType, Team);
 
     final frozenPlayers = frozenTeam.dynamic.getList<RealmObject>('players');
@@ -659,7 +659,7 @@ Future<void> main([List<String>? args]) async {
     realm.write(() => realm.add(Person('Peter')));
 
     dynamic peter = realm.dynamic.all('Person').single;
-    dynamic frozenPeter = peter.freeze();
+    dynamic frozenPeter = freezeDynamic(peter);
     expect(frozenPeter.runtimeType.toString(), '_ConcreteRealmObject');
     expect(frozenPeter.isFrozen, true);
     expect(frozenPeter.name, 'Peter');
@@ -673,7 +673,7 @@ Future<void> main([List<String>? args]) async {
 
   test('RealmObject.freeze when unmanaged throws', () {
     final person = Person('Peter');
-    expect(() => person.freeze(), throws<RealmStateError>("Can't freeze unmanaged objects"));
+    expect(() => freezeObject(person), throws<RealmStateError>("Can't freeze unmanaged objects"));
   });
 
   test('RealmObject.freeze when frozen returns same object', () {
@@ -682,12 +682,12 @@ Future<void> main([List<String>? args]) async {
 
     final liveObject = realm.write(() => realm.add(Person('Peter')));
 
-    final frozenObject = liveObject.freeze();
-    final deepFrozenObject = frozenObject.freeze();
+    final frozenObject = freezeObject(liveObject);
+    final deepFrozenObject = freezeObject(frozenObject);
 
     expect(identical(frozenObject, deepFrozenObject), true);
 
-    final anotherFrozenObject = liveObject.freeze();
+    final anotherFrozenObject = freezeObject(liveObject);
     expect(identical(frozenObject, anotherFrozenObject), false);
   });
 }

--- a/test/realm_object_test.dart
+++ b/test/realm_object_test.dart
@@ -564,7 +564,7 @@ Future<void> main([List<String>? args]) async {
   test('get/set all property types', () {
     final config = Configuration.local([AllTypes.schema]);
     final realm = getRealm(config);
-    
+
     var date = DateTime.now().toUtc();
     var objectId = ObjectId();
     var uuid = Uuid.v4();
@@ -601,5 +601,73 @@ Future<void> main([List<String>? args]) async {
     expect(object.objectIdProp, objectId);
     expect(object.uuidProp, uuid);
     expect(object.intProp, 5);
+  });
+
+  test('RealmObject.freeze when typed returns typed frozen object', () {
+    final config = Configuration.local([Person.schema, Team.schema]);
+    final realm = getRealm(config);
+
+    final liveTeam = realm.write(() {
+      return realm.add(Team('team', players: [Person('Peter')], scores: [123]));
+    });
+    final frozenTeam = liveTeam.freeze();
+
+    expect(frozenTeam.isFrozen, true);
+    expect(frozenTeam.realm.isFrozen, true);
+    expect(frozenTeam.players.single.isFrozen, true);
+
+    realm.write(() {
+      liveTeam.players.add(Person('George'));
+    });
+
+    expect(frozenTeam.players.length, 1);
+    expect(liveTeam.players.length, 2);
+  });
+
+  test('FrozenObject.changes throws', () {
+    final config = Configuration.local([Person.schema]);
+    final realm = getRealm(config);
+
+    final peter = realm.write(() => realm.add(Person('Peter')));
+    final frozenPeter = peter.freeze();
+
+    expect(() => frozenPeter.changes, throws<RealmStateError>('Object is frozen and cannot emit changes'));
+  });
+
+  test('RealmObject.freeze when generic returns generic frozen object', () {
+    final config = Configuration.local([Person.schema, Team.schema]);
+    final realm = getRealm(config);
+
+    // Cast to the base type to ensure we're not using the generated freeze() method.
+    RealmObject liveTeam = realm.write(() {
+      return realm.add(Team('team', players: [Person('Peter')], scores: [123]));
+    });
+
+    final frozenTeam = liveTeam.freeze();
+    expect(frozenTeam.runtimeType, Team);
+
+    final frozenPlayers = frozenTeam.dynamic.getList<RealmObject>('players');
+    expect(frozenPlayers.isFrozen, true);
+    expect(frozenPlayers.single.isFrozen, true);
+    expect(frozenTeam.dynamic.get('name'), 'team');
+  });
+
+  test('RealmObject.freeze when dynamic works', () {
+    final config = Configuration.local([Person.schema]);
+    final realm = getRealm(config);
+
+    realm.write(() => realm.add(Person('Peter')));
+
+    dynamic peter = realm.dynamic.all('Person').single;
+    dynamic frozenPeter = peter.freeze();
+    expect(frozenPeter.runtimeType.toString(), '_ConcreteRealmObject');
+    expect(frozenPeter.isFrozen, true);
+    expect(frozenPeter.name, 'Peter');
+
+    realm.write(() {
+      peter.name = 'Peter II';
+    });
+
+    expect(frozenPeter.name, 'Peter');
   });
 }

--- a/test/realm_object_test.g.dart
+++ b/test/realm_object_test.g.dart
@@ -25,6 +25,10 @@ class ObjectIdPrimaryKey extends _ObjectIdPrimaryKey
   Stream<RealmObjectChanges<ObjectIdPrimaryKey>> get changes =>
       RealmObject.getChanges<ObjectIdPrimaryKey>(this);
 
+  @override
+  ObjectIdPrimaryKey freeze() =>
+      RealmObject.freezeObject<ObjectIdPrimaryKey>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -53,6 +57,10 @@ class NullableObjectIdPrimaryKey extends _NullableObjectIdPrimaryKey
   @override
   Stream<RealmObjectChanges<NullableObjectIdPrimaryKey>> get changes =>
       RealmObject.getChanges<NullableObjectIdPrimaryKey>(this);
+
+  @override
+  NullableObjectIdPrimaryKey freeze() =>
+      RealmObject.freezeObject<NullableObjectIdPrimaryKey>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -84,6 +92,9 @@ class IntPrimaryKey extends _IntPrimaryKey with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<IntPrimaryKey>> get changes =>
       RealmObject.getChanges<IntPrimaryKey>(this);
 
+  @override
+  IntPrimaryKey freeze() => RealmObject.freezeObject<IntPrimaryKey>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -112,6 +123,10 @@ class NullableIntPrimaryKey extends _NullableIntPrimaryKey
   @override
   Stream<RealmObjectChanges<NullableIntPrimaryKey>> get changes =>
       RealmObject.getChanges<NullableIntPrimaryKey>(this);
+
+  @override
+  NullableIntPrimaryKey freeze() =>
+      RealmObject.freezeObject<NullableIntPrimaryKey>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -142,6 +157,9 @@ class StringPrimaryKey extends _StringPrimaryKey with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<StringPrimaryKey>> get changes =>
       RealmObject.getChanges<StringPrimaryKey>(this);
 
+  @override
+  StringPrimaryKey freeze() => RealmObject.freezeObject<StringPrimaryKey>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -170,6 +188,10 @@ class NullableStringPrimaryKey extends _NullableStringPrimaryKey
   @override
   Stream<RealmObjectChanges<NullableStringPrimaryKey>> get changes =>
       RealmObject.getChanges<NullableStringPrimaryKey>(this);
+
+  @override
+  NullableStringPrimaryKey freeze() =>
+      RealmObject.freezeObject<NullableStringPrimaryKey>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -201,6 +223,9 @@ class UuidPrimaryKey extends _UuidPrimaryKey with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<UuidPrimaryKey>> get changes =>
       RealmObject.getChanges<UuidPrimaryKey>(this);
 
+  @override
+  UuidPrimaryKey freeze() => RealmObject.freezeObject<UuidPrimaryKey>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -229,6 +254,10 @@ class NullableUuidPrimaryKey extends _NullableUuidPrimaryKey
   @override
   Stream<RealmObjectChanges<NullableUuidPrimaryKey>> get changes =>
       RealmObject.getChanges<NullableUuidPrimaryKey>(this);
+
+  @override
+  NullableUuidPrimaryKey freeze() =>
+      RealmObject.freezeObject<NullableUuidPrimaryKey>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -263,6 +292,10 @@ class RemappedFromAnotherFile extends _RemappedFromAnotherFile
   @override
   Stream<RealmObjectChanges<RemappedFromAnotherFile>> get changes =>
       RealmObject.getChanges<RemappedFromAnotherFile>(this);
+
+  @override
+  RemappedFromAnotherFile freeze() =>
+      RealmObject.freezeObject<RemappedFromAnotherFile>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -301,6 +334,9 @@ class BoolValue extends _BoolValue with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<BoolValue>> get changes =>
       RealmObject.getChanges<BoolValue>(this);
+
+  @override
+  BoolValue freeze() => RealmObject.freezeObject<BoolValue>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/test/results_test.dart
+++ b/test/results_test.dart
@@ -18,8 +18,6 @@
 
 // ignore_for_file: unused_local_variable
 
-import 'dart:math';
-
 import 'package:test/test.dart' hide test, throws;
 import '../lib/realm.dart';
 import 'test.dart';
@@ -486,5 +484,14 @@ Future<void> main([List<String>? args]) async {
     expect(livePeople.first.name, 'Peter II');
     expect(frozenPeople.length, 1);
     expect(frozenPeople.single.name, 'Peter');
+  });
+
+  test("FrozenResults.changes throws", () {
+    final config = Configuration.local([Person.schema]);
+    final realm = getRealm(config);
+
+    final frozenPeople = realm.all<Person>().freeze();
+
+    expect(() => frozenPeople.changes, throws<RealmStateError>('Results are frozen and cannot emit changes'));
   });
 }

--- a/test/results_test.dart
+++ b/test/results_test.dart
@@ -494,4 +494,19 @@ Future<void> main([List<String>? args]) async {
 
     expect(() => frozenPeople.changes, throws<RealmStateError>('Results are frozen and cannot emit changes'));
   });
+
+  test('Results.freeze when frozen returns same object', () {
+    final config = Configuration.local([Person.schema]);
+    final realm = getRealm(config);
+
+    final people = realm.all<Person>();
+
+    final frozenPeople = people.freeze();
+    final deepFrozenPeople = frozenPeople.freeze();
+
+    expect(identical(frozenPeople, deepFrozenPeople), true);
+
+    final frozenPeopleAgain = people.freeze();
+    expect(identical(frozenPeople, frozenPeopleAgain), false);
+  });
 }

--- a/test/results_test.dart
+++ b/test/results_test.dart
@@ -468,7 +468,7 @@ Future<void> main([List<String>? args]) async {
     });
 
     final livePeople = realm.all<Person>();
-    final frozenPeople = livePeople.freeze();
+    final frozenPeople = freezeResults(livePeople);
 
     expect(frozenPeople.length, 1);
     expect(frozenPeople.isFrozen, true);
@@ -490,7 +490,7 @@ Future<void> main([List<String>? args]) async {
     final config = Configuration.local([Person.schema]);
     final realm = getRealm(config);
 
-    final frozenPeople = realm.all<Person>().freeze();
+    final frozenPeople = freezeResults(realm.all<Person>());
 
     expect(() => frozenPeople.changes, throws<RealmStateError>('Results are frozen and cannot emit changes'));
   });
@@ -501,12 +501,12 @@ Future<void> main([List<String>? args]) async {
 
     final people = realm.all<Person>();
 
-    final frozenPeople = people.freeze();
-    final deepFrozenPeople = frozenPeople.freeze();
+    final frozenPeople = freezeResults(people);
+    final deepFrozenPeople = freezeResults(frozenPeople);
 
     expect(identical(frozenPeople, deepFrozenPeople), true);
 
-    final frozenPeopleAgain = people.freeze();
+    final frozenPeopleAgain = freezeResults(people);
     expect(identical(frozenPeople, frozenPeopleAgain), false);
   });
 }

--- a/test/test.dart
+++ b/test/test.dart
@@ -303,6 +303,46 @@ Realm getRealm(Configuration config) {
   return realm;
 }
 
+/// This is needed to make sure the frozen Realm gets forcefully closed by the
+/// time the test ends.
+Realm freezeRealm(Realm realm) {
+  final frozen = realm.freeze();
+  _openRealms.add(frozen);
+  return frozen;
+}
+
+/// This is needed to make sure the frozen Realm gets forcefully closed by the
+/// time the test ends.
+RealmResults<T> freezeResults<T extends RealmObject>(RealmResults<T> results) {
+  final frozen = results.freeze();
+  _openRealms.add(frozen.realm);
+  return frozen;
+}
+
+/// This is needed to make sure the frozen Realm gets forcefully closed by the
+/// time the test ends.
+RealmList<T> freezeList<T>(RealmList<T> list) {
+  final frozen = list.freeze();
+  _openRealms.add(frozen.realm);
+  return frozen;
+}
+
+/// This is needed to make sure the frozen Realm gets forcefully closed by the
+/// time the test ends.
+T freezeObject<T extends RealmObject>(T object) {
+  final frozen = object.freeze();
+  _openRealms.add(frozen.realm);
+  return frozen as T;
+}
+
+/// This is needed to make sure the frozen Realm gets forcefully closed by the
+/// time the test ends.
+dynamic freezeDynamic(dynamic object) {
+  dynamic frozen = object.freeze();
+  _openRealms.add(frozen.realm as Realm);
+  return frozen;
+}
+
 Future<void> tryDeleteRealm(String path) async {
   //Skip on CI to speed it up. We are creating the realms in $TEMP anyways.
   if (Platform.environment.containsKey("REALM_CI")) {

--- a/test/test.g.dart
+++ b/test/test.g.dart
@@ -24,6 +24,9 @@ class Car extends _Car with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<Car>> get changes =>
       RealmObject.getChanges<Car>(this);
 
+  @override
+  Car freeze() => RealmObject.freezeObject<Car>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -51,6 +54,9 @@ class Person extends _Person with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
       RealmObject.getChanges<Person>(this);
+
+  @override
+  Person freeze() => RealmObject.freezeObject<Person>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -93,6 +99,9 @@ class Dog extends _Dog with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Dog>> get changes =>
       RealmObject.getChanges<Dog>(this);
+
+  @override
+  Dog freeze() => RealmObject.freezeObject<Dog>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -143,6 +152,9 @@ class Team extends _Team with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Team>> get changes =>
       RealmObject.getChanges<Team>(this);
+
+  @override
+  Team freeze() => RealmObject.freezeObject<Team>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -196,6 +208,9 @@ class Student extends _Student with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Student>> get changes =>
       RealmObject.getChanges<Student>(this);
+
+  @override
+  Student freeze() => RealmObject.freezeObject<Student>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -265,6 +280,9 @@ class School extends _School with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<School>> get changes =>
       RealmObject.getChanges<School>(this);
 
+  @override
+  School freeze() => RealmObject.freezeObject<School>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -313,6 +331,9 @@ class RemappedClass extends $RemappedClass with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<RemappedClass>> get changes =>
       RealmObject.getChanges<RemappedClass>(this);
 
+  @override
+  RemappedClass freeze() => RealmObject.freezeObject<RemappedClass>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -345,6 +366,9 @@ class Task extends _Task with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Task>> get changes =>
       RealmObject.getChanges<Task>(this);
+
+  @override
+  Task freeze() => RealmObject.freezeObject<Task>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -383,6 +407,9 @@ class Schedule extends _Schedule with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Schedule>> get changes =>
       RealmObject.getChanges<Schedule>(this);
+
+  @override
+  Schedule freeze() => RealmObject.freezeObject<Schedule>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -525,6 +552,9 @@ class AllTypes extends _AllTypes with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<AllTypes>> get changes =>
       RealmObject.getChanges<AllTypes>(this);
 
+  @override
+  AllTypes freeze() => RealmObject.freezeObject<AllTypes>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -589,6 +619,9 @@ class LinksClass extends _LinksClass with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<LinksClass>> get changes =>
       RealmObject.getChanges<LinksClass>(this);
+
+  @override
+  LinksClass freeze() => RealmObject.freezeObject<LinksClass>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -680,6 +713,9 @@ class AllCollections extends _AllCollections with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<AllCollections>> get changes =>
       RealmObject.getChanges<AllCollections>(this);
+
+  @override
+  AllCollections freeze() => RealmObject.freezeObject<AllCollections>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -785,6 +821,9 @@ class NullableTypes extends _NullableTypes with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<NullableTypes>> get changes =>
       RealmObject.getChanges<NullableTypes>(this);
 
+  @override
+  NullableTypes freeze() => RealmObject.freezeObject<NullableTypes>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -857,6 +896,9 @@ class Event extends _Event with RealmEntity, RealmObject {
   Stream<RealmObjectChanges<Event>> get changes =>
       RealmObject.getChanges<Event>(this);
 
+  @override
+  Event freeze() => RealmObject.freezeObject<Event>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -917,6 +959,9 @@ class Party extends _Party with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Party>> get changes =>
       RealmObject.getChanges<Party>(this);
+
+  @override
+  Party freeze() => RealmObject.freezeObject<Party>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
@@ -984,6 +1029,9 @@ class Friend extends _Friend with RealmEntity, RealmObject {
   @override
   Stream<RealmObjectChanges<Friend>> get changes =>
       RealmObject.getChanges<Friend>(this);
+
+  @override
+  Friend freeze() => RealmObject.freezeObject<Friend>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;


### PR DESCRIPTION
Adds support for freezing Realms and entities:

```dart
final liveRealm = Realm(Configuration.local([...]));

final frozenRealm = liveRealm.freeze();
expect(frozenRealm.isFrozen, true);

final frozenResults = liveRealm.all<Foo>().freeze();
expect(frozenResults.isFrozen, true);

final frozenObject = liveRealm.find<Foo>(123).freeze();
expect(frozenObject.isFrozen, true);

final frozenList = liveRealm.find<Foo>(123).bars.freeze();
expect(frozenList.isFrozen, true);
```

Fixes https://github.com/realm/realm-dart/issues/56
Fixes https://github.com/realm/realm-dart/issues/54
Fixes https://github.com/realm/realm-dart/issues/55
Fixes https://github.com/realm/realm-dart/issues/808
Fixes https://github.com/realm/realm-dart/issues/807
Fixes https://github.com/realm/realm-dart/issues/806