### PR TITLE
Validate dynamic library version on Startup

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Update realm_dart.cpp (realm_dart_library_version)
         uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
         with:
-          find: 'RLM_API const char\* realm_dart_library_version() { return "[^"]*"; }'
+          find: 'RLM_API const char\* realm_dart_library_version\(\) \{ return "[^"]*"; \}'
           replace: 'RLM_API const char* realm_dart_library_version() { return "${{ steps.update-changelog.outputs.new-version }}"; }'
           include: '**realm_dart.cpp'
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -39,9 +39,16 @@ jobs:
         id: update-library-version
         uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
         with:
-          find: "  String get libraryVersion => '[^']*';"
-          replace: "  String get libraryVersion => '${{ steps.update-changelog.outputs.new-version }}';"
+          find: "static const libraryVersion = '[^']*';"
+          replace: "static const libraryVersion = '${{ steps.update-changelog.outputs.new-version }}';"
           include: '**realm_core.dart'
+
+      - name: Update realm_dart.cpp (realm_dart_library_version)
+        uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
+        with:
+          find: 'RLM_API const char\* realm_dart_library_version() { return "[^"]*"; }'
+          replace: 'RLM_API const char* realm_dart_library_version() { return "${{ steps.update-changelog.outputs.new-version }}"; }'
+          include: '**realm_dart.cpp'
 
       - name: Make sure we updated libraryVersion
         run: |

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-import 'cli/metrics/metrics_command.dart';
-import 'cli/metrics/options.dart';
-import 'cli/common/target_os_type.dart';
-
 import '../realm.dart' as realm show isFlutterPlatform;
 import '../realm.dart' show realmBinaryName;
+import 'cli/common/target_os_type.dart';
+import 'cli/metrics/metrics_command.dart';
+import 'cli/metrics/options.dart';
+import 'native/realm_core.dart';
 
 DynamicLibrary? _library;
 

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3181,6 +3181,16 @@ class RealmLibrary {
       _realm_dart_initializeDartApiDLPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
+  ffi.Pointer<ffi.Char> realm_dart_library_version() {
+    return _realm_dart_library_version();
+  }
+
+  late final _realm_dart_library_versionPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
+          'realm_dart_library_version');
+  late final _realm_dart_library_version = _realm_dart_library_versionPtr
+      .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
   ffi.Pointer<ffi.Void> realm_dart_object_to_persistent_handle(
     Object handle,
   ) {
@@ -9700,6 +9710,8 @@ class _SymbolAddresses {
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
       get realm_dart_initializeDartApiDL =>
           _library._realm_dart_initializeDartApiDLPtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>
+      get realm_dart_library_version => _library._realm_dart_library_versionPtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function(ffi.Handle)>>
       get realm_dart_object_to_persistent_handle =>
           _library._realm_dart_object_to_persistent_handlePtr;

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -64,13 +64,18 @@ class _RealmCore {
   _RealmCore._() {
     final lib = initRealm();
     _realmLib = RealmLibrary(lib);
+    if (libraryVersion != nativeLibraryVersion) {
+      throw RealmException('Dart package version does not match dynamically loaded native library version ($libraryVersion != $nativeLibraryVersion)');
+    }
   }
 
   factory _RealmCore() {
     return _instance ??= _RealmCore._();
   }
 
-  String get libraryVersion => '0.4.0+beta';
+  // stamped into the library by the build system (see prepare-release.yml)
+  static const libraryVersion = '0.4.0+beta';
+  late String nativeLibraryVersion = _realmLib.realm_dart_library_version().cast<Utf8>().toDartString();
 
   LastError? getLastError(Allocator allocator) {
     final error = allocator<realm_error_t>();

--- a/src/realm_dart.cpp
+++ b/src/realm_dart.cpp
@@ -86,3 +86,6 @@ RLM_API void realm_dart_userdata_async_free(void* userdata)
         delete async_userdata;
     });
 }
+
+// stamped into the library by the build system (see prepare-release.yml)
+RLM_API const char* realm_dart_library_version() { return "0.4.0+beta"; }

--- a/src/realm_dart.h
+++ b/src/realm_dart.h
@@ -39,4 +39,6 @@ typedef struct realm_dart_userdata_async* realm_dart_userdata_async_t;
 RLM_API realm_dart_userdata_async_t realm_dart_userdata_async_new(Dart_Handle handle, void* callback, realm_scheduler_t* scheduler);
 RLM_API void realm_dart_userdata_async_free(void* userdata);
 
+RLM_API const char* realm_dart_library_version();
+
 #endif // REALM_DART_H


### PR DESCRIPTION
Stamps library version into both dart and native code when preparing
release.

Compare the version when opening the library and throw a descriptive
exception if they don't match.
