### PR TITLE
Fix CHANGELOG Data API inaccuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * Added support for API key authentication. (Issue [#432](https://github.com/realm/realm-dart/issues/432))
   * Expose `User.apiKeys` client - this client can be used to create, fetch, and delete API keys.
   * Expose `Credentials.apiKey` that enable authentication with API keys.
-* Exposed `User.accessToken` and `User.refreshToken` - these tokens can be used to authenticate against the server when calling HTTP API outside of the Dart/Flutter SDK. For example, if you want to use the GraphQL or the data access API. (PR [#919](https://github.com/realm/realm-dart/pull/919))
+* Exposed `User.accessToken` and `User.refreshToken` - these tokens can be used to authenticate against the server when calling HTTP API outside of the Dart/Flutter SDK. For example, if you want to use the GraphQL. (PR [#919](https://github.com/realm/realm-dart/pull/919))
 
 ### Fixed
 * Previously removeAt did not truncate length. ([#883](https://github.com/realm/realm-dart/issues/883))


### PR DESCRIPTION
the data api doesn't use token-based authentication ([docs](https://www.mongodb.com/docs/atlas/app-services/data-api/generated-endpoints/#std-label-data-api-authenticate))