### PR TITLE
Remove extra byte in realm_string_t conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 * Added support for "frozen objects" - these are objects, queries, lists, or Realms that have been "frozen" at a specific version. All frozen objects can be accessed and queried as normal, but attempting to mutate them or add change listeners will throw an exception. `Realm`, `RealmObject`, `RealmList`, and `RealmResults` now have a method `freeze()` which returns an immutable version of the object, as well as an `isFrozen` property which can be used to check whether an object is frozen. ([#56](https://github.com/realm/realm-dart/issues/56))
 * You can now set a realm property of type `T` to any object `o` where `o is T`. Previously it was required that `o.runtimeType == T`. ([#904](https://github.com/realm/realm-dart/issues/904))
-* Performance of indexOf on realm lists has been improved. It now uses realm-core instead of the generic version from ListMixin. ([#911](https://github.com/realm/realm-dart/pull/911)). 
+* Performance of indexOf on realm lists has been improved. It now uses realm-core instead of the generic version from ListMixin. ([#911](https://github.com/realm/realm-dart/pull/911)).
 * Added support for migrations for local Realms. You can now construct a configuration with a migration callback that will be invoked if the schema version of the file on disk is lower than the schema version supplied by the callback. (Issue [#70](https://github.com/realm/realm-dart/issues/70))
 
   A minimal example looks like this:
@@ -42,12 +42,14 @@
 * Previously removeAt did not truncate length. ([#883](https://github.com/realm/realm-dart/issues/883))
 * List.length= now throws, if you try to increase length, ([#894](https://github.com/realm/realm-dart/pull/894)).
 * Queries on lists were broken. ([#909](https://github.com/realm/realm-dart/issues/909))
-* Queries on results didn't filter the existing results. ([#908](https://github.com/realm/realm-dart/issues/908)). 
+* Queries on results didn't filter the existing results. ([#908](https://github.com/realm/realm-dart/issues/908)).
   As an example
   ```dart
   expect(realm.query<Person>('FALSEPREDICATE').query('TRUEPREDICATE'), isEmpty);
   ```
   would fail if any Persons exists
+* Fixed an issue that would cause passwords sent to the server (e.g. `Credentials.EmailPassword` or `EmailPasswordAuthProvider.registerUser`) to contain an extra empty byte at the end. (PR [#918](https://github.com/realm/realm-dart/pull/918))
+
 ### Compatibility
 * Realm Studio: 12.0.0 or later.
 

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -2063,9 +2063,9 @@ extension _StringEx on String {
 
   Pointer<realm_string_t> toRealmString(Allocator allocator) {
     final realm_string = allocator<realm_string_t>();
-    realm_string.ref.data = toCharPtr(allocator);
     final units = utf8.encode(this);
-    realm_string.ref.size = units.length + 1;
+    realm_string.ref.data = units.toCharPtr(allocator).cast();
+    realm_string.ref.size = units.length;
     return realm_string;
   }
 }


### PR DESCRIPTION
`realm_string_t` should never have been 0-terminated because it knows its own length. In fact, adding an extra empty byte will result in `\u0000` being appended at the end of the string. I don't know how to test this since the only place it's used currently is for the password, but I've verified it manually by looking at the http request body.