### PR TITLE
Implement list of nullables with minimal refactorings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * You can now set a realm property of type `T` to any object `o` where `o is T`. Previously it was required that `o.runtimeType == T`. ([#904](https://github.com/realm/realm-dart/issues/904))
 * Performance of indexOf on realm lists has been improved. It now uses realm-core instead of the generic version from ListMixin. ([#911](https://github.com/realm/realm-dart/pull/911))
 * Performance of remove on realm list has been improved. It now uses indexOf and removeAt. ([#915](https://github.com/realm/realm-dart/pull/915))
-* Added support for migrations for local Realms. You can now construct a configuration with a migration callback that will be invoked if the schema version of the file on disk is lower than the schema version supplied by the callback. (Issue [#70](https://github.com/realm/realm-dart/issues/70))
+* Added support for migrations for local Realms. You can now construct a configuration with a migration callback that will be invoked if the schema version of the file on disk is lower than the schema version supplied by the callback. ([#70](https://github.com/realm/realm-dart/issues/70))
 
   A minimal example looks like this:
   ```dart
@@ -50,6 +50,7 @@
   ```
   would fail if any Persons exists
 * Fixed an issue that would cause passwords sent to the server (e.g. `Credentials.EmailPassword` or `EmailPasswordAuthProvider.registerUser`) to contain an extra empty byte at the end. (PR [#918](https://github.com/realm/realm-dart/pull/918))
+* Added support for realm list of nullable primitive types, ie. `RealmList<int?>`. ([#163](https://github.com/realm/realm-dart/issues/163))
 
 ### Compatibility
 * Realm Studio: 12.0.0 or later.

--- a/generator/lib/src/dart_type_ex.dart
+++ b/generator/lib/src/dart_type_ex.dart
@@ -52,10 +52,10 @@ extension DartTypeEx on DartType {
     if (isRealmCollection) {
       return (this as ParameterizedType).typeArguments.last;
     }
-    return this;
+    return asNonNullable;
   }
 
-  String get basicMappedName => basicType.asNonNullable.mappedName;
+  String get basicMappedName => basicType.mappedName;
 
   DartType get mappedType {
     final self = this;
@@ -66,15 +66,15 @@ extension DartTypeEx on DartType {
         if (self != mapped) {
           if (self.isDartCoreList) {
             final mappedList = provider.listType(mapped);
-            return PseudoType('Realm${mappedList.getDisplayString(withNullability: false)}', nullabilitySuffix: mappedList.nullabilitySuffix);
+            return PseudoType('Realm${mappedList.getDisplayString(withNullability: true)}', nullabilitySuffix: mappedList.nullabilitySuffix);
           }
           if (self.isDartCoreSet) {
             final mappedSet = provider.setType(mapped);
-            return PseudoType('Realm${mappedSet.getDisplayString(withNullability: false)}', nullabilitySuffix: mappedSet.nullabilitySuffix);
+            return PseudoType('Realm${mappedSet.getDisplayString(withNullability: true)}', nullabilitySuffix: mappedSet.nullabilitySuffix);
           }
           if (self.isDartCoreMap) {
             final mappedMap = provider.mapType(self.typeArguments.first, mapped);
-            return PseudoType('Realm${mappedMap.getDisplayString(withNullability: false)}', nullabilitySuffix: mappedMap.nullabilitySuffix);
+            return PseudoType('Realm${mappedMap.getDisplayString(withNullability: true)}', nullabilitySuffix: mappedMap.nullabilitySuffix);
           }
         }
       }

--- a/generator/lib/src/realm_field_info.dart
+++ b/generator/lib/src/realm_field_info.dart
@@ -44,7 +44,7 @@ class RealmFieldInfo {
   bool get isRealmCollection => fieldElement.type.isRealmCollection;
   bool get isLate => fieldElement.isLate;
   bool get hasDefaultValue => fieldElement.hasInitializer;
-  bool get optional => type.isNullable;
+  bool get optional => type.isNullable || (type.isRealmCollection && (type as ParameterizedType).typeArguments.last.isNullable);
   bool get isRequired => !(hasDefaultValue || optional);
 
   String get name => fieldElement.name;

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -178,7 +178,7 @@ class RealmCoreAccessor implements RealmAccessor {
   void set(RealmObject object, String name, Object? value, {bool isDefault = false, bool update = false}) {
     final propertyMeta = metadata[name];
     try {
-      if (value is RealmList<Object>) {
+      if (value is RealmList<Object?>) {
         final handle = realmCore.getListProperty(object, propertyMeta.key);
         if (update) realmCore.listClear(handle);
         for (var i = 0; i < value.length; i++) {

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -923,4 +923,29 @@ Future<void> main([List<String>? args]) async {
       carol: [null, 1, 1]
     });
   });
+
+  test('RealmList<T> is a RealmList<T?> (covariance)', () {
+    // List<T> in dart is covariant. So is RealmList<T>.
+    // In particular (since a T is also a T?) a RealmList<T> is also a RealmList<T?>.
+    // Here follows a few tests to prove it, as it came up in a PR review
+    final list = RealmList([1, 2, 3]);
+    expect(list, isA<RealmList<int>>());
+    expect(list, isA<RealmList<int?>>());
+
+    final nullableList = RealmList<int?>([1, 2, 3]);
+    expect(nullableList, isNot(isA<RealmList<int>>()));
+    expect(nullableList, isA<RealmList<int?>>());
+
+    // .. also when managed
+    final config = Configuration.local([Player.schema, Game.schema]);
+    final realm = getRealm(config);
+
+    final game = Game();
+    realm.write(() => realm.add(game));
+
+    expect(game.winnerByRound.isManaged, isTrue);
+
+    expect(game.winnerByRound, isA<RealmList<Player>>());
+    expect(game.winnerByRound, isA<RealmList<Player?>>());
+  });
 }

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -856,4 +856,71 @@ Future<void> main([List<String>? args]) async {
       )),
     );
   });
+
+  test('List of nullables', () {
+    final config = Configuration.local([Player.schema, Game.schema]);
+    final realm = getRealm(config);
+
+    final game = Game();
+    final alice = Player('alice', game: game);
+    final bob = Player('bob', game: game);
+    final carol = Player('carol', game: game);
+    final players = [alice, bob, carol];
+
+    realm.write(() => realm.addAll(players));
+
+    void checkResult(List<Player> winnerByRound, Map<Player, List<int?>> scoresByPlayer) {
+      expect(game.winnerByRound, winnerByRound);
+      for (final p in players) {
+        expect(p.scoresByRound, scoresByPlayer[p] ?? []);
+      }
+    }
+
+    checkResult([], {});
+
+    int currentRound = 0;
+    void playRound(Map<Player, int> scores) {
+      realm.write(() {
+        for (final p in players) {
+          p.scoresByRound.add(scores[p]);
+        }
+        final bestResult =
+            scores.entries.fold<MapEntry<Player, int>?>(null, (bestResult, result) => result.value > (bestResult?.value ?? 0) ? result : bestResult);
+        game.winnerByRound[currentRound++] = bestResult!.key;
+      });
+    }
+
+    playRound({alice: 1, bob: 2});
+
+    checkResult([
+      bob
+    ], {
+      alice: [1],
+      bob: [2],
+      carol: [null]
+    });
+
+    playRound({alice: 3, carol: 1});
+
+    checkResult([
+      bob,
+      alice
+    ], {
+      alice: [1, 3],
+      bob: [2, null],
+      carol: [null, 1]
+    });
+
+    playRound({alice: 2, bob: 3, carol: 1});
+
+    checkResult([
+      bob,
+      alice,
+      bob
+    ], {
+      alice: [1, 3, 2],
+      bob: [2, null, 3],
+      carol: [null, 1, 1]
+    });
+  });
 }

--- a/test/test.dart
+++ b/test/test.dart
@@ -142,6 +142,14 @@ class _AllCollections {
   late List<ObjectId> objectIds;
   late List<Uuid> uuids;
   late List<int> ints;
+
+  late List<String?> nullableStrings;
+  late List<bool?> nullableBools;
+  late List<DateTime?> nullableDates;
+  late List<double?> nullableDoubles;
+  late List<ObjectId?> nullableObjectIds;
+  late List<Uuid?> nullableUuids;
+  late List<int?> nullableInts;
 }
 
 @RealmModel()
@@ -197,6 +205,20 @@ class _Friend {
 class _When {
   late DateTime dateTimeUtc;
   late String locationName; // tz database/Olson name
+}
+
+@RealmModel()
+class _Player {
+  @PrimaryKey()
+  late String name;
+  _Game? game;
+  final scoresByRound = <int?>[]; // null means player didn't finish
+}
+
+@RealmModel()
+class _Game {
+  final winnerByRound = <_Player>[]; // null means no winner yet
+  int get rounds => winnerByRound.length;
 }
 
 String? testName;

--- a/test/test.g.dart
+++ b/test/test.g.dart
@@ -646,6 +646,13 @@ class AllCollections extends _AllCollections with RealmEntity, RealmObject {
     Iterable<ObjectId> objectIds = const [],
     Iterable<Uuid> uuids = const [],
     Iterable<int> ints = const [],
+    Iterable<String?> nullableStrings = const [],
+    Iterable<bool?> nullableBools = const [],
+    Iterable<DateTime?> nullableDates = const [],
+    Iterable<double?> nullableDoubles = const [],
+    Iterable<ObjectId?> nullableObjectIds = const [],
+    Iterable<Uuid?> nullableUuids = const [],
+    Iterable<int?> nullableInts = const [],
   }) {
     RealmObject.set<RealmList<String>>(
         this, 'strings', RealmList<String>(strings));
@@ -658,6 +665,20 @@ class AllCollections extends _AllCollections with RealmEntity, RealmObject {
         this, 'objectIds', RealmList<ObjectId>(objectIds));
     RealmObject.set<RealmList<Uuid>>(this, 'uuids', RealmList<Uuid>(uuids));
     RealmObject.set<RealmList<int>>(this, 'ints', RealmList<int>(ints));
+    RealmObject.set<RealmList<String?>>(
+        this, 'nullableStrings', RealmList<String?>(nullableStrings));
+    RealmObject.set<RealmList<bool?>>(
+        this, 'nullableBools', RealmList<bool?>(nullableBools));
+    RealmObject.set<RealmList<DateTime?>>(
+        this, 'nullableDates', RealmList<DateTime?>(nullableDates));
+    RealmObject.set<RealmList<double?>>(
+        this, 'nullableDoubles', RealmList<double?>(nullableDoubles));
+    RealmObject.set<RealmList<ObjectId?>>(
+        this, 'nullableObjectIds', RealmList<ObjectId?>(nullableObjectIds));
+    RealmObject.set<RealmList<Uuid?>>(
+        this, 'nullableUuids', RealmList<Uuid?>(nullableUuids));
+    RealmObject.set<RealmList<int?>>(
+        this, 'nullableInts', RealmList<int?>(nullableInts));
   }
 
   AllCollections._();
@@ -711,6 +732,56 @@ class AllCollections extends _AllCollections with RealmEntity, RealmObject {
   set ints(covariant RealmList<int> value) => throw RealmUnsupportedSetError();
 
   @override
+  RealmList<String?> get nullableStrings =>
+      RealmObject.get<String?>(this, 'nullableStrings') as RealmList<String?>;
+  @override
+  set nullableStrings(covariant RealmList<String?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  RealmList<bool?> get nullableBools =>
+      RealmObject.get<bool?>(this, 'nullableBools') as RealmList<bool?>;
+  @override
+  set nullableBools(covariant RealmList<bool?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  RealmList<DateTime?> get nullableDates =>
+      RealmObject.get<DateTime?>(this, 'nullableDates') as RealmList<DateTime?>;
+  @override
+  set nullableDates(covariant RealmList<DateTime?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  RealmList<double?> get nullableDoubles =>
+      RealmObject.get<double?>(this, 'nullableDoubles') as RealmList<double?>;
+  @override
+  set nullableDoubles(covariant RealmList<double?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  RealmList<ObjectId?> get nullableObjectIds =>
+      RealmObject.get<ObjectId?>(this, 'nullableObjectIds')
+          as RealmList<ObjectId?>;
+  @override
+  set nullableObjectIds(covariant RealmList<ObjectId?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  RealmList<Uuid?> get nullableUuids =>
+      RealmObject.get<Uuid?>(this, 'nullableUuids') as RealmList<Uuid?>;
+  @override
+  set nullableUuids(covariant RealmList<Uuid?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  RealmList<int?> get nullableInts =>
+      RealmObject.get<int?>(this, 'nullableInts') as RealmList<int?>;
+  @override
+  set nullableInts(covariant RealmList<int?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
   Stream<RealmObjectChanges<AllCollections>> get changes =>
       RealmObject.getChanges<AllCollections>(this);
 
@@ -736,6 +807,20 @@ class AllCollections extends _AllCollections with RealmEntity, RealmObject {
           collectionType: RealmCollectionType.list),
       SchemaProperty('ints', RealmPropertyType.int,
           collectionType: RealmCollectionType.list),
+      SchemaProperty('nullableStrings', RealmPropertyType.string,
+          optional: true, collectionType: RealmCollectionType.list),
+      SchemaProperty('nullableBools', RealmPropertyType.bool,
+          optional: true, collectionType: RealmCollectionType.list),
+      SchemaProperty('nullableDates', RealmPropertyType.timestamp,
+          optional: true, collectionType: RealmCollectionType.list),
+      SchemaProperty('nullableDoubles', RealmPropertyType.double,
+          optional: true, collectionType: RealmCollectionType.list),
+      SchemaProperty('nullableObjectIds', RealmPropertyType.objectid,
+          optional: true, collectionType: RealmCollectionType.list),
+      SchemaProperty('nullableUuids', RealmPropertyType.uuid,
+          optional: true, collectionType: RealmCollectionType.list),
+      SchemaProperty('nullableInts', RealmPropertyType.int,
+          optional: true, collectionType: RealmCollectionType.list),
     ]);
   }
 }
@@ -1087,6 +1172,93 @@ class When extends _When with RealmEntity, RealmObject {
     return const SchemaObject(When, 'When', [
       SchemaProperty('dateTimeUtc', RealmPropertyType.timestamp),
       SchemaProperty('locationName', RealmPropertyType.string),
+    ]);
+  }
+}
+
+class Player extends _Player with RealmEntity, RealmObject {
+  Player(
+    String name, {
+    Game? game,
+    Iterable<int?> scoresByRound = const [],
+  }) {
+    RealmObject.set(this, 'name', name);
+    RealmObject.set(this, 'game', game);
+    RealmObject.set<RealmList<int?>>(
+        this, 'scoresByRound', RealmList<int?>(scoresByRound));
+  }
+
+  Player._();
+
+  @override
+  String get name => RealmObject.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => RealmObject.set(this, 'name', value);
+
+  @override
+  Game? get game => RealmObject.get<Game>(this, 'game') as Game?;
+  @override
+  set game(covariant Game? value) => RealmObject.set(this, 'game', value);
+
+  @override
+  RealmList<int?> get scoresByRound =>
+      RealmObject.get<int?>(this, 'scoresByRound') as RealmList<int?>;
+  @override
+  set scoresByRound(covariant RealmList<int?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<Player>> get changes =>
+      RealmObject.getChanges<Player>(this);
+
+  @override
+  Player freeze() => RealmObject.freezeObject<Player>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(Player._);
+    return const SchemaObject(Player, 'Player', [
+      SchemaProperty('name', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('game', RealmPropertyType.object,
+          optional: true, linkTarget: 'Game'),
+      SchemaProperty('scoresByRound', RealmPropertyType.int,
+          optional: true, collectionType: RealmCollectionType.list),
+    ]);
+  }
+}
+
+class Game extends _Game with RealmEntity, RealmObject {
+  Game({
+    Iterable<Player> winnerByRound = const [],
+  }) {
+    RealmObject.set<RealmList<Player>>(
+        this, 'winnerByRound', RealmList<Player>(winnerByRound));
+  }
+
+  Game._();
+
+  @override
+  RealmList<Player> get winnerByRound =>
+      RealmObject.get<Player>(this, 'winnerByRound') as RealmList<Player>;
+  @override
+  set winnerByRound(covariant RealmList<Player> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<Game>> get changes =>
+      RealmObject.getChanges<Game>(this);
+
+  @override
+  Game freeze() => RealmObject.freezeObject<Game>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(Game._);
+    return const SchemaObject(Game, 'Game', [
+      SchemaProperty('winnerByRound', RealmPropertyType.object,
+          linkTarget: 'Player', collectionType: RealmCollectionType.list),
     ]);
   }
 }


### PR DESCRIPTION
Allow list of nullable primitives in realm models, such as:
```dart
@RealmModel()
class _Player {
  @PrimaryKey()
  late String name;
  final scoresByRound = <int?>[]; // null means player didn't finish
}
```
Fixes #163 (supersedes  #708)