### PR TITLE
Add support for embedded objects

### DIFF
--- a/common/lib/src/realm_common_base.dart
+++ b/common/lib/src/realm_common_base.dart
@@ -16,12 +16,37 @@
 //
 // //////////////////////////////////////////////////////////////////////////////
 
+/// An enum controlling the base type for a [RealmModel].
+///
+/// {@category Annotations}
+enum ObjectType {
+  /// A standalone top-level object that can be persisted in Realm. It can link
+  /// to other objects or collections of other objects.
+  topLevel('RealmObject'),
+
+  /// An object that can be embedded in other objects. It is considered owned
+  /// by its parent and will be deleted if its parent is deleted.
+  embedded('EmbeddedObject'),
+
+  /// A special type of object used to facilitate unidirectional synchronization
+  /// with Atlas App Services. It is used to push data to Realm without the ability
+  /// to query or modify it.
+  asymmetric('AsymmetricObject');
+
+  const ObjectType([this.className = 'Unknown']);
+
+  /// The name of the base class exposed by the Realm SDK.
+  final String className;
+}
 
 /// Annotation class used to define `Realm` data model classes and their properties
 ///
 /// {@category Annotations}
 class RealmModel {
-  const RealmModel();
+  /// The type of the base class for this model.
+  final ObjectType type;
+
+  const RealmModel({this.type = ObjectType.topLevel});
 }
 
 /// MapTo annotation for class member level.
@@ -36,7 +61,7 @@ class MapTo {
 }
 
 /// Indicates a primary key property.
-/// 
+///
 /// It enables quick lookup of objects and enforces uniqueness of the values stored.
 /// It may only be applied to a single property in a [RealmModel] class.
 /// Only [String] and [int] can be used as primary keys.
@@ -47,8 +72,8 @@ class PrimaryKey {
   const PrimaryKey();
 }
 
-/// Indicates an indexed property. 
-/// 
+/// Indicates an indexed property.
+///
 /// Indexed properties slightly slow down insertions but can greatly speed up queries.
 ///
 /// {@category Annotations}
@@ -57,7 +82,7 @@ class Indexed {
 }
 
 /// Indicates an ignored property.
-/// 
+///
 /// Ignored properties will not be persisted in the `Realm`.
 ///
 /// {@category Annotations}

--- a/common/lib/src/realm_common_base.dart
+++ b/common/lib/src/realm_common_base.dart
@@ -31,7 +31,7 @@ enum ObjectType {
   /// A special type of object used to facilitate unidirectional synchronization
   /// with Atlas App Services. It is used to push data to Realm without the ability
   /// to query or modify it.
-  asymmetric('AsymmetricObject');
+  _asymmetric('AsymmetricObject');
 
   const ObjectType([this.className = 'Unknown']);
 

--- a/common/lib/src/realm_common_base.dart
+++ b/common/lib/src/realm_common_base.dart
@@ -46,7 +46,7 @@ class RealmModel {
   /// The type of the base class for this model.
   final ObjectType type;
 
-  const RealmModel({this.type = ObjectType.topLevel});
+  const RealmModel([this.type = ObjectType.topLevel]);
 }
 
 /// MapTo annotation for class member level.

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -23,10 +23,10 @@ import 'package:sane_uuid/uuid.dart';
 
 /// @nodoc
 abstract class RealmAccessorMarker {
-  T getValue<T>(RealmObjectMarker object, String propertyName);
-  T? getObject<T>(RealmObjectMarker object, String propertyName);
-  List<T> getList<T>(RealmObjectMarker object, String propertyName);
-  void set<T>(RealmObjectMarker object, String propertyName, T value, {bool isDefault = false, bool update = false});
+  T getValue<T>(RealmObjectBaseMarker object, String propertyName);
+  T? getObject<T>(RealmObjectBaseMarker object, String propertyName);
+  List<T> getList<T>(RealmObjectBaseMarker object, String propertyName);
+  void set<T>(RealmObjectBaseMarker object, String propertyName, T value, {bool isDefault = false, bool update = false});
 }
 
 Type _typeOf<T>() => T; // TODO(kasper): Replace with public version once realm_common contains all
@@ -44,11 +44,11 @@ class Mapping<T> {
   Type get listOfNullablesType => List<T?>;
 
   // Factories
-  T? getObject(RealmAccessorMarker accessor, RealmObjectMarker object, String propertyName) => accessor.getObject<T>(object, propertyName);
-  T getValue(RealmAccessorMarker accessor, RealmObjectMarker object, String propertyName) => accessor.getValue<T>(object, propertyName);
-  T? getNullableValue(RealmAccessorMarker accessor, RealmObjectMarker object, String propertyName) => accessor.getValue<T?>(object, propertyName);
-  List<T> getList(RealmAccessorMarker accessor, RealmObjectMarker object, String propertyName) => accessor.getList<T>(object, propertyName);
-  List<T?> getListOfNullables(RealmAccessorMarker accessor, RealmObjectMarker object, String propertyName) => accessor.getList<T?>(object, propertyName);
+  T? getObject(RealmAccessorMarker accessor, RealmObjectBaseMarker object, String propertyName) => accessor.getObject<T>(object, propertyName);
+  T getValue(RealmAccessorMarker accessor, RealmObjectBaseMarker object, String propertyName) => accessor.getValue<T>(object, propertyName);
+  T? getNullableValue(RealmAccessorMarker accessor, RealmObjectBaseMarker object, String propertyName) => accessor.getValue<T?>(object, propertyName);
+  List<T> getList(RealmAccessorMarker accessor, RealmObjectBaseMarker object, String propertyName) => accessor.getList<T>(object, propertyName);
+  List<T?> getListOfNullables(RealmAccessorMarker accessor, RealmObjectBaseMarker object, String propertyName) => accessor.getList<T?>(object, propertyName);
 }
 
 const _intMapping = Mapping<int>(indexable: true);
@@ -114,7 +114,13 @@ class RealmStateError extends StateError implements RealmError {
 class Decimal128 {} // TODO Support decimal128 datatype https://github.com/realm/realm-dart/issues/725
 
 /// @nodoc
-class RealmObjectMarker {}
+class RealmObjectBaseMarker {}
+
+/// @nodoc
+class RealmObjectMarker extends RealmObjectBaseMarker {}
+
+/// @nodoc
+class EmbeddedObjectMarker extends RealmObjectBaseMarker {}
 
 // Union type
 /// @nodoc

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -69,7 +69,7 @@ enum RealmPropertyType {
   float(Mapping<Float>()),
   double(_doubleMapping),
   decimal128,
-  object(Mapping<RealmObjectMarker>()),
+  object(Mapping<RealmObjectBaseMarker>()),
   _13, // ignore: unused_field, constant_identifier_names
   linkingObjects,
   objectid(Mapping<ObjectId>(indexable: true)),

--- a/example/bin/myapp.g.dart
+++ b/example/bin/myapp.g.dart
@@ -6,7 +6,8 @@ part of 'myapp.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
+class Car extends _Car
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Car(
     String make, {
     String? model,
@@ -57,7 +58,7 @@ class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Car>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Car>(
     Car._,
@@ -73,7 +74,8 @@ class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
+class Person extends _Person
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Person(
     String name, {
     int age = 1,
@@ -105,7 +107,7 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
     Person._,

--- a/example/bin/myapp.g.dart
+++ b/example/bin/myapp.g.dart
@@ -61,6 +61,7 @@ class Car extends _Car
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Car>(
+    ObjectType.topLevel,
     Car._,
     'Car',
     {
@@ -110,6 +111,7 @@ class Person extends _Person
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
+    ObjectType.topLevel,
     Person._,
     'Person',
     {

--- a/flutter/realm_flutter/example/lib/main.g.dart
+++ b/flutter/realm_flutter/example/lib/main.g.dart
@@ -6,7 +6,8 @@ part of 'main.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
+class Car extends _Car
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Car(
     String make, {
     String? model,
@@ -57,7 +58,7 @@ class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Car>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Car>(
     Car._,
@@ -73,7 +74,8 @@ class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
+class Person extends _Person
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Person(
     String name, {
     int age = 1,
@@ -105,7 +107,7 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
     Person._,

--- a/flutter/realm_flutter/example/lib/main.g.dart
+++ b/flutter/realm_flutter/example/lib/main.g.dart
@@ -61,6 +61,7 @@ class Car extends _Car
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Car>(
+    ObjectType.topLevel,
     Car._,
     'Car',
     {
@@ -110,6 +111,7 @@ class Person extends _Person
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
+    ObjectType.topLevel,
     Person._,
     'Person',
     {

--- a/flutter/realm_flutter/tests/test_driver/realm_test.dart
+++ b/flutter/realm_flutter/tests/test_driver/realm_test.dart
@@ -10,6 +10,7 @@ import '../test/app_test.dart' as app_test;
 import '../test/configuration_test.dart' as configuration_test;
 import '../test/credentials_test.dart' as credentials_test;
 import '../test/dynamic_realm_test.dart' as dynamic_realm_test;
+import '../test/embedded_test.dart' as embedded_test;
 import '../test/list_test.dart' as list_test;
 import '../test/realm_object_test.dart' as realm_object_test;
 import '../test/realm_test.dart' as realm_test;
@@ -28,6 +29,7 @@ Future<String> main(List<String> args) async {
     await configuration_test.main(args);
     await credentials_test.main(args);
     await dynamic_realm_test.main(args);
+    await embedded_test.main(args);
     await list_test.main(args);
     await realm_object_test.main(args);
     await realm_test.main(args);

--- a/generator/lib/src/class_element_ex.dart
+++ b/generator/lib/src/class_element_ex.dart
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:realm_common/realm_common.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'annotation_value.dart';
@@ -64,7 +65,10 @@ extension ClassElementEx on ClassElement {
 
   RealmModelInfo? get realmInfo {
     try {
-      if (realmModelInfo == null) return null;
+      final modelInfo = realmModelInfo;
+      if (modelInfo == null) {
+        return null;
+      }
 
       final modelName = this.name;
 
@@ -142,13 +146,10 @@ extension ClassElementEx on ClassElement {
         );
       }
 
+      final objectType = modelInfo.value.getField('type')!.getField('index')!.toIntValue()!;
+
       final mappedFields = fields.realmInfo.toList();
-      return RealmModelInfo(
-        name,
-        modelName,
-        realmName,
-        mappedFields,
-      );
+      return RealmModelInfo(name, modelName, realmName, mappedFields, ObjectType.values[objectType]);
     } on InvalidGenerationSourceError catch (_) {
       rethrow;
     } catch (e) {

--- a/generator/lib/src/realm_model_info.dart
+++ b/generator/lib/src/realm_model_info.dart
@@ -15,6 +15,8 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////
+import 'package:realm_common/realm_common.dart';
+
 import 'dart_type_ex.dart';
 import 'field_element_ex.dart';
 import 'realm_field_info.dart';
@@ -24,11 +26,12 @@ class RealmModelInfo {
   final String modelName;
   final String realmName;
   final List<RealmFieldInfo> fields;
+  final ObjectType baseType;
 
-  RealmModelInfo(this.name, this.modelName, this.realmName, this.fields);
+  RealmModelInfo(this.name, this.modelName, this.realmName, this.fields, this.baseType);
 
   Iterable<String> toCode() sync* {
-    yield 'class $name extends $modelName with RealmEntityMixin, RealmObjectMixin {';
+    yield 'class $name extends $modelName with RealmEntityMixin, RealmObjectBaseMixin, ${baseType.className}Mixin {';
     {
       final allExceptCollections = fields.where((f) => !f.type.isRealmCollection).toList();
 
@@ -67,7 +70,7 @@ class RealmModelInfo {
           ]);
 
       yield '@override';
-      yield 'Stream<RealmObjectChanges<$name>> get changes => RealmObjectMixin.getChanges(this);';
+      yield 'Stream<RealmObjectChanges<$name>> get changes => RealmObjectBaseMixin.getChanges(this);';
       yield '';
 
       final primaryKey = fields.cast<RealmFieldInfo?>().firstWhere((element) => element!.primaryKey, orElse: () => null);

--- a/generator/lib/src/realm_model_info.dart
+++ b/generator/lib/src/realm_model_info.dart
@@ -76,6 +76,7 @@ class RealmModelInfo {
       final primaryKey = fields.cast<RealmFieldInfo?>().firstWhere((element) => element!.primaryKey, orElse: () => null);
       yield 'static const schema = SchemaObject<$name>(';
       {
+        yield 'ObjectType.${baseType.name},';
         yield '$name._,';
         yield "'$realmName',";
         yield '{';

--- a/generator/test/error_test_data/embedded_object_primary_key.dart
+++ b/generator/test/error_test_data/embedded_object_primary_key.dart
@@ -1,0 +1,9 @@
+import 'package:realm_common/realm_common.dart';
+
+//part 'embedded_object_primary_key.g.dart';
+
+@RealmModel(ObjectType.embedded)
+class _Bad {
+  @PrimaryKey()
+  late int id;
+}

--- a/generator/test/error_test_data/embedded_object_primary_key.expected
+++ b/generator/test/error_test_data/embedded_object_primary_key.expected
@@ -1,0 +1,12 @@
+Primary key not allowed on embedded objects
+
+in: asset:pkg/test/error_test_data/embedded_object_primary_key.dart:8:12
+  ╷
+5 │ @RealmModel(ObjectType.embedded)
+6 │ class _Bad {
+  │       ━━━━ 
+7 │   @PrimaryKey()
+8 │   late int id;
+  │            ^^ Bad is marked as embedded but has primary key defined
+  ╵
+Remove the @PrimaryKey annotation from the field or set the object type to topLevel.

--- a/generator/test/good_test.dart
+++ b/generator/test/good_test.dart
@@ -70,6 +70,7 @@ class MappedToo extends _MappedToo
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<MappedToo>(
+    ObjectType.topLevel,
     MappedToo._,
     'this is also mapped',
     {

--- a/generator/test/good_test.dart
+++ b/generator/test/good_test.dart
@@ -36,7 +36,8 @@ class _MappedToo {
 // RealmObjectGenerator
 // **************************************************************************
 
-class MappedToo extends _MappedToo with RealmEntityMixin, RealmObjectMixin {
+class MappedToo extends _MappedToo
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   MappedToo({
     Original? singleLink,
     Iterable<Original> listLink = const [],
@@ -66,7 +67,7 @@ class MappedToo extends _MappedToo with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<MappedToo>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<MappedToo>(
     MappedToo._,

--- a/generator/test/good_test_data/all_types.expected
+++ b/generator/test/good_test_data/all_types.expected
@@ -28,6 +28,7 @@ class Foo extends _Foo
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Foo>(
+    ObjectType.topLevel,
     Foo._,
     'MyFoo',
     {
@@ -177,6 +178,7 @@ class Bar extends _Bar
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Bar>(
+    ObjectType.topLevel,
     Bar._,
     'Bar',
     {
@@ -267,6 +269,7 @@ class PrimitiveTypes extends _PrimitiveTypes
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<PrimitiveTypes>(
+    ObjectType.topLevel,
     PrimitiveTypes._,
     'PrimitiveTypes',
     {

--- a/generator/test/good_test_data/all_types.expected
+++ b/generator/test/good_test_data/all_types.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Foo extends _Foo with RealmEntityMixin, RealmObjectMixin {
+class Foo extends _Foo
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Foo({
     int x = 0,
   }) {
@@ -24,7 +25,7 @@ class Foo extends _Foo with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Foo>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Foo>(
     Foo._,
@@ -37,7 +38,8 @@ class Foo extends _Foo with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Bar extends _Bar with RealmEntityMixin, RealmObjectMixin {
+class Bar extends _Bar
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Bar(
     String name,
     bool aBool,
@@ -172,7 +174,7 @@ class Bar extends _Bar with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Bar>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Bar>(
     Bar._,
@@ -197,7 +199,7 @@ class Bar extends _Bar with RealmEntityMixin, RealmObjectMixin {
 }
 
 class PrimitiveTypes extends _PrimitiveTypes
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   PrimitiveTypes(
     String stringProp,
     bool boolProp,
@@ -262,7 +264,7 @@ class PrimitiveTypes extends _PrimitiveTypes
 
   @override
   Stream<RealmObjectChanges<PrimitiveTypes>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<PrimitiveTypes>(
     PrimitiveTypes._,

--- a/generator/test/good_test_data/embedded_objects.dart
+++ b/generator/test/good_test_data/embedded_objects.dart
@@ -1,0 +1,38 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel()
+class _Parent {
+  late _Child1? child;
+
+  late List<_Child1> children;
+}
+
+@RealmModel(ObjectType.embedded)
+class _Child1 {
+  late String value;
+
+  late _Child2? child;
+
+  late List<_Child2> children;
+
+  late _Parent? linkToParent;
+}
+
+@RealmModel(ObjectType.embedded)
+class _Child2 {
+  late bool boolProp;
+  late int intProp;
+  late double doubleProp;
+  late String stringProp;
+  late DateTime dateProp;
+  late ObjectId objectIdProp;
+  late Uuid uuidProp;
+
+  late bool? nullableBoolProp;
+  late int? nullableIntProp;
+  late double? nullableDoubleProp;
+  late String? nullableStringProp;
+  late DateTime? nullableDateProp;
+  late ObjectId? nullableObjectIdProp;
+  late Uuid? nullableUuidProp;
+}

--- a/generator/test/good_test_data/embedded_objects.expected
+++ b/generator/test/good_test_data/embedded_objects.expected
@@ -1,0 +1,314 @@
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class Parent extends _Parent
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
+  Parent({
+    Child1? child,
+    Iterable<Child1> children = const [],
+  }) {
+    _childProperty.setValue(this, child);
+    _childrenProperty.setValue(this, RealmList<Child1>(children));
+  }
+
+  Parent._();
+
+  static const _childProperty = ObjectProperty<Child1>('child', 'Child1');
+  @override
+  Child1? get child => _childProperty.getValue(this);
+  @override
+  set child(covariant Child1? value) => _childProperty.setValue(this, value);
+
+  static const _childrenProperty = ListProperty<Child1>(
+      'children', RealmPropertyType.object,
+      linkTarget: 'Child1');
+  @override
+  RealmList<Child1> get children => _childrenProperty.getValue(this);
+  @override
+  set children(covariant RealmList<Child1> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<Parent>> get changes =>
+      RealmObjectBaseMixin.getChanges(this);
+
+  static const schema = SchemaObject<Parent>(
+    ObjectType.topLevel,
+    Parent._,
+    'Parent',
+    {
+      'child': _childProperty,
+      'children': _childrenProperty,
+    },
+  );
+  @override
+  SchemaObject get instanceSchema => schema;
+  }
+
+  class Child1 extends _Child1
+    with RealmEntityMixin, RealmObjectBaseMixin, EmbeddedObjectMixin {
+  Child1(
+    String value, {
+    Child2? child,
+    Parent? linkToParent,
+    Iterable<Child2> children = const [],
+  }) {
+    _valueProperty.setValue(this, value);
+    _childProperty.setValue(this, child);
+    _linkToParentProperty.setValue(this, linkToParent);
+    _childrenProperty.setValue(this, RealmList<Child2>(children));
+  }
+
+  Child1._();
+
+  static const _valueProperty = ValueProperty<String>(
+    'value',
+    RealmPropertyType.string,
+  );
+  @override
+  String get value => _valueProperty.getValue(this);
+  @override
+  set value(String value) => _valueProperty.setValue(this, value);
+
+  static const _childProperty = ObjectProperty<Child2>('child', 'Child2');
+  @override
+  Child2? get child => _childProperty.getValue(this);
+  @override
+  set child(covariant Child2? value) => _childProperty.setValue(this, value);
+
+  static const _childrenProperty = ListProperty<Child2>(
+      'children', RealmPropertyType.object,
+      linkTarget: 'Child2');
+  @override
+  RealmList<Child2> get children => _childrenProperty.getValue(this);
+  @override
+  set children(covariant RealmList<Child2> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _linkToParentProperty =
+      ObjectProperty<Parent>('linkToParent', 'Parent');
+  @override
+  Parent? get linkToParent => _linkToParentProperty.getValue(this);
+  @override
+  set linkToParent(covariant Parent? value) =>
+      _linkToParentProperty.setValue(this, value);
+
+  @override
+  Stream<RealmObjectChanges<Child1>> get changes =>
+      RealmObjectBaseMixin.getChanges(this);
+
+  static const schema = SchemaObject<Child1>(
+    ObjectType.embedded,
+    Child1._,
+    'Child1',
+    {
+      'value': _valueProperty,
+      'child': _childProperty,
+      'children': _childrenProperty,
+      'linkToParent': _linkToParentProperty,
+    },
+  );
+  @override
+  SchemaObject get instanceSchema => schema;
+  }
+
+  class Child2 extends _Child2
+    with RealmEntityMixin, RealmObjectBaseMixin, EmbeddedObjectMixin {
+  Child2(
+    bool boolProp,
+    int intProp,
+    double doubleProp,
+    String stringProp,
+    DateTime dateProp,
+    ObjectId objectIdProp,
+    Uuid uuidProp, {
+    bool? nullableBoolProp,
+    int? nullableIntProp,
+    double? nullableDoubleProp,
+    String? nullableStringProp,
+    DateTime? nullableDateProp,
+    ObjectId? nullableObjectIdProp,
+    Uuid? nullableUuidProp,
+  }) {
+    _boolPropProperty.setValue(this, boolProp);
+    _intPropProperty.setValue(this, intProp);
+    _doublePropProperty.setValue(this, doubleProp);
+    _stringPropProperty.setValue(this, stringProp);
+    _datePropProperty.setValue(this, dateProp);
+    _objectIdPropProperty.setValue(this, objectIdProp);
+    _uuidPropProperty.setValue(this, uuidProp);
+    _nullableBoolPropProperty.setValue(this, nullableBoolProp);
+    _nullableIntPropProperty.setValue(this, nullableIntProp);
+    _nullableDoublePropProperty.setValue(this, nullableDoubleProp);
+    _nullableStringPropProperty.setValue(this, nullableStringProp);
+    _nullableDatePropProperty.setValue(this, nullableDateProp);
+    _nullableObjectIdPropProperty.setValue(this, nullableObjectIdProp);
+    _nullableUuidPropProperty.setValue(this, nullableUuidProp);
+  }
+
+  Child2._();
+
+  static const _boolPropProperty = ValueProperty<bool>(
+    'boolProp',
+    RealmPropertyType.bool,
+  );
+  @override
+  bool get boolProp => _boolPropProperty.getValue(this);
+  @override
+  set boolProp(bool value) => _boolPropProperty.setValue(this, value);
+
+  static const _intPropProperty = ValueProperty<int>(
+    'intProp',
+    RealmPropertyType.int,
+  );
+  @override
+  int get intProp => _intPropProperty.getValue(this);
+  @override
+  set intProp(int value) => _intPropProperty.setValue(this, value);
+
+  static const _doublePropProperty = ValueProperty<double>(
+    'doubleProp',
+    RealmPropertyType.double,
+  );
+  @override
+  double get doubleProp => _doublePropProperty.getValue(this);
+  @override
+  set doubleProp(double value) => _doublePropProperty.setValue(this, value);
+
+  static const _stringPropProperty = ValueProperty<String>(
+    'stringProp',
+    RealmPropertyType.string,
+  );
+  @override
+  String get stringProp => _stringPropProperty.getValue(this);
+  @override
+  set stringProp(String value) => _stringPropProperty.setValue(this, value);
+
+  static const _datePropProperty = ValueProperty<DateTime>(
+    'dateProp',
+    RealmPropertyType.timestamp,
+  );
+  @override
+  DateTime get dateProp => _datePropProperty.getValue(this);
+  @override
+  set dateProp(DateTime value) => _datePropProperty.setValue(this, value);
+
+  static const _objectIdPropProperty = ValueProperty<ObjectId>(
+    'objectIdProp',
+    RealmPropertyType.objectid,
+  );
+  @override
+  ObjectId get objectIdProp => _objectIdPropProperty.getValue(this);
+  @override
+  set objectIdProp(ObjectId value) =>
+      _objectIdPropProperty.setValue(this, value);
+
+  static const _uuidPropProperty = ValueProperty<Uuid>(
+    'uuidProp',
+    RealmPropertyType.uuid,
+  );
+  @override
+  Uuid get uuidProp => _uuidPropProperty.getValue(this);
+  @override
+  set uuidProp(Uuid value) => _uuidPropProperty.setValue(this, value);
+
+  static const _nullableBoolPropProperty = ValueProperty<bool?>(
+    'nullableBoolProp',
+    RealmPropertyType.bool,
+  );
+  @override
+  bool? get nullableBoolProp => _nullableBoolPropProperty.getValue(this);
+  @override
+  set nullableBoolProp(bool? value) =>
+      _nullableBoolPropProperty.setValue(this, value);
+
+  static const _nullableIntPropProperty = ValueProperty<int?>(
+    'nullableIntProp',
+    RealmPropertyType.int,
+  );
+  @override
+  int? get nullableIntProp => _nullableIntPropProperty.getValue(this);
+  @override
+  set nullableIntProp(int? value) =>
+      _nullableIntPropProperty.setValue(this, value);
+
+  static const _nullableDoublePropProperty = ValueProperty<double?>(
+    'nullableDoubleProp',
+    RealmPropertyType.double,
+  );
+  @override
+  double? get nullableDoubleProp => _nullableDoublePropProperty.getValue(this);
+  @override
+  set nullableDoubleProp(double? value) =>
+      _nullableDoublePropProperty.setValue(this, value);
+
+  static const _nullableStringPropProperty = ValueProperty<String?>(
+    'nullableStringProp',
+    RealmPropertyType.string,
+  );
+  @override
+  String? get nullableStringProp => _nullableStringPropProperty.getValue(this);
+  @override
+  set nullableStringProp(String? value) =>
+      _nullableStringPropProperty.setValue(this, value);
+
+  static const _nullableDatePropProperty = ValueProperty<DateTime?>(
+    'nullableDateProp',
+    RealmPropertyType.timestamp,
+  );
+  @override
+  DateTime? get nullableDateProp => _nullableDatePropProperty.getValue(this);
+  @override
+  set nullableDateProp(DateTime? value) =>
+      _nullableDatePropProperty.setValue(this, value);
+
+  static const _nullableObjectIdPropProperty = ValueProperty<ObjectId?>(
+    'nullableObjectIdProp',
+    RealmPropertyType.objectid,
+  );
+  @override
+  ObjectId? get nullableObjectIdProp =>
+      _nullableObjectIdPropProperty.getValue(this);
+  @override
+  set nullableObjectIdProp(ObjectId? value) =>
+      _nullableObjectIdPropProperty.setValue(this, value);
+
+  static const _nullableUuidPropProperty = ValueProperty<Uuid?>(
+    'nullableUuidProp',
+    RealmPropertyType.uuid,
+  );
+  @override
+  Uuid? get nullableUuidProp => _nullableUuidPropProperty.getValue(this);
+  @override
+  set nullableUuidProp(Uuid? value) =>
+      _nullableUuidPropProperty.setValue(this, value);
+
+  @override
+  Stream<RealmObjectChanges<Child2>> get changes =>
+      RealmObjectBaseMixin.getChanges(this);
+
+  static const schema = SchemaObject<Child2>(
+    ObjectType.embedded,
+    Child2._,
+    'Child2',
+    {
+      'boolProp': _boolPropProperty,
+      'intProp': _intPropProperty,
+      'doubleProp': _doublePropProperty,
+      'stringProp': _stringPropProperty,
+      'dateProp': _datePropProperty,
+      'objectIdProp': _objectIdPropProperty,
+      'uuidProp': _uuidPropProperty,
+      'nullableBoolProp': _nullableBoolPropProperty,
+      'nullableIntProp': _nullableIntPropProperty,
+      'nullableDoubleProp': _nullableDoublePropProperty,
+      'nullableStringProp': _nullableStringPropProperty,
+      'nullableDateProp': _nullableDatePropProperty,
+      'nullableObjectIdProp': _nullableObjectIdPropProperty,
+      'nullableUuidProp': _nullableUuidPropProperty,
+    },
+  );
+  @override
+  SchemaObject get instanceSchema => schema;
+}

--- a/generator/test/good_test_data/indexable_types.expected
+++ b/generator/test/good_test_data/indexable_types.expected
@@ -164,6 +164,7 @@ class Indexable extends _Indexable
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Indexable>(
+    ObjectType.topLevel,
     Indexable._,
     'Indexable',
     {

--- a/generator/test/good_test_data/indexable_types.expected
+++ b/generator/test/good_test_data/indexable_types.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Indexable extends _Indexable with RealmEntityMixin, RealmObjectMixin {
+class Indexable extends _Indexable
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Indexable(
     bool aBool,
     int anInt,
@@ -160,7 +161,7 @@ class Indexable extends _Indexable with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Indexable>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Indexable>(
     Indexable._,

--- a/generator/test/good_test_data/list_initialization.expected
+++ b/generator/test/good_test_data/list_initialization.expected
@@ -26,6 +26,7 @@ class Person extends _Person
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
+    ObjectType.topLevel,
     Person._,
     'Person',
     {

--- a/generator/test/good_test_data/list_initialization.expected
+++ b/generator/test/good_test_data/list_initialization.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
+class Person extends _Person
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Person({
     Iterable<Person> children = const [],
   }) {
@@ -22,7 +23,7 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
     Person._,

--- a/generator/test/good_test_data/mapto.expected
+++ b/generator/test/good_test_data/mapto.expected
@@ -49,6 +49,7 @@ class Original extends $Original
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Original>(
+    ObjectType.topLevel,
     Original._,
     'another type',
     {

--- a/generator/test/good_test_data/mapto.expected
+++ b/generator/test/good_test_data/mapto.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Original extends $Original with RealmEntityMixin, RealmObjectMixin {
+class Original extends $Original
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Original({
     int primitiveProperty = 0,
     Original? objectProperty,
@@ -45,7 +46,7 @@ class Original extends $Original with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Original>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Original>(
     Original._,

--- a/generator/test/good_test_data/optional_argument.expected
+++ b/generator/test/good_test_data/optional_argument.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
+class Person extends _Person
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Person({
     Person? spouse,
   }) {
@@ -19,7 +20,7 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
     Person._,

--- a/generator/test/good_test_data/optional_argument.expected
+++ b/generator/test/good_test_data/optional_argument.expected
@@ -23,6 +23,7 @@ class Person extends _Person
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
+    ObjectType.topLevel,
     Person._,
     'Person',
     {

--- a/generator/test/good_test_data/pinhole.expected
+++ b/generator/test/good_test_data/pinhole.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Foo extends _Foo with RealmEntityMixin, RealmObjectMixin {
+class Foo extends _Foo
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Foo({
     int x = 0,
   }) {
@@ -23,7 +24,7 @@ class Foo extends _Foo with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Foo>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Foo>(
     Foo._,

--- a/generator/test/good_test_data/pinhole.expected
+++ b/generator/test/good_test_data/pinhole.expected
@@ -27,6 +27,7 @@ class Foo extends _Foo
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Foo>(
+    ObjectType.topLevel,
     Foo._,
     'Foo',
     {

--- a/generator/test/good_test_data/primary_key.expected
+++ b/generator/test/good_test_data/primary_key.expected
@@ -27,6 +27,7 @@ class IntPK extends _IntPK
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<IntPK>(
+    ObjectType.topLevel,
     IntPK._,
     'IntPK',
     {
@@ -63,6 +64,7 @@ class NullableIntPK extends _NullableIntPK
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableIntPK>(
+    ObjectType.topLevel,
     NullableIntPK._,
     'NullableIntPK',
     {
@@ -99,6 +101,7 @@ class StringPK extends _StringPK
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<StringPK>(
+    ObjectType.topLevel,
     StringPK._,
     'StringPK',
     {
@@ -135,6 +138,7 @@ class NullableStringPK extends _NullableStringPK
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableStringPK>(
+    ObjectType.topLevel,
     NullableStringPK._,
     'NullableStringPK',
     {
@@ -171,6 +175,7 @@ class ObjectIdPK extends _ObjectIdPK
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<ObjectIdPK>(
+    ObjectType.topLevel,
     ObjectIdPK._,
     'ObjectIdPK',
     {
@@ -207,6 +212,7 @@ class NullableObjectIdPK extends _NullableObjectIdPK
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableObjectIdPK>(
+    ObjectType.topLevel,
     NullableObjectIdPK._,
     'NullableObjectIdPK',
     {
@@ -243,6 +249,7 @@ class UuidPK extends _UuidPK
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<UuidPK>(
+    ObjectType.topLevel,
     UuidPK._,
     'UuidPK',
     {
@@ -279,6 +286,7 @@ class NullableUuidPK extends _NullableUuidPK
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableUuidPK>(
+    ObjectType.topLevel,
     NullableUuidPK._,
     'NullableUuidPK',
     {

--- a/generator/test/good_test_data/primary_key.expected
+++ b/generator/test/good_test_data/primary_key.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class IntPK extends _IntPK with RealmEntityMixin, RealmObjectMixin {
+class IntPK extends _IntPK
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   IntPK(
     int id,
   ) {
@@ -23,7 +24,7 @@ class IntPK extends _IntPK with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<IntPK>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<IntPK>(
     IntPK._,
@@ -38,7 +39,7 @@ class IntPK extends _IntPK with RealmEntityMixin, RealmObjectMixin {
 }
 
 class NullableIntPK extends _NullableIntPK
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableIntPK(
     int? id,
   ) {
@@ -59,7 +60,7 @@ class NullableIntPK extends _NullableIntPK
 
   @override
   Stream<RealmObjectChanges<NullableIntPK>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableIntPK>(
     NullableIntPK._,
@@ -73,7 +74,8 @@ class NullableIntPK extends _NullableIntPK
   SchemaObject get instanceSchema => schema;
 }
 
-class StringPK extends _StringPK with RealmEntityMixin, RealmObjectMixin {
+class StringPK extends _StringPK
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   StringPK(
     String id,
   ) {
@@ -94,7 +96,7 @@ class StringPK extends _StringPK with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<StringPK>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<StringPK>(
     StringPK._,
@@ -109,7 +111,7 @@ class StringPK extends _StringPK with RealmEntityMixin, RealmObjectMixin {
 }
 
 class NullableStringPK extends _NullableStringPK
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableStringPK(
     String? id,
   ) {
@@ -130,7 +132,7 @@ class NullableStringPK extends _NullableStringPK
 
   @override
   Stream<RealmObjectChanges<NullableStringPK>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableStringPK>(
     NullableStringPK._,
@@ -144,7 +146,8 @@ class NullableStringPK extends _NullableStringPK
   SchemaObject get instanceSchema => schema;
 }
 
-class ObjectIdPK extends _ObjectIdPK with RealmEntityMixin, RealmObjectMixin {
+class ObjectIdPK extends _ObjectIdPK
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   ObjectIdPK(
     ObjectId id,
   ) {
@@ -165,7 +168,7 @@ class ObjectIdPK extends _ObjectIdPK with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<ObjectIdPK>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<ObjectIdPK>(
     ObjectIdPK._,
@@ -180,7 +183,7 @@ class ObjectIdPK extends _ObjectIdPK with RealmEntityMixin, RealmObjectMixin {
 }
 
 class NullableObjectIdPK extends _NullableObjectIdPK
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableObjectIdPK(
     ObjectId? id,
   ) {
@@ -201,7 +204,7 @@ class NullableObjectIdPK extends _NullableObjectIdPK
 
   @override
   Stream<RealmObjectChanges<NullableObjectIdPK>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableObjectIdPK>(
     NullableObjectIdPK._,
@@ -215,7 +218,8 @@ class NullableObjectIdPK extends _NullableObjectIdPK
   SchemaObject get instanceSchema => schema;
 }
 
-class UuidPK extends _UuidPK with RealmEntityMixin, RealmObjectMixin {
+class UuidPK extends _UuidPK
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   UuidPK(
     Uuid id,
   ) {
@@ -236,7 +240,7 @@ class UuidPK extends _UuidPK with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<UuidPK>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<UuidPK>(
     UuidPK._,
@@ -251,7 +255,7 @@ class UuidPK extends _UuidPK with RealmEntityMixin, RealmObjectMixin {
 }
 
 class NullableUuidPK extends _NullableUuidPK
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableUuidPK(
     Uuid? id,
   ) {
@@ -272,7 +276,7 @@ class NullableUuidPK extends _NullableUuidPK
 
   @override
   Stream<RealmObjectChanges<NullableUuidPK>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableUuidPK>(
     NullableUuidPK._,

--- a/generator/test/good_test_data/required_argument.expected
+++ b/generator/test/good_test_data/required_argument.expected
@@ -27,6 +27,7 @@ class Person extends _Person
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
+    ObjectType.topLevel,
     Person._,
     'Person',
     {

--- a/generator/test/good_test_data/required_argument.expected
+++ b/generator/test/good_test_data/required_argument.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
+class Person extends _Person
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Person(
     String name,
   ) {
@@ -23,7 +24,7 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
     Person._,

--- a/generator/test/good_test_data/required_argument_with_default_value.expected
+++ b/generator/test/good_test_data/required_argument_with_default_value.expected
@@ -27,6 +27,7 @@ class Person extends _Person
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
+    ObjectType.topLevel,
     Person._,
     'Person',
     {

--- a/generator/test/good_test_data/required_argument_with_default_value.expected
+++ b/generator/test/good_test_data/required_argument_with_default_value.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
+class Person extends _Person
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Person({
     int age = 47,
   }) {
@@ -23,7 +24,7 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
     Person._,

--- a/generator/test/good_test_data/user_defined_getter.expected
+++ b/generator/test/good_test_data/user_defined_getter.expected
@@ -26,6 +26,7 @@ class Person extends _Person
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
+    ObjectType.topLevel,
     Person._,
     'Person',
     {

--- a/generator/test/good_test_data/user_defined_getter.expected
+++ b/generator/test/good_test_data/user_defined_getter.expected
@@ -2,7 +2,8 @@
 // RealmObjectGenerator
 // **************************************************************************
 
-class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
+class Person extends _Person
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Person(
     String name,
   ) {
@@ -22,7 +23,7 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
     Person._,

--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -18,7 +18,6 @@
 
 import 'package:http/http.dart' as http;
 import 'dart:convert';
-import 'package:crypto/crypto.dart';
 
 class BaasClient {
   static const String _confirmFuncSource = '''exports = async ({ token, tokenId, username }) => {
@@ -247,7 +246,7 @@ class BaasClient {
             "authFunctionName": "authFunc",
             "authFunctionId": "$authFuncId"
             }''');
-    
+
       const facebookSecret = "876750ac6d06618b323dee591602897f";
       final dynamic createFacebookSecretResult = await _post('groups/$_groupId/apps/$appId/secrets', '{"name":"facebookSecret","value":"$facebookSecret"}');
       String facebookClientSecretKeyName = createFacebookSecretResult['name'] as String;
@@ -292,7 +291,7 @@ class BaasClient {
             "name": "picture"
           }''');
     }
-    
+
     print('Creating database db_$name$_appSuffix');
 
     await _createMongoDBService(app, '''{

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -332,6 +332,8 @@ class SchemaObject<T extends Object?> with IterableMixin<SchemaProperty> {
   /// Returns the name of this schema type.
   final String name;
 
+  final ObjectType baseType;
+
   SchemaProperty operator [](String propertyName) =>
       properties[propertyName] ?? (throw RealmException("Property '$propertyName' does not exist on class '$name'"));
 
@@ -339,7 +341,7 @@ class SchemaObject<T extends Object?> with IterableMixin<SchemaProperty> {
   final SchemaProperty? primaryKey;
 
   /// Creates schema instance with object type and collection of object's properties.
-  const SchemaObject(this.objectFactory, this.name, this.properties, [this.primaryKey]);
+  const SchemaObject(this.baseType, this.objectFactory, this.name, this.properties, [this.primaryKey]);
 
   @override
   Iterator<SchemaProperty> get iterator => properties.values.iterator;

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -316,7 +316,7 @@ class InMemoryConfiguration extends Configuration {
   }) : super._();
 }
 
-/// A collection of properties describing the underlying schema of a [RealmObject].
+/// A collection of properties describing the underlying schema of a [RealmObjectBase].
 ///
 /// {@category Configuration}
 class SchemaObject<T extends Object?> with IterableMixin<SchemaProperty> {
@@ -355,7 +355,7 @@ class RealmSchema extends MapView<String, SchemaObject> {
   RealmSchema(super.map)
       : _byType = {
           for (final s in map.values)
-            if (s.type != RealmObject) s.nullableType: s // only register subtypes (the nullable form)
+            if (s.type != RealmObjectBase) s.nullableType: s // only register subtypes (the nullable form)
         };
 
   SchemaObject<T>? getByType<T extends Object?>() => _byType[typeOf<T?>()] as SchemaObject<T>?;

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -119,6 +119,17 @@ class ManagedRealmList<T extends Object?> extends collection.ListBase<T> with Re
     return result;
   }
 
+  @override
+  bool remove(Object? element) {
+    final index = indexOf(element);
+    if (index < 0) {
+      return false;
+    }
+
+    realmCore.listRemoveElementAt(handle, index);
+    return true;
+  }
+
   /// Removes all objects from this list; the length of the list becomes zero.
   /// The objects are not deleted from the realm, but are no longer referenced from this list.
   @override

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -165,7 +165,7 @@ class UnmanagedRealmList<T extends Object?> extends collection.ListBase<T> with 
 // The query operations on lists, as well as the ability to subscribe for notifications,
 // only work for list of objects (core restriction), so we add these as an extension methods
 // to allow the compiler to prevent misuse.
-extension RealmListOfObject<T extends RealmObject> on RealmList<T> {
+extension RealmListOfObject<T extends RealmObjectBase> on RealmList<T> {
   /// Filters the list and returns a new [RealmResults] according to the provided [query] (with optional [arguments]).
   ///
   /// Only works for lists of [RealmObject]s.

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -509,7 +509,7 @@ class _RealmCore {
       result[property.name] = property;
     }
 
-    return SchemaObject<RealmObject>(() => throw Error(), name, result, result.values.singleWhereOrNull((s) => s.primaryKey));
+    return SchemaObject<RealmObjectBase>(() => throw Error(), name, result, result.values.singleWhereOrNull((s) => s.primaryKey));
   }
 
   void deleteRealmFiles(String path) {
@@ -628,7 +628,7 @@ class _RealmCore {
     });
   }
 
-  Object? getProperty(RealmObject object, int propertyKey) {
+  Object? getProperty(RealmObjectBase object, int propertyKey) {
     return using((Arena arena) {
       final realm_value = arena<realm_value_t>();
       _realmLib.invokeGetBool(() => _realmLib.realm_get_value(object.handle._pointer, propertyKey, realm_value));
@@ -636,14 +636,14 @@ class _RealmCore {
     });
   }
 
-  void setProperty(RealmObject object, int propertyKey, Object? value, bool isDefault) {
+  void setProperty(RealmObjectBase object, int propertyKey, Object? value, bool isDefault) {
     return using((Arena arena) {
       final realm_value = _toRealmValue(value, arena);
       _realmLib.invokeGetBool(() => _realmLib.realm_set_value(object.handle._pointer, propertyKey, realm_value.ref, isDefault));
     });
   }
 
-  String objectToString(RealmObject object) {
+  String objectToString(RealmObjectBase object) {
     return _realmLib.realm_object_to_string(object.handle._pointer).cast<Utf8>().toRealmDartString(freeRealmMemory: true)!;
   }
 
@@ -799,7 +799,7 @@ class _RealmCore {
     });
   }
 
-  RealmLinkHandle _getObjectAsLink(RealmObject object) {
+  RealmLinkHandle _getObjectAsLink(RealmObjectBase object) {
     final realmLink = _realmLib.realm_object_as_link(object.handle._pointer);
     return RealmLinkHandle._(realmLink);
   }
@@ -809,7 +809,7 @@ class _RealmCore {
     return RealmObjectHandle._(pointer);
   }
 
-  RealmListHandle getListProperty(RealmObject object, int propertyKey) {
+  RealmListHandle getListProperty(RealmObjectBase object, int propertyKey) {
     final pointer = _realmLib.invokeGetPointer(() => _realmLib.realm_get_list(object.handle._pointer, propertyKey));
     return RealmListHandle._(pointer);
   }
@@ -866,7 +866,7 @@ class _RealmCore {
     return _realmLib.realm_equals(first._pointer.cast(), second._pointer.cast());
   }
 
-  bool objectEquals(RealmObject first, RealmObject second) => _equals(first.handle, second.handle);
+  bool objectEquals(RealmObjectBase first, RealmObjectBase second) => _equals(first.handle, second.handle);
   bool realmEquals(Realm first, Realm second) => _equals(first.handle, second.handle);
   bool userEquals(User first, User second) => _equals(first.handle, second.handle);
   bool subscriptionEquals(Subscription first, Subscription second) => _equals(first.handle, second.handle);
@@ -876,7 +876,7 @@ class _RealmCore {
     return RealmResultsHandle._(resultsPointer);
   }
 
-  bool objectIsValid(RealmObject object) {
+  bool objectIsValid(RealmObjectBase object) {
     return _realmLib.realm_object_is_valid(object.handle._pointer);
   }
 
@@ -958,7 +958,7 @@ class _RealmCore {
     return RealmNotificationTokenHandle._(pointer);
   }
 
-  RealmNotificationTokenHandle subscribeObjectNotifications(RealmObject object, NotificationsController controller) {
+  RealmNotificationTokenHandle subscribeObjectNotifications(RealmObjectBase object, NotificationsController controller) {
     final pointer = _realmLib.invokeGetPointer(() => _realmLib.realm_object_add_notification_callback(
           object.handle._pointer,
           controller.toWeakHandle(),
@@ -2005,7 +2005,7 @@ void _intoRealmQueryArg(Object? value, Pointer<realm_query_arg_t> realm_query_ar
 void _intoRealmValue(Object? value, Pointer<realm_value_t> realm_value, Allocator allocator) {
   if (value == null) {
     realm_value.ref.type = realm_value_type.RLM_TYPE_NULL;
-  } else if (value is RealmObject) {
+  } else if (value is RealmObjectBase) {
     //when converting a RealmObject to realm_value.link we assume the object is managed
     final link = realmCore._getObjectAsLink(value);
     realm_value.ref.values.link.target = link.targetKey;

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -2104,8 +2104,7 @@ extension on Pointer<realm_value_t> {
       case realm_value_type.RLM_TYPE_LINK:
         final objectKey = ref.values.link.target;
         final classKey = ref.values.link.target_table;
-        RealmObjectHandle handle = realmCore._getObject(realm, classKey, objectKey);
-        return handle;
+        return realmCore._getObject(realm, classKey, objectKey);
       case realm_value_type.RLM_TYPE_BINARY:
         throw Exception("Not implemented");
       case realm_value_type.RLM_TYPE_TIMESTAMP:

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -839,37 +839,31 @@ class _RealmCore {
   }
 
   void listSetElementAt(RealmListHandle handle, int index, Object? value) {
-    return using((Arena arena) {
+    using((Arena arena) {
       final realm_value = _toRealmValue(value, arena);
       _realmLib.invokeGetBool(() => _realmLib.realm_list_set(handle._pointer, index, realm_value.ref));
     });
   }
 
   void listInsertElementAt(RealmListHandle handle, int index, Object? value) {
-    return using((Arena arena) {
+    using((Arena arena) {
       final realm_value = _toRealmValue(value, arena);
       _realmLib.invokeGetBool(() => _realmLib.realm_list_insert(handle._pointer, index, realm_value.ref));
     });
   }
 
   RealmObjectHandle listSetEmbeddedObjectAt(RealmListHandle handle, int index) {
-    return using((Arena arena) {
-      final ptr = _realmLib.invokeGetPointer(() => _realmLib.realm_list_set_embedded(handle._pointer, index));
-      return RealmObjectHandle._(ptr);
-    });
+    final ptr = _realmLib.invokeGetPointer(() => _realmLib.realm_list_set_embedded(handle._pointer, index));
+    return RealmObjectHandle._(ptr);
   }
 
   RealmObjectHandle listInsertEmbeddedObjectAt(RealmListHandle handle, int index) {
-    return using((Arena arena) {
-      final ptr = _realmLib.invokeGetPointer(() => _realmLib.realm_list_insert_embedded(handle._pointer, index));
-      return RealmObjectHandle._(ptr);
-    });
+    final ptr = _realmLib.invokeGetPointer(() => _realmLib.realm_list_insert_embedded(handle._pointer, index));
+    return RealmObjectHandle._(ptr);
   }
 
   void listRemoveElementAt(RealmListHandle handle, int index) {
-    return using((Arena arena) {
-      _realmLib.invokeGetBool(() => _realmLib.realm_list_erase(handle._pointer, index));
-    });
+    _realmLib.invokeGetBool(() => _realmLib.realm_list_erase(handle._pointer, index));
   }
 
   void listDeleteAll(RealmList list) {

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -2242,8 +2242,6 @@ extension ObjectTypeNative on ObjectType {
         return realm_class_flags.RLM_CLASS_NORMAL;
       case ObjectType.embedded:
         return realm_class_flags.RLM_CLASS_EMBEDDED;
-      case ObjectType.asymmetric:
-        return realm_class_flags.RLM_CLASS_ASYMMETRIC;
       default:
         throw RealmException('Invalid ObjectType: $this');
     }
@@ -2255,8 +2253,6 @@ extension ObjectTypeNative on ObjectType {
         return ObjectType.topLevel;
       case realm_class_flags.RLM_CLASS_EMBEDDED:
         return ObjectType.embedded;
-      case realm_class_flags.RLM_CLASS_ASYMMETRIC:
-        return ObjectType.asymmetric;
       default:
         throw RealmException('Invalid ObjectType: $flags');
     }

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -51,6 +51,7 @@ export 'package:realm_common/realm_common.dart'
         SyncConnectionErrorCode,
         SyncSessionErrorCode,
         RealmModel,
+        ObjectType,
         RealmUnsupportedSetError,
         RealmStateError,
         RealmCollectionType,
@@ -75,7 +76,17 @@ export "configuration.dart"
 export 'credentials.dart' show Credentials, AuthProviderType, EmailPasswordAuthProvider;
 export 'list.dart' show RealmList, RealmListOfObject, RealmListChanges;
 export 'realm_object.dart'
-    show RealmEntityMixin, RealmObjectBaseMixin, RealmException, RealmObject, RealmObjectChanges, DynamicRealmObject, RealmObjectBase, RealmObjectMixin;
+    show
+        RealmEntityMixin,
+        RealmObjectBaseMixin,
+        RealmObjectMixin,
+        EmbeddedObjectMixin,
+        RealmException,
+        RealmObjectBase,
+        RealmObject,
+        EmbeddedObject,
+        DynamicRealmObject,
+        RealmObjectChanges;
 export 'realm_property.dart';
 export 'results.dart' show RealmResults, RealmResultsChanges;
 export 'session.dart' show Session, SessionState, ConnectionState, ProgressDirection, ProgressMode, SyncProgress, ConnectionStateChange;
@@ -391,6 +402,13 @@ extension RealmInternal on Realm {
   }
 
   RealmMetadata get metadata => _metadata;
+
+  void manageEmbedded(RealmObjectHandle handle, EmbeddedObject object, {bool update = false}) {
+    final metadata = _metadata.getByType(object.runtimeType);
+
+    final accessor = RealmCoreAccessor(metadata);
+    object.manage(this, handle, accessor, update);
+  }
 }
 
 /// @nodoc

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -409,6 +409,13 @@ extension RealmInternal on Realm {
     final accessor = RealmCoreAccessor(metadata);
     object.manage(this, handle, accessor, update);
   }
+
+  /// This should only be used for testing
+  RealmResults<T> allEmbedded<T extends EmbeddedObject>() {
+    final metadata = _metadata.getByStaticType<T>();
+    final handle = realmCore.findAll(this, metadata.key);
+    return RealmResultsInternal.create<T>(handle, this, metadata);
+  }
 }
 
 /// @nodoc

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -522,11 +522,15 @@ class RealmMetadata {
       (throw RealmError("Object type $name not configured in the current Realm's schema. Add type $name to your config before opening the Realm"));
 
   RealmObjectMetadata? getLinkMeta<LinkT extends Object?>(RealmPropertyMetadata propertyMeta) {
-    if (_isTypedRealmObject<LinkT>()) return getByType(LinkT);
+    if (_isTypedRealmObject<LinkT>()) {
+      return getByType(LinkT);
+    }
+
     final target = propertyMeta.schema.linkTarget;
     if (target != null) {
       return getByName(target);
     }
+
     return null;
   }
 }

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -74,7 +74,8 @@ export "configuration.dart"
         SyncClientResetErrorHandler;
 export 'credentials.dart' show Credentials, AuthProviderType, EmailPasswordAuthProvider;
 export 'list.dart' show RealmList, RealmListOfObject, RealmListChanges;
-export 'realm_object.dart' show RealmEntityMixin, RealmObjectMixin, RealmException, RealmObject, RealmObjectChanges, DynamicRealmObject;
+export 'realm_object.dart'
+    show RealmEntityMixin, RealmObjectBaseMixin, RealmException, RealmObject, RealmObjectChanges, DynamicRealmObject, RealmObjectBase, RealmObjectMixin;
 export 'realm_property.dart';
 export 'results.dart' show RealmResults, RealmResultsChanges;
 export 'session.dart' show Session, SessionState, ConnectionState, ProgressDirection, ProgressMode, SyncProgress, ConnectionStateChange;
@@ -175,7 +176,7 @@ class Realm implements Finalizable {
     return object;
   }
 
-  RealmObjectHandle _createObject(RealmObject object, RealmObjectMetadata metadata, bool update) {
+  RealmObjectHandle _createObject(RealmObjectBase object, RealmObjectMetadata metadata, bool update) {
     final key = metadata.key;
     final primaryKey = metadata.primaryKey;
     if (primaryKey == null) {
@@ -365,7 +366,7 @@ class Transaction {
   }
 }
 
-bool _isTypedRealmObject<T>() => isStrictSubtype<T, RealmObject?>();
+bool _isTypedRealmObject<T>() => isStrictSubtype<T, RealmObjectBase?>();
 
 /// @nodoc
 extension RealmInternal on Realm {
@@ -489,7 +490,7 @@ class RealmMetadata {
       _typeMap[type] ??
       (throw RealmError("Object type $type not configured in the current Realm's schema. Add type $type to your config before opening the Realm"));
 
-  RealmObjectMetadata getByStaticType<T extends RealmObject>() => getByType(T);
+  RealmObjectMetadata getByStaticType<T extends RealmObjectBase>() => getByType(T);
 
   RealmObjectMetadata getByName(String name) =>
       _stringMap[name] ??

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -146,9 +146,21 @@ class RealmCoreAccessor implements RealmAccessor {
         }
         return;
       }
+
+      if (value is EmbeddedObject) {
+        if (value.isManaged) {
+          throw RealmError("Can't set an embedded object that is already managed");
+        }
+
+        final handle = realmCore.createEmbeddedObject(object, propertyMeta.key);
+        object.realm.manageEmbedded(handle, value, update: update);
+        return;
+      }
+
       if (value is RealmObject && !value.isManaged) {
         object.realm.add<RealmObject>(value, update: update); // Compiler issue. Why is the explicit type argument needed?
       }
+
       realmCore.setProperty(object, propertyMeta.key, value, isDefault);
     } on Exception catch (e) {
       throw RealmException("Error setting property ${metadata.type}.$propertyName Error: $e");
@@ -156,6 +168,7 @@ class RealmCoreAccessor implements RealmAccessor {
   }
 }
 
+/// @nodoc
 mixin RealmEntityMixin {
   Realm? _realm;
 
@@ -274,6 +287,9 @@ mixin RealmObjectBaseMixin on RealmEntityMixin implements Finalizable, RealmObje
 
 /// @nodoc
 mixin RealmObjectMixin on RealmObjectBaseMixin implements RealmObject {}
+
+/// @nodoc
+mixin EmbeddedObjectMixin on RealmObjectBaseMixin implements EmbeddedObject {}
 
 /// @nodoc
 //RealmObject package internal members

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -144,8 +144,6 @@ class RealmCoreAccessor implements RealmAccessor {
             realm,
             listMeta,
           ) as RealmList<ElementT>;
-        case ObjectType.asymmetric:
-          throw RealmError("Getting a list of asymmetric objects is not supported");
         default:
           // Fallback
           break;
@@ -357,8 +355,6 @@ extension RealmObjectInternal on RealmObjectBase {
         case ObjectType.embedded:
           object = _ConcreteEmbeddedObject() as T; // compiler needs the cast
           break;
-        case ObjectType.asymmetric:
-          throw RealmError('Asymmetric objects are not supported yet.');
       }
     }
     if (object is RealmObjectBaseMixin) {

--- a/lib/src/realm_property.dart
+++ b/lib/src/realm_property.dart
@@ -192,12 +192,21 @@ class _DynamicProperty implements SchemaProperty {
     final map = propertyType.mapping;
     final accessor = object.accessor;
     if (collectionType == RealmCollectionType.none) {
-      if (propertyType == RealmPropertyType.object) return map.getObject(accessor, object, name);
-      if (optional) return map.getNullableValue(accessor, object, name);
+      if (propertyType == RealmPropertyType.object) {
+        return map.getObject(accessor, object, name);
+      }
+
+      if (optional) {
+        return map.getNullableValue(accessor, object, name);
+      }
+
       return map.getValue(accessor, object, name);
     }
     if (collectionType == RealmCollectionType.list) {
-      if (optional) return map.getListOfNullables(accessor, object, name);
+      if (optional) {
+        return map.getListOfNullables(accessor, object, name);
+      }
+
       return map.getList(accessor, object, name);
     }
     throw RealmError('Unsupported collection type: $collectionType');

--- a/lib/src/realm_property.dart
+++ b/lib/src/realm_property.dart
@@ -22,7 +22,7 @@ import 'realm_object.dart';
 import 'list.dart';
 import 'type_utils.dart';
 
-/// Describes a [RealmObject]'s property with its name, type and other attributes in the [RealmSchema]
+/// Describes a [RealmObjectBase]'s property with its name, type and other attributes in the [RealmSchema]
 ///{@category Configuration}
 abstract class SchemaProperty {
   /// The name of the property as persisted in the [Realm]
@@ -53,10 +53,10 @@ abstract class SchemaProperty {
   Object? get defaultValue;
 
   /// Get value of this property from [object]
-  Object? getValue(RealmObject object);
+  Object? getValue(RealmObjectBase object);
 
   /// Set value of this property on [object]
-  void setValue(RealmObject object, Object? value);
+  void setValue(RealmObjectBase object, Object? value);
 
   factory SchemaProperty.dynamic({
     required String name,
@@ -106,7 +106,7 @@ abstract class BaseProperty<T extends Object?> implements SchemaProperty {
   final T? defaultValue;
 
   @override
-  void setValue(RealmObject object, covariant T value) {
+  void setValue(RealmObjectBase object, covariant T value) {
     object.accessor.set(object, name, value);
   }
 }
@@ -123,7 +123,7 @@ class ValueProperty<T extends Object?> extends BaseProperty<T> {
   });
 
   @override
-  T getValue(RealmObject object) {
+  T getValue(RealmObjectBase object) {
     return (object.accessor.getValue<T>(object, name) ?? defaultValue) as T;
   }
 
@@ -132,11 +132,11 @@ class ValueProperty<T extends Object?> extends BaseProperty<T> {
 }
 
 /// @nodoc
-class ObjectProperty<LinkT extends RealmObject> extends BaseProperty<LinkT?> {
+class ObjectProperty<LinkT extends RealmObjectBase> extends BaseProperty<LinkT?> {
   const ObjectProperty(String name, String linkTarget) : super(name, RealmPropertyType.object, linkTarget: linkTarget);
 
   @override
-  LinkT? getValue(RealmObject object) {
+  LinkT? getValue(RealmObjectBase object) {
     return object.accessor.getObject<LinkT>(object, name);
   }
 
@@ -149,7 +149,7 @@ class ListProperty<ElementT extends Object?> extends BaseProperty<RealmList<Elem
   const ListProperty(super.name, super.propertyType, {super.linkTarget}) : super(collectionType: RealmCollectionType.list);
 
   @override
-  RealmList<ElementT> getValue(RealmObject object) {
+  RealmList<ElementT> getValue(RealmObjectBase object) {
     return object.accessor.getList<ElementT>(object, name);
   }
 
@@ -188,7 +188,7 @@ class _DynamicProperty implements SchemaProperty {
   Object? get defaultValue => null;
 
   @override
-  Object? getValue(RealmObject object) {
+  Object? getValue(RealmObjectBase object) {
     final map = propertyType.mapping;
     final accessor = object.accessor;
     if (collectionType == RealmCollectionType.none) {
@@ -204,7 +204,7 @@ class _DynamicProperty implements SchemaProperty {
   }
 
   @override
-  void setValue(RealmObject object, Object? value) {
+  void setValue(RealmObjectBase object, Object? value) {
     object.accessor.set(object, name, value);
   }
 

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -36,7 +36,7 @@ class RealmResults<T extends Object?> extends collection.IterableBase<T> impleme
   /// The Realm instance this collection belongs to.
   final Realm realm;
 
-  final _supportsSnapshot = <T>[] is List<RealmObject?>;
+  final _supportsSnapshot = <T>[] is List<RealmObjectBase?>;
 
   RealmResults._(this._handle, this.realm, this._metadata);
 

--- a/test/dynamic_realm_test.dart
+++ b/test/dynamic_realm_test.dart
@@ -32,6 +32,7 @@ Future<void> main([List<String>? args]) async {
 
   _assertSchemaExists(Realm realm, SchemaObject expected) {
     final foundSchema = realm.schema[expected.name]!;
+    expect(foundSchema.baseType, expected.baseType);
     expect(foundSchema.properties.length, expected.properties.length);
 
     for (final prop in foundSchema.properties.values) {
@@ -45,19 +46,35 @@ Future<void> main([List<String>? args]) async {
   }
 
   test('schema is read from disk', () {
-    final config = Configuration.local([Car.schema, Dog.schema, Person.schema, AllTypes.schema, LinksClass.schema]);
+    final config = Configuration.local([
+      Car.schema,
+      Dog.schema,
+      Person.schema,
+      AllTypes.schema,
+      LinksClass.schema,
+      ObjectWithEmbedded.schema,
+      AllTypesEmbedded.schema,
+      RecursiveEmbedded1.schema,
+      RecursiveEmbedded2.schema,
+      RecursiveEmbedded3.schema
+    ]);
     getRealm(config).close();
 
     final dynamicConfig = Configuration.local([]);
     final realm = getRealm(dynamicConfig);
 
-    expect(realm.schema.length, 5);
+    expect(realm.schema.length, 10);
 
     _assertSchemaExists(realm, Car.schema);
     _assertSchemaExists(realm, Dog.schema);
     _assertSchemaExists(realm, Person.schema);
     _assertSchemaExists(realm, AllTypes.schema);
     _assertSchemaExists(realm, LinksClass.schema);
+    _assertSchemaExists(realm, ObjectWithEmbedded.schema);
+    _assertSchemaExists(realm, AllTypesEmbedded.schema);
+    _assertSchemaExists(realm, RecursiveEmbedded1.schema);
+    _assertSchemaExists(realm, RecursiveEmbedded2.schema);
+    _assertSchemaExists(realm, RecursiveEmbedded3.schema);
   });
 
   test('dynamic is always the same', () {

--- a/test/embedded_test.dart
+++ b/test/embedded_test.dart
@@ -1,0 +1,129 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// ignore_for_file: unused_local_variable
+
+import 'package:test/test.dart' hide test, throws;
+import '../lib/realm.dart';
+import 'test.dart';
+
+Future<void> main([List<String>? args]) async {
+  await setupTests(args);
+
+  test('local Realm with orphan embedded schemas works', () {
+    final config = Configuration.local([AllTypesEmbedded.schema]);
+    final realm = getRealm(config);
+    realm.close();
+
+    final dynamicRealm = getRealm(Configuration.local([], path: config.path));
+
+    final schema = dynamicRealm.schema;
+    expect(schema.values.single.baseType, ObjectType.embedded);
+  });
+
+  baasTest('synchronized Realm with orphan embedded schemas throws', (configuration) async {
+    final app = App(configuration);
+    final user = await getIntegrationUser(app);
+    final config = Configuration.flexibleSync(user, [AllTypesEmbedded.schema]);
+
+    expect(() => getRealm(config), throws<RealmException>("Embedded object 'AllTypesEmbedded' is unreachable by any link path from top level objects"));
+  });
+
+  test('Embedded object roundtrip', () {
+    final config = Configuration.local(
+        [AllTypesEmbedded.schema, ObjectWithEmbedded.schema, RecursiveEmbedded1.schema, RecursiveEmbedded2.schema, RecursiveEmbedded3.schema]);
+    final realm = getRealm(config);
+
+    final now = DateTime.now();
+    final oid = ObjectId();
+    final uuid = Uuid.v4();
+    realm.write(() {
+      realm.add(ObjectWithEmbedded('abc', singleObject: AllTypesEmbedded('str', true, now, 1.23, oid, uuid, 99)));
+    });
+
+    final obj = realm.all<ObjectWithEmbedded>().single;
+    final json = obj.toJson();
+
+    expect(json, contains('"stringProp":"str"'));
+    expect(json, contains('"boolProp":true'));
+    expect(json, contains('"dateProp":"${now.toNormalizedDateString()}"'));
+    expect(json, contains('"doubleProp":1.23'));
+    expect(json, contains('"objectIdProp":"$oid"'));
+    expect(json, contains('"uuidProp":"$uuid"'));
+    expect(json, contains('"intProp":99'));
+
+    expect(json, contains('"nullableStringProp":null'));
+    expect(json, contains('"nullableBoolProp":null'));
+    expect(json, contains('"nullableDateProp":null'));
+    expect(json, contains('"nullableDoubleProp":null'));
+    expect(json, contains('"nullableObjectIdProp":null'));
+    expect(json, contains('"nullableUuidProp":null'));
+    expect(json, contains('"nullableIntProp":null'));
+  });
+
+  test('Embedded object get/set properties', () {
+    final config = Configuration.local(
+        [AllTypesEmbedded.schema, ObjectWithEmbedded.schema, RecursiveEmbedded1.schema, RecursiveEmbedded2.schema, RecursiveEmbedded3.schema]);
+    final realm = getRealm(config);
+
+    final graph = ObjectWithEmbedded('TopLevel1',
+        recursiveObject: RecursiveEmbedded1('Child1', child: RecursiveEmbedded2('Child2'), children: [
+          RecursiveEmbedded2('List1', child: RecursiveEmbedded3('Child3'), topLevel: ObjectWithEmbedded('TopLeve2')),
+          RecursiveEmbedded2('List2'),
+        ]));
+
+    // Make a cycle
+    graph.recursiveObject!.child!.topLevel = graph;
+    realm.write(() {
+      realm.add(graph);
+    });
+
+    expect(graph.isManaged, true);
+    expect(graph.recursiveObject!.isManaged, true);
+
+    final refetched = realm.all<ObjectWithEmbedded>().first;
+
+    expect(refetched, graph);
+    expect(refetched.value, 'TopLevel1');
+
+    final child1 = refetched.recursiveObject;
+    expect(child1, isNotNull);
+    expect(child1!.isManaged, true);
+    expect(child1.value, 'Child1');
+    expect(child1.topLevel, isNull);
+
+    final child2 = child1.child;
+    expect(child2, isNotNull);
+    expect(child2!.isManaged, true);
+    expect(child2.value, 'Child2');
+    expect(child2.topLevel, refetched);
+    expect(child2.child, isNull);
+    expect(child2.children, isEmpty);
+
+    final listChild1 = child1.children[0];
+    expect(listChild1.isManaged, true);
+    expect(listChild1.value, 'List1');
+    expect(listChild1.child!.value, 'Child3');
+    expect(listChild1.topLevel!.value, 'TopLeve2');
+
+    final listChild2 = child1.children[1];
+    expect(listChild2.isManaged, true);
+    expect(listChild2.value, 'List2');
+    expect(listChild2.child, isNull);
+  });
+}

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -93,8 +93,8 @@ Future<void> main([List<String>? args]) async {
     final teams = realm.all<Team>();
     final players = teams[0].players;
 
-    expect(() => realm.write(() => players[-1] = Person('')), throws<RealmException>("Index out of range"));
-    expect(() => realm.write(() => players[800] = Person('')), throws<RealmException>());
+    expect(() => realm.write(() => players[-1] = Person('')), throws<RealmException>("Index can not be negative"));
+    expect(() => realm.write(() => players[800] = Person('')), throws<RealmException>("Index can not exceed the size of the list: 800, size: 0"));
   });
 
   test('List clear items from list', () {

--- a/test/realm_object_test.dart
+++ b/test/realm_object_test.dart
@@ -90,20 +90,6 @@ class _BoolValue {
   late bool value;
 }
 
-extension on DateTime {
-  String toNormalizedDateString() {
-    final utc = toUtc();
-    // This is kind of silly, but Core serializes negative dates as -003-01-01 12:34:56
-    final utcYear = utc.year < 0 ? '-${utc.year.abs().toString().padLeft(3, '0')}' : utc.year.toString().padLeft(4, '0');
-
-    // For some reason Core always rounds up to the next second for negative dates, so we need to do the same
-    final seconds = utc.microsecondsSinceEpoch < 0 && utc.microsecondsSinceEpoch % 1000000 != 0 ? utc.second + 1 : utc.second;
-    return '$utcYear-${_format(utc.month)}-${_format(utc.day)} ${_format(utc.hour)}:${_format(utc.minute)}:${_format(seconds)}';
-  }
-
-  static String _format(int value) => value.toString().padLeft(2, '0');
-}
-
 Future<void> main([List<String>? args]) async {
   await setupTests(args);
 

--- a/test/realm_object_test.g.dart
+++ b/test/realm_object_test.g.dart
@@ -31,6 +31,7 @@ class ObjectIdPrimaryKey extends _ObjectIdPrimaryKey
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<ObjectIdPrimaryKey>(
+    ObjectType.topLevel,
     ObjectIdPrimaryKey._,
     'ObjectIdPrimaryKey',
     {
@@ -67,6 +68,7 @@ class NullableObjectIdPrimaryKey extends _NullableObjectIdPrimaryKey
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableObjectIdPrimaryKey>(
+    ObjectType.topLevel,
     NullableObjectIdPrimaryKey._,
     'NullableObjectIdPrimaryKey',
     {
@@ -103,6 +105,7 @@ class IntPrimaryKey extends _IntPrimaryKey
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<IntPrimaryKey>(
+    ObjectType.topLevel,
     IntPrimaryKey._,
     'IntPrimaryKey',
     {
@@ -139,6 +142,7 @@ class NullableIntPrimaryKey extends _NullableIntPrimaryKey
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableIntPrimaryKey>(
+    ObjectType.topLevel,
     NullableIntPrimaryKey._,
     'NullableIntPrimaryKey',
     {
@@ -175,6 +179,7 @@ class StringPrimaryKey extends _StringPrimaryKey
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<StringPrimaryKey>(
+    ObjectType.topLevel,
     StringPrimaryKey._,
     'StringPrimaryKey',
     {
@@ -211,6 +216,7 @@ class NullableStringPrimaryKey extends _NullableStringPrimaryKey
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableStringPrimaryKey>(
+    ObjectType.topLevel,
     NullableStringPrimaryKey._,
     'NullableStringPrimaryKey',
     {
@@ -247,6 +253,7 @@ class UuidPrimaryKey extends _UuidPrimaryKey
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<UuidPrimaryKey>(
+    ObjectType.topLevel,
     UuidPrimaryKey._,
     'UuidPrimaryKey',
     {
@@ -283,6 +290,7 @@ class NullableUuidPrimaryKey extends _NullableUuidPrimaryKey
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableUuidPrimaryKey>(
+    ObjectType.topLevel,
     NullableUuidPrimaryKey._,
     'NullableUuidPrimaryKey',
     {
@@ -318,6 +326,7 @@ class RemappedFromAnotherFile extends _RemappedFromAnotherFile
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<RemappedFromAnotherFile>(
+    ObjectType.topLevel,
     RemappedFromAnotherFile._,
     'class with spaces',
     {
@@ -364,6 +373,7 @@ class BoolValue extends _BoolValue
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<BoolValue>(
+    ObjectType.topLevel,
     BoolValue._,
     'BoolValue',
     {

--- a/test/realm_object_test.g.dart
+++ b/test/realm_object_test.g.dart
@@ -7,7 +7,7 @@ part of 'realm_object_test.dart';
 // **************************************************************************
 
 class ObjectIdPrimaryKey extends _ObjectIdPrimaryKey
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   ObjectIdPrimaryKey(
     ObjectId id,
   ) {
@@ -28,7 +28,7 @@ class ObjectIdPrimaryKey extends _ObjectIdPrimaryKey
 
   @override
   Stream<RealmObjectChanges<ObjectIdPrimaryKey>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<ObjectIdPrimaryKey>(
     ObjectIdPrimaryKey._,
@@ -43,7 +43,7 @@ class ObjectIdPrimaryKey extends _ObjectIdPrimaryKey
 }
 
 class NullableObjectIdPrimaryKey extends _NullableObjectIdPrimaryKey
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableObjectIdPrimaryKey(
     ObjectId? id,
   ) {
@@ -64,7 +64,7 @@ class NullableObjectIdPrimaryKey extends _NullableObjectIdPrimaryKey
 
   @override
   Stream<RealmObjectChanges<NullableObjectIdPrimaryKey>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableObjectIdPrimaryKey>(
     NullableObjectIdPrimaryKey._,
@@ -79,7 +79,7 @@ class NullableObjectIdPrimaryKey extends _NullableObjectIdPrimaryKey
 }
 
 class IntPrimaryKey extends _IntPrimaryKey
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   IntPrimaryKey(
     int id,
   ) {
@@ -100,7 +100,7 @@ class IntPrimaryKey extends _IntPrimaryKey
 
   @override
   Stream<RealmObjectChanges<IntPrimaryKey>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<IntPrimaryKey>(
     IntPrimaryKey._,
@@ -115,7 +115,7 @@ class IntPrimaryKey extends _IntPrimaryKey
 }
 
 class NullableIntPrimaryKey extends _NullableIntPrimaryKey
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableIntPrimaryKey(
     int? id,
   ) {
@@ -136,7 +136,7 @@ class NullableIntPrimaryKey extends _NullableIntPrimaryKey
 
   @override
   Stream<RealmObjectChanges<NullableIntPrimaryKey>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableIntPrimaryKey>(
     NullableIntPrimaryKey._,
@@ -151,7 +151,7 @@ class NullableIntPrimaryKey extends _NullableIntPrimaryKey
 }
 
 class StringPrimaryKey extends _StringPrimaryKey
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   StringPrimaryKey(
     String id,
   ) {
@@ -172,7 +172,7 @@ class StringPrimaryKey extends _StringPrimaryKey
 
   @override
   Stream<RealmObjectChanges<StringPrimaryKey>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<StringPrimaryKey>(
     StringPrimaryKey._,
@@ -187,7 +187,7 @@ class StringPrimaryKey extends _StringPrimaryKey
 }
 
 class NullableStringPrimaryKey extends _NullableStringPrimaryKey
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableStringPrimaryKey(
     String? id,
   ) {
@@ -208,7 +208,7 @@ class NullableStringPrimaryKey extends _NullableStringPrimaryKey
 
   @override
   Stream<RealmObjectChanges<NullableStringPrimaryKey>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableStringPrimaryKey>(
     NullableStringPrimaryKey._,
@@ -223,7 +223,7 @@ class NullableStringPrimaryKey extends _NullableStringPrimaryKey
 }
 
 class UuidPrimaryKey extends _UuidPrimaryKey
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   UuidPrimaryKey(
     Uuid id,
   ) {
@@ -244,7 +244,7 @@ class UuidPrimaryKey extends _UuidPrimaryKey
 
   @override
   Stream<RealmObjectChanges<UuidPrimaryKey>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<UuidPrimaryKey>(
     UuidPrimaryKey._,
@@ -259,7 +259,7 @@ class UuidPrimaryKey extends _UuidPrimaryKey
 }
 
 class NullableUuidPrimaryKey extends _NullableUuidPrimaryKey
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableUuidPrimaryKey(
     Uuid? id,
   ) {
@@ -280,7 +280,7 @@ class NullableUuidPrimaryKey extends _NullableUuidPrimaryKey
 
   @override
   Stream<RealmObjectChanges<NullableUuidPrimaryKey>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableUuidPrimaryKey>(
     NullableUuidPrimaryKey._,
@@ -295,7 +295,7 @@ class NullableUuidPrimaryKey extends _NullableUuidPrimaryKey
 }
 
 class RemappedFromAnotherFile extends _RemappedFromAnotherFile
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   RemappedFromAnotherFile({
     RemappedClass? linkToAnotherClass,
   }) {
@@ -315,7 +315,7 @@ class RemappedFromAnotherFile extends _RemappedFromAnotherFile
 
   @override
   Stream<RealmObjectChanges<RemappedFromAnotherFile>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<RemappedFromAnotherFile>(
     RemappedFromAnotherFile._,
@@ -328,7 +328,8 @@ class RemappedFromAnotherFile extends _RemappedFromAnotherFile
   SchemaObject get instanceSchema => schema;
 }
 
-class BoolValue extends _BoolValue with RealmEntityMixin, RealmObjectMixin {
+class BoolValue extends _BoolValue
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   BoolValue(
     int key,
     bool value,
@@ -360,7 +361,7 @@ class BoolValue extends _BoolValue with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<BoolValue>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<BoolValue>(
     BoolValue._,

--- a/test/test.dart
+++ b/test/test.dart
@@ -240,25 +240,23 @@ class _AllTypesEmbedded {
   late List<ObjectId> objectIds;
   late List<Uuid> uuids;
   late List<int> ints;
-
-  late List<String?> nullableStrings;
-  late List<bool?> nullableBools;
-  late List<DateTime?> nullableDates;
-  late List<double?> nullableDoubles;
-  late List<ObjectId?> nullableObjectIds;
-  late List<Uuid?> nullableUuids;
-  late List<int?> nullableInts;
 }
 
 @RealmModel()
 class _ObjectWithEmbedded {
-  late String value;
+  @PrimaryKey()
+  @MapTo('_id')
+  late String id;
+
+  late Uuid? differentiator;
 
   late _AllTypesEmbedded? singleObject;
 
   late List<_AllTypesEmbedded> list;
 
   late _RecursiveEmbedded1? recursiveObject;
+
+  late List<_RecursiveEmbedded1> recursiveList;
 }
 
 @RealmModel(ObjectType.embedded)
@@ -517,6 +515,10 @@ Future<User> getIntegrationUser(App app) async {
   await app.emailPasswordAuthProvider.registerUser(email, password);
 
   return await loginWithRetry(app, Credentials.emailPassword(email, password));
+}
+
+Future<User> getAnonymousUser(App app) {
+  return app.logIn(Credentials.anonymous(reuseCredentials: false));
 }
 
 Future<Realm> getIntegrationRealm({App? app, ObjectId? differentiator}) async {

--- a/test/test.g.dart
+++ b/test/test.g.dart
@@ -1399,13 +1399,6 @@ class AllTypesEmbedded extends _AllTypesEmbedded
     Iterable<ObjectId> objectIds = const [],
     Iterable<Uuid> uuids = const [],
     Iterable<int> ints = const [],
-    Iterable<String?> nullableStrings = const [],
-    Iterable<bool?> nullableBools = const [],
-    Iterable<DateTime?> nullableDates = const [],
-    Iterable<double?> nullableDoubles = const [],
-    Iterable<ObjectId?> nullableObjectIds = const [],
-    Iterable<Uuid?> nullableUuids = const [],
-    Iterable<int?> nullableInts = const [],
   }) {
     _stringPropProperty.setValue(this, stringProp);
     _boolPropProperty.setValue(this, boolProp);
@@ -1428,16 +1421,6 @@ class AllTypesEmbedded extends _AllTypesEmbedded
     _objectIdsProperty.setValue(this, RealmList<ObjectId>(objectIds));
     _uuidsProperty.setValue(this, RealmList<Uuid>(uuids));
     _intsProperty.setValue(this, RealmList<int>(ints));
-    _nullableStringsProperty.setValue(
-        this, RealmList<String?>(nullableStrings));
-    _nullableBoolsProperty.setValue(this, RealmList<bool?>(nullableBools));
-    _nullableDatesProperty.setValue(this, RealmList<DateTime?>(nullableDates));
-    _nullableDoublesProperty.setValue(
-        this, RealmList<double?>(nullableDoubles));
-    _nullableObjectIdsProperty.setValue(
-        this, RealmList<ObjectId?>(nullableObjectIds));
-    _nullableUuidsProperty.setValue(this, RealmList<Uuid?>(nullableUuids));
-    _nullableIntsProperty.setValue(this, RealmList<int?>(nullableInts));
   }
 
   AllTypesEmbedded._();
@@ -1631,66 +1614,6 @@ class AllTypesEmbedded extends _AllTypesEmbedded
   @override
   set ints(covariant RealmList<int> value) => throw RealmUnsupportedSetError();
 
-  static const _nullableStringsProperty =
-      ListProperty<String?>('nullableStrings', RealmPropertyType.string);
-  @override
-  RealmList<String?> get nullableStrings =>
-      _nullableStringsProperty.getValue(this);
-  @override
-  set nullableStrings(covariant RealmList<String?> value) =>
-      throw RealmUnsupportedSetError();
-
-  static const _nullableBoolsProperty =
-      ListProperty<bool?>('nullableBools', RealmPropertyType.bool);
-  @override
-  RealmList<bool?> get nullableBools => _nullableBoolsProperty.getValue(this);
-  @override
-  set nullableBools(covariant RealmList<bool?> value) =>
-      throw RealmUnsupportedSetError();
-
-  static const _nullableDatesProperty =
-      ListProperty<DateTime?>('nullableDates', RealmPropertyType.timestamp);
-  @override
-  RealmList<DateTime?> get nullableDates =>
-      _nullableDatesProperty.getValue(this);
-  @override
-  set nullableDates(covariant RealmList<DateTime?> value) =>
-      throw RealmUnsupportedSetError();
-
-  static const _nullableDoublesProperty =
-      ListProperty<double?>('nullableDoubles', RealmPropertyType.double);
-  @override
-  RealmList<double?> get nullableDoubles =>
-      _nullableDoublesProperty.getValue(this);
-  @override
-  set nullableDoubles(covariant RealmList<double?> value) =>
-      throw RealmUnsupportedSetError();
-
-  static const _nullableObjectIdsProperty =
-      ListProperty<ObjectId?>('nullableObjectIds', RealmPropertyType.objectid);
-  @override
-  RealmList<ObjectId?> get nullableObjectIds =>
-      _nullableObjectIdsProperty.getValue(this);
-  @override
-  set nullableObjectIds(covariant RealmList<ObjectId?> value) =>
-      throw RealmUnsupportedSetError();
-
-  static const _nullableUuidsProperty =
-      ListProperty<Uuid?>('nullableUuids', RealmPropertyType.uuid);
-  @override
-  RealmList<Uuid?> get nullableUuids => _nullableUuidsProperty.getValue(this);
-  @override
-  set nullableUuids(covariant RealmList<Uuid?> value) =>
-      throw RealmUnsupportedSetError();
-
-  static const _nullableIntsProperty =
-      ListProperty<int?>('nullableInts', RealmPropertyType.int);
-  @override
-  RealmList<int?> get nullableInts => _nullableIntsProperty.getValue(this);
-  @override
-  set nullableInts(covariant RealmList<int?> value) =>
-      throw RealmUnsupportedSetError();
-
   @override
   Stream<RealmObjectChanges<AllTypesEmbedded>> get changes =>
       RealmObjectBaseMixin.getChanges(this);
@@ -1721,13 +1644,6 @@ class AllTypesEmbedded extends _AllTypesEmbedded
       'objectIds': _objectIdsProperty,
       'uuids': _uuidsProperty,
       'ints': _intsProperty,
-      'nullableStrings': _nullableStringsProperty,
-      'nullableBools': _nullableBoolsProperty,
-      'nullableDates': _nullableDatesProperty,
-      'nullableDoubles': _nullableDoublesProperty,
-      'nullableObjectIds': _nullableObjectIdsProperty,
-      'nullableUuids': _nullableUuidsProperty,
-      'nullableInts': _nullableIntsProperty,
     },
   );
   @override
@@ -1737,27 +1653,43 @@ class AllTypesEmbedded extends _AllTypesEmbedded
 class ObjectWithEmbedded extends _ObjectWithEmbedded
     with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   ObjectWithEmbedded(
-    String value, {
+    String id, {
+    Uuid? differentiator,
     AllTypesEmbedded? singleObject,
     RecursiveEmbedded1? recursiveObject,
     Iterable<AllTypesEmbedded> list = const [],
+    Iterable<RecursiveEmbedded1> recursiveList = const [],
   }) {
-    _valueProperty.setValue(this, value);
+    _idProperty.setValue(this, id);
+    _differentiatorProperty.setValue(this, differentiator);
     _singleObjectProperty.setValue(this, singleObject);
     _recursiveObjectProperty.setValue(this, recursiveObject);
     _listProperty.setValue(this, RealmList<AllTypesEmbedded>(list));
+    _recursiveListProperty.setValue(
+        this, RealmList<RecursiveEmbedded1>(recursiveList));
   }
 
   ObjectWithEmbedded._();
 
-  static const _valueProperty = ValueProperty<String>(
-    'value',
+  static const _idProperty = ValueProperty<String>(
+    '_id',
     RealmPropertyType.string,
+    primaryKey: true,
   );
   @override
-  String get value => _valueProperty.getValue(this);
+  String get id => _idProperty.getValue(this);
   @override
-  set value(String value) => _valueProperty.setValue(this, value);
+  set id(String value) => throw RealmUnsupportedSetError();
+
+  static const _differentiatorProperty = ValueProperty<Uuid?>(
+    'differentiator',
+    RealmPropertyType.uuid,
+  );
+  @override
+  Uuid? get differentiator => _differentiatorProperty.getValue(this);
+  @override
+  set differentiator(Uuid? value) =>
+      _differentiatorProperty.setValue(this, value);
 
   static const _singleObjectProperty =
       ObjectProperty<AllTypesEmbedded>('singleObject', 'AllTypesEmbedded');
@@ -1785,6 +1717,16 @@ class ObjectWithEmbedded extends _ObjectWithEmbedded
   set recursiveObject(covariant RecursiveEmbedded1? value) =>
       _recursiveObjectProperty.setValue(this, value);
 
+  static const _recursiveListProperty = ListProperty<RecursiveEmbedded1>(
+      'recursiveList', RealmPropertyType.object,
+      linkTarget: 'RecursiveEmbedded1');
+  @override
+  RealmList<RecursiveEmbedded1> get recursiveList =>
+      _recursiveListProperty.getValue(this);
+  @override
+  set recursiveList(covariant RealmList<RecursiveEmbedded1> value) =>
+      throw RealmUnsupportedSetError();
+
   @override
   Stream<RealmObjectChanges<ObjectWithEmbedded>> get changes =>
       RealmObjectBaseMixin.getChanges(this);
@@ -1794,11 +1736,14 @@ class ObjectWithEmbedded extends _ObjectWithEmbedded
     ObjectWithEmbedded._,
     'ObjectWithEmbedded',
     {
-      'value': _valueProperty,
+      '_id': _idProperty,
+      'differentiator': _differentiatorProperty,
       'singleObject': _singleObjectProperty,
       'list': _listProperty,
       'recursiveObject': _recursiveObjectProperty,
+      'recursiveList': _recursiveListProperty,
     },
+    _idProperty,
   );
   @override
   SchemaObject get instanceSchema => schema;

--- a/test/test.g.dart
+++ b/test/test.g.dart
@@ -31,6 +31,7 @@ class Car extends _Car
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Car>(
+    ObjectType.topLevel,
     Car._,
     'Car',
     {
@@ -66,6 +67,7 @@ class Person extends _Person
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
+    ObjectType.topLevel,
     Person._,
     'Person',
     {
@@ -120,6 +122,7 @@ class Dog extends _Dog
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Dog>(
+    ObjectType.topLevel,
     Dog._,
     'Dog',
     {
@@ -178,6 +181,7 @@ class Team extends _Team
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Team>(
+    ObjectType.topLevel,
     Team._,
     'Team',
     {
@@ -245,6 +249,7 @@ class Student extends _Student
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Student>(
+    ObjectType.topLevel,
     Student._,
     'Student',
     {
@@ -327,6 +332,7 @@ class School extends _School
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<School>(
+    ObjectType.topLevel,
     School._,
     'School',
     {
@@ -380,6 +386,7 @@ class RemappedClass extends $RemappedClass
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<RemappedClass>(
+    ObjectType.topLevel,
     RemappedClass._,
     'myRemappedClass',
     {
@@ -416,6 +423,7 @@ class Task extends _Task
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Task>(
+    ObjectType.topLevel,
     Task._,
     'Task',
     {
@@ -462,6 +470,7 @@ class Schedule extends _Schedule
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Schedule>(
+    ObjectType.topLevel,
     Schedule._,
     'Schedule',
     {
@@ -650,6 +659,7 @@ class AllTypes extends _AllTypes
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<AllTypes>(
+    ObjectType.topLevel,
     AllTypes._,
     'AllTypes',
     {
@@ -717,6 +727,7 @@ class LinksClass extends _LinksClass
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<LinksClass>(
+    ObjectType.topLevel,
     LinksClass._,
     'LinksClass',
     {
@@ -888,6 +899,7 @@ class AllCollections extends _AllCollections
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<AllCollections>(
+    ObjectType.topLevel,
     AllCollections._,
     'AllCollections',
     {
@@ -1026,6 +1038,7 @@ class NullableTypes extends _NullableTypes
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableTypes>(
+    ObjectType.topLevel,
     NullableTypes._,
     'NullableTypes',
     {
@@ -1115,6 +1128,7 @@ class Event extends _Event
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Event>(
+    ObjectType.topLevel,
     Event._,
     'Event',
     {
@@ -1182,6 +1196,7 @@ class Party extends _Party
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Party>(
+    ObjectType.topLevel,
     Party._,
     'Party',
     {
@@ -1253,6 +1268,7 @@ class Friend extends _Friend
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Friend>(
+    ObjectType.topLevel,
     Friend._,
     'Friend',
     {
@@ -1310,6 +1326,7 @@ class Player extends _Player
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Player>(
+    ObjectType.topLevel,
     Player._,
     'Player',
     {
@@ -1347,10 +1364,615 @@ class Game extends _Game
       RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Game>(
+    ObjectType.topLevel,
     Game._,
     'Game',
     {
       'winnerByRound': _winnerByRoundProperty,
+    },
+  );
+  @override
+  SchemaObject get instanceSchema => schema;
+}
+
+class AllTypesEmbedded extends _AllTypesEmbedded
+    with RealmEntityMixin, RealmObjectBaseMixin, EmbeddedObjectMixin {
+  AllTypesEmbedded(
+    String stringProp,
+    bool boolProp,
+    DateTime dateProp,
+    double doubleProp,
+    ObjectId objectIdProp,
+    Uuid uuidProp,
+    int intProp, {
+    String? nullableStringProp,
+    bool? nullableBoolProp,
+    DateTime? nullableDateProp,
+    double? nullableDoubleProp,
+    ObjectId? nullableObjectIdProp,
+    Uuid? nullableUuidProp,
+    int? nullableIntProp,
+    Iterable<String> strings = const [],
+    Iterable<bool> bools = const [],
+    Iterable<DateTime> dates = const [],
+    Iterable<double> doubles = const [],
+    Iterable<ObjectId> objectIds = const [],
+    Iterable<Uuid> uuids = const [],
+    Iterable<int> ints = const [],
+    Iterable<String?> nullableStrings = const [],
+    Iterable<bool?> nullableBools = const [],
+    Iterable<DateTime?> nullableDates = const [],
+    Iterable<double?> nullableDoubles = const [],
+    Iterable<ObjectId?> nullableObjectIds = const [],
+    Iterable<Uuid?> nullableUuids = const [],
+    Iterable<int?> nullableInts = const [],
+  }) {
+    _stringPropProperty.setValue(this, stringProp);
+    _boolPropProperty.setValue(this, boolProp);
+    _datePropProperty.setValue(this, dateProp);
+    _doublePropProperty.setValue(this, doubleProp);
+    _objectIdPropProperty.setValue(this, objectIdProp);
+    _uuidPropProperty.setValue(this, uuidProp);
+    _intPropProperty.setValue(this, intProp);
+    _nullableStringPropProperty.setValue(this, nullableStringProp);
+    _nullableBoolPropProperty.setValue(this, nullableBoolProp);
+    _nullableDatePropProperty.setValue(this, nullableDateProp);
+    _nullableDoublePropProperty.setValue(this, nullableDoubleProp);
+    _nullableObjectIdPropProperty.setValue(this, nullableObjectIdProp);
+    _nullableUuidPropProperty.setValue(this, nullableUuidProp);
+    _nullableIntPropProperty.setValue(this, nullableIntProp);
+    _stringsProperty.setValue(this, RealmList<String>(strings));
+    _boolsProperty.setValue(this, RealmList<bool>(bools));
+    _datesProperty.setValue(this, RealmList<DateTime>(dates));
+    _doublesProperty.setValue(this, RealmList<double>(doubles));
+    _objectIdsProperty.setValue(this, RealmList<ObjectId>(objectIds));
+    _uuidsProperty.setValue(this, RealmList<Uuid>(uuids));
+    _intsProperty.setValue(this, RealmList<int>(ints));
+    _nullableStringsProperty.setValue(
+        this, RealmList<String?>(nullableStrings));
+    _nullableBoolsProperty.setValue(this, RealmList<bool?>(nullableBools));
+    _nullableDatesProperty.setValue(this, RealmList<DateTime?>(nullableDates));
+    _nullableDoublesProperty.setValue(
+        this, RealmList<double?>(nullableDoubles));
+    _nullableObjectIdsProperty.setValue(
+        this, RealmList<ObjectId?>(nullableObjectIds));
+    _nullableUuidsProperty.setValue(this, RealmList<Uuid?>(nullableUuids));
+    _nullableIntsProperty.setValue(this, RealmList<int?>(nullableInts));
+  }
+
+  AllTypesEmbedded._();
+
+  static const _stringPropProperty = ValueProperty<String>(
+    'stringProp',
+    RealmPropertyType.string,
+  );
+  @override
+  String get stringProp => _stringPropProperty.getValue(this);
+  @override
+  set stringProp(String value) => _stringPropProperty.setValue(this, value);
+
+  static const _boolPropProperty = ValueProperty<bool>(
+    'boolProp',
+    RealmPropertyType.bool,
+  );
+  @override
+  bool get boolProp => _boolPropProperty.getValue(this);
+  @override
+  set boolProp(bool value) => _boolPropProperty.setValue(this, value);
+
+  static const _datePropProperty = ValueProperty<DateTime>(
+    'dateProp',
+    RealmPropertyType.timestamp,
+  );
+  @override
+  DateTime get dateProp => _datePropProperty.getValue(this);
+  @override
+  set dateProp(DateTime value) => _datePropProperty.setValue(this, value);
+
+  static const _doublePropProperty = ValueProperty<double>(
+    'doubleProp',
+    RealmPropertyType.double,
+  );
+  @override
+  double get doubleProp => _doublePropProperty.getValue(this);
+  @override
+  set doubleProp(double value) => _doublePropProperty.setValue(this, value);
+
+  static const _objectIdPropProperty = ValueProperty<ObjectId>(
+    'objectIdProp',
+    RealmPropertyType.objectid,
+  );
+  @override
+  ObjectId get objectIdProp => _objectIdPropProperty.getValue(this);
+  @override
+  set objectIdProp(ObjectId value) =>
+      _objectIdPropProperty.setValue(this, value);
+
+  static const _uuidPropProperty = ValueProperty<Uuid>(
+    'uuidProp',
+    RealmPropertyType.uuid,
+  );
+  @override
+  Uuid get uuidProp => _uuidPropProperty.getValue(this);
+  @override
+  set uuidProp(Uuid value) => _uuidPropProperty.setValue(this, value);
+
+  static const _intPropProperty = ValueProperty<int>(
+    'intProp',
+    RealmPropertyType.int,
+  );
+  @override
+  int get intProp => _intPropProperty.getValue(this);
+  @override
+  set intProp(int value) => _intPropProperty.setValue(this, value);
+
+  static const _nullableStringPropProperty = ValueProperty<String?>(
+    'nullableStringProp',
+    RealmPropertyType.string,
+  );
+  @override
+  String? get nullableStringProp => _nullableStringPropProperty.getValue(this);
+  @override
+  set nullableStringProp(String? value) =>
+      _nullableStringPropProperty.setValue(this, value);
+
+  static const _nullableBoolPropProperty = ValueProperty<bool?>(
+    'nullableBoolProp',
+    RealmPropertyType.bool,
+  );
+  @override
+  bool? get nullableBoolProp => _nullableBoolPropProperty.getValue(this);
+  @override
+  set nullableBoolProp(bool? value) =>
+      _nullableBoolPropProperty.setValue(this, value);
+
+  static const _nullableDatePropProperty = ValueProperty<DateTime?>(
+    'nullableDateProp',
+    RealmPropertyType.timestamp,
+  );
+  @override
+  DateTime? get nullableDateProp => _nullableDatePropProperty.getValue(this);
+  @override
+  set nullableDateProp(DateTime? value) =>
+      _nullableDatePropProperty.setValue(this, value);
+
+  static const _nullableDoublePropProperty = ValueProperty<double?>(
+    'nullableDoubleProp',
+    RealmPropertyType.double,
+  );
+  @override
+  double? get nullableDoubleProp => _nullableDoublePropProperty.getValue(this);
+  @override
+  set nullableDoubleProp(double? value) =>
+      _nullableDoublePropProperty.setValue(this, value);
+
+  static const _nullableObjectIdPropProperty = ValueProperty<ObjectId?>(
+    'nullableObjectIdProp',
+    RealmPropertyType.objectid,
+  );
+  @override
+  ObjectId? get nullableObjectIdProp =>
+      _nullableObjectIdPropProperty.getValue(this);
+  @override
+  set nullableObjectIdProp(ObjectId? value) =>
+      _nullableObjectIdPropProperty.setValue(this, value);
+
+  static const _nullableUuidPropProperty = ValueProperty<Uuid?>(
+    'nullableUuidProp',
+    RealmPropertyType.uuid,
+  );
+  @override
+  Uuid? get nullableUuidProp => _nullableUuidPropProperty.getValue(this);
+  @override
+  set nullableUuidProp(Uuid? value) =>
+      _nullableUuidPropProperty.setValue(this, value);
+
+  static const _nullableIntPropProperty = ValueProperty<int?>(
+    'nullableIntProp',
+    RealmPropertyType.int,
+  );
+  @override
+  int? get nullableIntProp => _nullableIntPropProperty.getValue(this);
+  @override
+  set nullableIntProp(int? value) =>
+      _nullableIntPropProperty.setValue(this, value);
+
+  static const _stringsProperty =
+      ListProperty<String>('strings', RealmPropertyType.string);
+  @override
+  RealmList<String> get strings => _stringsProperty.getValue(this);
+  @override
+  set strings(covariant RealmList<String> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _boolsProperty =
+      ListProperty<bool>('bools', RealmPropertyType.bool);
+  @override
+  RealmList<bool> get bools => _boolsProperty.getValue(this);
+  @override
+  set bools(covariant RealmList<bool> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _datesProperty =
+      ListProperty<DateTime>('dates', RealmPropertyType.timestamp);
+  @override
+  RealmList<DateTime> get dates => _datesProperty.getValue(this);
+  @override
+  set dates(covariant RealmList<DateTime> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _doublesProperty =
+      ListProperty<double>('doubles', RealmPropertyType.double);
+  @override
+  RealmList<double> get doubles => _doublesProperty.getValue(this);
+  @override
+  set doubles(covariant RealmList<double> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _objectIdsProperty =
+      ListProperty<ObjectId>('objectIds', RealmPropertyType.objectid);
+  @override
+  RealmList<ObjectId> get objectIds => _objectIdsProperty.getValue(this);
+  @override
+  set objectIds(covariant RealmList<ObjectId> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _uuidsProperty =
+      ListProperty<Uuid>('uuids', RealmPropertyType.uuid);
+  @override
+  RealmList<Uuid> get uuids => _uuidsProperty.getValue(this);
+  @override
+  set uuids(covariant RealmList<Uuid> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _intsProperty = ListProperty<int>('ints', RealmPropertyType.int);
+  @override
+  RealmList<int> get ints => _intsProperty.getValue(this);
+  @override
+  set ints(covariant RealmList<int> value) => throw RealmUnsupportedSetError();
+
+  static const _nullableStringsProperty =
+      ListProperty<String?>('nullableStrings', RealmPropertyType.string);
+  @override
+  RealmList<String?> get nullableStrings =>
+      _nullableStringsProperty.getValue(this);
+  @override
+  set nullableStrings(covariant RealmList<String?> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _nullableBoolsProperty =
+      ListProperty<bool?>('nullableBools', RealmPropertyType.bool);
+  @override
+  RealmList<bool?> get nullableBools => _nullableBoolsProperty.getValue(this);
+  @override
+  set nullableBools(covariant RealmList<bool?> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _nullableDatesProperty =
+      ListProperty<DateTime?>('nullableDates', RealmPropertyType.timestamp);
+  @override
+  RealmList<DateTime?> get nullableDates =>
+      _nullableDatesProperty.getValue(this);
+  @override
+  set nullableDates(covariant RealmList<DateTime?> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _nullableDoublesProperty =
+      ListProperty<double?>('nullableDoubles', RealmPropertyType.double);
+  @override
+  RealmList<double?> get nullableDoubles =>
+      _nullableDoublesProperty.getValue(this);
+  @override
+  set nullableDoubles(covariant RealmList<double?> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _nullableObjectIdsProperty =
+      ListProperty<ObjectId?>('nullableObjectIds', RealmPropertyType.objectid);
+  @override
+  RealmList<ObjectId?> get nullableObjectIds =>
+      _nullableObjectIdsProperty.getValue(this);
+  @override
+  set nullableObjectIds(covariant RealmList<ObjectId?> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _nullableUuidsProperty =
+      ListProperty<Uuid?>('nullableUuids', RealmPropertyType.uuid);
+  @override
+  RealmList<Uuid?> get nullableUuids => _nullableUuidsProperty.getValue(this);
+  @override
+  set nullableUuids(covariant RealmList<Uuid?> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _nullableIntsProperty =
+      ListProperty<int?>('nullableInts', RealmPropertyType.int);
+  @override
+  RealmList<int?> get nullableInts => _nullableIntsProperty.getValue(this);
+  @override
+  set nullableInts(covariant RealmList<int?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<AllTypesEmbedded>> get changes =>
+      RealmObjectBaseMixin.getChanges(this);
+
+  static const schema = SchemaObject<AllTypesEmbedded>(
+    ObjectType.embedded,
+    AllTypesEmbedded._,
+    'AllTypesEmbedded',
+    {
+      'stringProp': _stringPropProperty,
+      'boolProp': _boolPropProperty,
+      'dateProp': _datePropProperty,
+      'doubleProp': _doublePropProperty,
+      'objectIdProp': _objectIdPropProperty,
+      'uuidProp': _uuidPropProperty,
+      'intProp': _intPropProperty,
+      'nullableStringProp': _nullableStringPropProperty,
+      'nullableBoolProp': _nullableBoolPropProperty,
+      'nullableDateProp': _nullableDatePropProperty,
+      'nullableDoubleProp': _nullableDoublePropProperty,
+      'nullableObjectIdProp': _nullableObjectIdPropProperty,
+      'nullableUuidProp': _nullableUuidPropProperty,
+      'nullableIntProp': _nullableIntPropProperty,
+      'strings': _stringsProperty,
+      'bools': _boolsProperty,
+      'dates': _datesProperty,
+      'doubles': _doublesProperty,
+      'objectIds': _objectIdsProperty,
+      'uuids': _uuidsProperty,
+      'ints': _intsProperty,
+      'nullableStrings': _nullableStringsProperty,
+      'nullableBools': _nullableBoolsProperty,
+      'nullableDates': _nullableDatesProperty,
+      'nullableDoubles': _nullableDoublesProperty,
+      'nullableObjectIds': _nullableObjectIdsProperty,
+      'nullableUuids': _nullableUuidsProperty,
+      'nullableInts': _nullableIntsProperty,
+    },
+  );
+  @override
+  SchemaObject get instanceSchema => schema;
+}
+
+class ObjectWithEmbedded extends _ObjectWithEmbedded
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
+  ObjectWithEmbedded(
+    String value, {
+    AllTypesEmbedded? singleObject,
+    RecursiveEmbedded1? recursiveObject,
+    Iterable<AllTypesEmbedded> list = const [],
+  }) {
+    _valueProperty.setValue(this, value);
+    _singleObjectProperty.setValue(this, singleObject);
+    _recursiveObjectProperty.setValue(this, recursiveObject);
+    _listProperty.setValue(this, RealmList<AllTypesEmbedded>(list));
+  }
+
+  ObjectWithEmbedded._();
+
+  static const _valueProperty = ValueProperty<String>(
+    'value',
+    RealmPropertyType.string,
+  );
+  @override
+  String get value => _valueProperty.getValue(this);
+  @override
+  set value(String value) => _valueProperty.setValue(this, value);
+
+  static const _singleObjectProperty =
+      ObjectProperty<AllTypesEmbedded>('singleObject', 'AllTypesEmbedded');
+  @override
+  AllTypesEmbedded? get singleObject => _singleObjectProperty.getValue(this);
+  @override
+  set singleObject(covariant AllTypesEmbedded? value) =>
+      _singleObjectProperty.setValue(this, value);
+
+  static const _listProperty = ListProperty<AllTypesEmbedded>(
+      'list', RealmPropertyType.object,
+      linkTarget: 'AllTypesEmbedded');
+  @override
+  RealmList<AllTypesEmbedded> get list => _listProperty.getValue(this);
+  @override
+  set list(covariant RealmList<AllTypesEmbedded> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _recursiveObjectProperty = ObjectProperty<RecursiveEmbedded1>(
+      'recursiveObject', 'RecursiveEmbedded1');
+  @override
+  RecursiveEmbedded1? get recursiveObject =>
+      _recursiveObjectProperty.getValue(this);
+  @override
+  set recursiveObject(covariant RecursiveEmbedded1? value) =>
+      _recursiveObjectProperty.setValue(this, value);
+
+  @override
+  Stream<RealmObjectChanges<ObjectWithEmbedded>> get changes =>
+      RealmObjectBaseMixin.getChanges(this);
+
+  static const schema = SchemaObject<ObjectWithEmbedded>(
+    ObjectType.topLevel,
+    ObjectWithEmbedded._,
+    'ObjectWithEmbedded',
+    {
+      'value': _valueProperty,
+      'singleObject': _singleObjectProperty,
+      'list': _listProperty,
+      'recursiveObject': _recursiveObjectProperty,
+    },
+  );
+  @override
+  SchemaObject get instanceSchema => schema;
+}
+
+class RecursiveEmbedded1 extends _RecursiveEmbedded1
+    with RealmEntityMixin, RealmObjectBaseMixin, EmbeddedObjectMixin {
+  RecursiveEmbedded1(
+    String value, {
+    RecursiveEmbedded2? child,
+    ObjectWithEmbedded? topLevel,
+    Iterable<RecursiveEmbedded2> children = const [],
+  }) {
+    _valueProperty.setValue(this, value);
+    _childProperty.setValue(this, child);
+    _topLevelProperty.setValue(this, topLevel);
+    _childrenProperty.setValue(this, RealmList<RecursiveEmbedded2>(children));
+  }
+
+  RecursiveEmbedded1._();
+
+  static const _valueProperty = ValueProperty<String>(
+    'value',
+    RealmPropertyType.string,
+  );
+  @override
+  String get value => _valueProperty.getValue(this);
+  @override
+  set value(String value) => _valueProperty.setValue(this, value);
+
+  static const _childProperty =
+      ObjectProperty<RecursiveEmbedded2>('child', 'RecursiveEmbedded2');
+  @override
+  RecursiveEmbedded2? get child => _childProperty.getValue(this);
+  @override
+  set child(covariant RecursiveEmbedded2? value) =>
+      _childProperty.setValue(this, value);
+
+  static const _childrenProperty = ListProperty<RecursiveEmbedded2>(
+      'children', RealmPropertyType.object,
+      linkTarget: 'RecursiveEmbedded2');
+  @override
+  RealmList<RecursiveEmbedded2> get children =>
+      _childrenProperty.getValue(this);
+  @override
+  set children(covariant RealmList<RecursiveEmbedded2> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _topLevelProperty =
+      ObjectProperty<ObjectWithEmbedded>('topLevel', 'ObjectWithEmbedded');
+  @override
+  ObjectWithEmbedded? get topLevel => _topLevelProperty.getValue(this);
+  @override
+  set topLevel(covariant ObjectWithEmbedded? value) =>
+      _topLevelProperty.setValue(this, value);
+
+  @override
+  Stream<RealmObjectChanges<RecursiveEmbedded1>> get changes =>
+      RealmObjectBaseMixin.getChanges(this);
+
+  static const schema = SchemaObject<RecursiveEmbedded1>(
+    ObjectType.embedded,
+    RecursiveEmbedded1._,
+    'RecursiveEmbedded1',
+    {
+      'value': _valueProperty,
+      'child': _childProperty,
+      'children': _childrenProperty,
+      'topLevel': _topLevelProperty,
+    },
+  );
+  @override
+  SchemaObject get instanceSchema => schema;
+}
+
+class RecursiveEmbedded2 extends _RecursiveEmbedded2
+    with RealmEntityMixin, RealmObjectBaseMixin, EmbeddedObjectMixin {
+  RecursiveEmbedded2(
+    String value, {
+    RecursiveEmbedded3? child,
+    ObjectWithEmbedded? topLevel,
+    Iterable<RecursiveEmbedded3> children = const [],
+  }) {
+    _valueProperty.setValue(this, value);
+    _childProperty.setValue(this, child);
+    _topLevelProperty.setValue(this, topLevel);
+    _childrenProperty.setValue(this, RealmList<RecursiveEmbedded3>(children));
+  }
+
+  RecursiveEmbedded2._();
+
+  static const _valueProperty = ValueProperty<String>(
+    'value',
+    RealmPropertyType.string,
+  );
+  @override
+  String get value => _valueProperty.getValue(this);
+  @override
+  set value(String value) => _valueProperty.setValue(this, value);
+
+  static const _childProperty =
+      ObjectProperty<RecursiveEmbedded3>('child', 'RecursiveEmbedded3');
+  @override
+  RecursiveEmbedded3? get child => _childProperty.getValue(this);
+  @override
+  set child(covariant RecursiveEmbedded3? value) =>
+      _childProperty.setValue(this, value);
+
+  static const _childrenProperty = ListProperty<RecursiveEmbedded3>(
+      'children', RealmPropertyType.object,
+      linkTarget: 'RecursiveEmbedded3');
+  @override
+  RealmList<RecursiveEmbedded3> get children =>
+      _childrenProperty.getValue(this);
+  @override
+  set children(covariant RealmList<RecursiveEmbedded3> value) =>
+      throw RealmUnsupportedSetError();
+
+  static const _topLevelProperty =
+      ObjectProperty<ObjectWithEmbedded>('topLevel', 'ObjectWithEmbedded');
+  @override
+  ObjectWithEmbedded? get topLevel => _topLevelProperty.getValue(this);
+  @override
+  set topLevel(covariant ObjectWithEmbedded? value) =>
+      _topLevelProperty.setValue(this, value);
+
+  @override
+  Stream<RealmObjectChanges<RecursiveEmbedded2>> get changes =>
+      RealmObjectBaseMixin.getChanges(this);
+
+  static const schema = SchemaObject<RecursiveEmbedded2>(
+    ObjectType.embedded,
+    RecursiveEmbedded2._,
+    'RecursiveEmbedded2',
+    {
+      'value': _valueProperty,
+      'child': _childProperty,
+      'children': _childrenProperty,
+      'topLevel': _topLevelProperty,
+    },
+  );
+  @override
+  SchemaObject get instanceSchema => schema;
+}
+
+class RecursiveEmbedded3 extends _RecursiveEmbedded3
+    with RealmEntityMixin, RealmObjectBaseMixin, EmbeddedObjectMixin {
+  RecursiveEmbedded3(
+    String value,
+  ) {
+    _valueProperty.setValue(this, value);
+  }
+
+  RecursiveEmbedded3._();
+
+  static const _valueProperty = ValueProperty<String>(
+    'value',
+    RealmPropertyType.string,
+  );
+  @override
+  String get value => _valueProperty.getValue(this);
+  @override
+  set value(String value) => _valueProperty.setValue(this, value);
+
+  @override
+  Stream<RealmObjectChanges<RecursiveEmbedded3>> get changes =>
+      RealmObjectBaseMixin.getChanges(this);
+
+  static const schema = SchemaObject<RecursiveEmbedded3>(
+    ObjectType.embedded,
+    RecursiveEmbedded3._,
+    'RecursiveEmbedded3',
+    {
+      'value': _valueProperty,
     },
   );
   @override

--- a/test/test.g.dart
+++ b/test/test.g.dart
@@ -6,7 +6,8 @@ part of 'test.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
+class Car extends _Car
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Car(
     String make,
   ) {
@@ -27,7 +28,7 @@ class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Car>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Car>(
     Car._,
@@ -41,7 +42,8 @@ class Car extends _Car with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
+class Person extends _Person
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Person(
     String name,
   ) {
@@ -61,7 +63,7 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Person>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Person>(
     Person._,
@@ -74,7 +76,8 @@ class Person extends _Person with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Dog extends _Dog with RealmEntityMixin, RealmObjectMixin {
+class Dog extends _Dog
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Dog(
     String name, {
     int? age,
@@ -114,7 +117,7 @@ class Dog extends _Dog with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Dog>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Dog>(
     Dog._,
@@ -130,7 +133,8 @@ class Dog extends _Dog with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Team extends _Team with RealmEntityMixin, RealmObjectMixin {
+class Team extends _Team
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Team(
     String name, {
     Iterable<Person> players = const [],
@@ -171,7 +175,7 @@ class Team extends _Team with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Team>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Team>(
     Team._,
@@ -186,7 +190,8 @@ class Team extends _Team with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Student extends _Student with RealmEntityMixin, RealmObjectMixin {
+class Student extends _Student
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Student(
     int number, {
     String? name,
@@ -237,7 +242,7 @@ class Student extends _Student with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Student>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Student>(
     Student._,
@@ -254,7 +259,8 @@ class Student extends _Student with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class School extends _School with RealmEntityMixin, RealmObjectMixin {
+class School extends _School
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   School(
     String name, {
     String? city,
@@ -318,7 +324,7 @@ class School extends _School with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<School>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<School>(
     School._,
@@ -337,7 +343,7 @@ class School extends _School with RealmEntityMixin, RealmObjectMixin {
 }
 
 class RemappedClass extends $RemappedClass
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   RemappedClass(
     String remappedProperty, {
     Iterable<RemappedClass> listProperty = const [],
@@ -371,7 +377,7 @@ class RemappedClass extends $RemappedClass
 
   @override
   Stream<RealmObjectChanges<RemappedClass>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<RemappedClass>(
     RemappedClass._,
@@ -385,7 +391,8 @@ class RemappedClass extends $RemappedClass
   SchemaObject get instanceSchema => schema;
 }
 
-class Task extends _Task with RealmEntityMixin, RealmObjectMixin {
+class Task extends _Task
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Task(
     ObjectId id,
   ) {
@@ -406,7 +413,7 @@ class Task extends _Task with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Task>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Task>(
     Task._,
@@ -420,7 +427,8 @@ class Task extends _Task with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Schedule extends _Schedule with RealmEntityMixin, RealmObjectMixin {
+class Schedule extends _Schedule
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Schedule(
     ObjectId id, {
     Iterable<Task> tasks = const [],
@@ -451,7 +459,7 @@ class Schedule extends _Schedule with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Schedule>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Schedule>(
     Schedule._,
@@ -466,7 +474,8 @@ class Schedule extends _Schedule with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class AllTypes extends _AllTypes with RealmEntityMixin, RealmObjectMixin {
+class AllTypes extends _AllTypes
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   AllTypes(
     String stringProp,
     bool boolProp,
@@ -638,7 +647,7 @@ class AllTypes extends _AllTypes with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<AllTypes>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<AllTypes>(
     AllTypes._,
@@ -664,7 +673,8 @@ class AllTypes extends _AllTypes with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class LinksClass extends _LinksClass with RealmEntityMixin, RealmObjectMixin {
+class LinksClass extends _LinksClass
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   LinksClass(
     Uuid id, {
     LinksClass? link,
@@ -704,7 +714,7 @@ class LinksClass extends _LinksClass with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<LinksClass>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<LinksClass>(
     LinksClass._,
@@ -721,7 +731,7 @@ class LinksClass extends _LinksClass with RealmEntityMixin, RealmObjectMixin {
 }
 
 class AllCollections extends _AllCollections
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   AllCollections({
     Iterable<String> strings = const [],
     Iterable<bool> bools = const [],
@@ -875,7 +885,7 @@ class AllCollections extends _AllCollections
 
   @override
   Stream<RealmObjectChanges<AllCollections>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<AllCollections>(
     AllCollections._,
@@ -902,7 +912,7 @@ class AllCollections extends _AllCollections
 }
 
 class NullableTypes extends _NullableTypes
-    with RealmEntityMixin, RealmObjectMixin {
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   NullableTypes(
     ObjectId id,
     ObjectId differentiator, {
@@ -1013,7 +1023,7 @@ class NullableTypes extends _NullableTypes
 
   @override
   Stream<RealmObjectChanges<NullableTypes>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<NullableTypes>(
     NullableTypes._,
@@ -1035,7 +1045,8 @@ class NullableTypes extends _NullableTypes
   SchemaObject get instanceSchema => schema;
 }
 
-class Event extends _Event with RealmEntityMixin, RealmObjectMixin {
+class Event extends _Event
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Event(
     ObjectId id, {
     String? name,
@@ -1101,7 +1112,7 @@ class Event extends _Event with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Event>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Event>(
     Event._,
@@ -1119,7 +1130,8 @@ class Event extends _Event with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Party extends _Party with RealmEntityMixin, RealmObjectMixin {
+class Party extends _Party
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Party(
     int year, {
     Friend? host,
@@ -1167,7 +1179,7 @@ class Party extends _Party with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Party>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Party>(
     Party._,
@@ -1183,7 +1195,8 @@ class Party extends _Party with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Friend extends _Friend with RealmEntityMixin, RealmObjectMixin {
+class Friend extends _Friend
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Friend(
     String name, {
     int age = 42,
@@ -1237,7 +1250,7 @@ class Friend extends _Friend with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Friend>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Friend>(
     Friend._,
@@ -1254,7 +1267,8 @@ class Friend extends _Friend with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Player extends _Player with RealmEntityMixin, RealmObjectMixin {
+class Player extends _Player
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Player(
     String name, {
     Game? game,
@@ -1293,7 +1307,7 @@ class Player extends _Player with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Player>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Player>(
     Player._,
@@ -1309,7 +1323,8 @@ class Player extends _Player with RealmEntityMixin, RealmObjectMixin {
   SchemaObject get instanceSchema => schema;
 }
 
-class Game extends _Game with RealmEntityMixin, RealmObjectMixin {
+class Game extends _Game
+    with RealmEntityMixin, RealmObjectBaseMixin, RealmObjectMixin {
   Game({
     Iterable<Player> winnerByRound = const [],
   }) {
@@ -1329,7 +1344,7 @@ class Game extends _Game with RealmEntityMixin, RealmObjectMixin {
 
   @override
   Stream<RealmObjectChanges<Game>> get changes =>
-      RealmObjectMixin.getChanges(this);
+      RealmObjectBaseMixin.getChanges(this);
 
   static const schema = SchemaObject<Game>(
     Game._,


### PR DESCRIPTION
## Overview

This refactors our object hierarchy and extracts a base class - `RealmObjectBase` that is then implemented by `RealmObject` and `EmbeddedObject` (with `AsymmetricObject` coming as a follow-up). I've updated the API exposed on `Realm` to make sure the generic constraints are the correct ones (i.e. most of the times, they're constraints on `RealmObject` as embedded objects can't be queried or added directly).

## TODO

- [x] Extract a RealmObjectBase type
- [x] Add support for embedded objects in the generator
- [x] Add support for embedded objects in accessors
- [x] Add support for embedded objects in the dynamic API
- [ ] Add support for get_parent
- [x] Tests
  - [x] Generator
  - [x] Links to embedded objects
  - [x] Lists of embedded objects
  - [x] Dynamic access

Fixes https://github.com/realm/realm-dart/issues/662