### PR TITLE
Support unit tests with realm in Flutter projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fixed wrong assertion on query error that could result in a crash. (Core upgrade)
 * Use random tmp directory for download. ([#1060](https://github.com/realm/realm-dart/issues/1060))
 * Bump minimum Dart SDK version to 2.17.5 and Flutter SDK version to 3.0.3 due to an issue with the Dart virtual machine when implementing `Finalizable`. ([dart-lang/sdk#49075](https://github.com/dart-lang/sdk/issues/49075))
+* Support install command in flutter projects that use unit and widget tests. ([#870](https://github.com/realm/realm-dart/issues/870))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/flutter/realm_flutter/android/build.gradle
+++ b/flutter/realm_flutter/android/build.gradle
@@ -93,7 +93,7 @@ task downloadRealmBinaries(type: Exec) {
     def (flutterRoot, flutterExecutablePath) = getPaths()
 
     workingDir "${project.rootProject.projectDir}${File.separator}.."
-    commandLine flutterExecutablePath, 'pub', 'run', 'realm', 'install', '--target-os-type', 'android', '--package-name', 'realm'
+    commandLine flutterExecutablePath, 'pub', 'run', 'realm', 'install', '--target-os-type', 'android', '--flavor', 'flutter'
 }
 
 preBuild.dependsOn runMetrics, downloadRealmBinaries

--- a/flutter/realm_flutter/ios/realm.podspec
+++ b/flutter/realm_flutter/ios/realm.podspec
@@ -48,11 +48,11 @@ Pod::Spec.new do |s|
                                   'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/**"'
                                 }
                                 #Use --debug to debug the install command on both prepare_command and script_phase below
-  s.prepare_command           = "source \"#{project_dir}/Flutter/flutter_export_environment.sh\" && cd \"$FLUTTER_APPLICATION_PATH\" && \"$FLUTTER_ROOT/bin/flutter\" pub run realm install --target-os-type ios --package-name realm"
+  s.prepare_command           = "source \"#{project_dir}/Flutter/flutter_export_environment.sh\" && cd \"$FLUTTER_APPLICATION_PATH\" && \"$FLUTTER_ROOT/bin/flutter\" pub run realm install --target-os-type ios --flavor flutter"
   s.script_phases             = [
                                   { :name => 'Download Realm Flutter iOS Binaries',
                                   #Use --debug to debug the install command
-                                  :script => 'source "$PROJECT_DIR/../Flutter/flutter_export_environment.sh" && cd "$FLUTTER_APPLICATION_PATH" && "$FLUTTER_ROOT/bin/flutter" pub run realm install --target-os-type ios --package-name realm',
+                                  :script => 'source "$PROJECT_DIR/../Flutter/flutter_export_environment.sh" && cd "$FLUTTER_APPLICATION_PATH" && "$FLUTTER_ROOT/bin/flutter" pub run realm install --target-os-type ios --flavor flutter',
                                     :execution_position => :before_headers
                                   },
                                   { :name => 'Report Metrics',

--- a/flutter/realm_flutter/linux/CMakeLists.txt
+++ b/flutter/realm_flutter/linux/CMakeLists.txt
@@ -37,7 +37,7 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # message ("FLUTTER_TOOL_ENVIRONMENT is ${FLUTTER_TOOL_ENVIRONMENT}")
 # message ("FLUTTER_ROOT is ${FLUTTER_ROOT}")
 
-execute_process(COMMAND "${FLUTTER_ROOT}/bin/flutter" "pub" "run" "realm" "install" "--target-os-type" "linux" "--package-name" "realm" #"--debug"
+execute_process(COMMAND "${FLUTTER_ROOT}/bin/flutter" "pub" "run" "realm" "install" "--target-os-type" "linux" "--flavor" "flutter" #"--debug"
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
   # COMMAND_ERROR_IS_FATAL ANY

--- a/flutter/realm_flutter/macos/realm.podspec
+++ b/flutter/realm_flutter/macos/realm.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.script_phases             = [
                                   { :name => 'Download Realm Flutter iOS Binaries',
                                     #Use --debug to debug the install command
-                                    :script => 'source "$PROJECT_DIR/../Flutter/ephemeral/flutter_export_environment.sh" && cd "$FLUTTER_APPLICATION_PATH" && "$FLUTTER_ROOT/bin/flutter" pub run realm install --target-os-type macos --package-name realm',
+                                    :script => 'source "$PROJECT_DIR/../Flutter/ephemeral/flutter_export_environment.sh" && cd "$FLUTTER_APPLICATION_PATH" && "$FLUTTER_ROOT/bin/flutter" pub run realm install --target-os-type macos --flavor flutter',
                                     :execution_position => :before_headers
                                   },
                                   { :name => 'Report Metrics',

--- a/flutter/realm_flutter/windows/CMakeLists.txt
+++ b/flutter/realm_flutter/windows/CMakeLists.txt
@@ -48,7 +48,7 @@ add_definitions(-DAPP_DIR_NAME="${APP_DIR_NAME}")
 # message ("FLUTTER_TOOL_ENVIRONMENT is ${FLUTTER_TOOL_ENVIRONMENT}")
 # message ("FLUTTER_ROOT is ${FLUTTER_ROOT}")
 
-execute_process(COMMAND "${FLUTTER_ROOT}\\bin\\flutter.bat" "pub" "run" "realm" "install" "--target-os-type" "windows" "--package-name" "realm" #"--debug"
+execute_process(COMMAND "${FLUTTER_ROOT}\\bin\\flutter.bat" "pub" "run" "realm" "install" "--target-os-type" "windows" "--flavor" "flutter" #"--debug"
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
   COMMAND_ERROR_IS_FATAL ANY

--- a/lib/src/cli/common/target_os_type.dart
+++ b/lib/src/cli/common/target_os_type.dart
@@ -26,8 +26,24 @@ enum TargetOsType {
   windows,
 }
 
+// Cannot use Dart 2.17 enhanced enums, due to stupid issue with build_cli :-/
+enum Flavor {
+  flutter,
+  dart,
+}
+
+extension FlavorEx on Flavor {
+  String get packageName {
+    switch (this) {
+      case Flavor.dart:
+        return 'realm_dart';
+      case Flavor.flutter:
+        return 'realm';
+    }
+  }
+}
+
 extension StringEx on String {
-  TargetOsType? get asTargetOsType => TargetOsType.values
-      .where((element) => element.toString().split('.').last == this)
-      .firstOrNull;
+  TargetOsType? get asTargetOsType => TargetOsType.values.where((element) => element.toString().split('.').last == this).firstOrNull;
+  Flavor? get asFlavor => Flavor.values.where((element) => element.toString() == this).firstOrNull;
 }

--- a/lib/src/cli/common/target_os_type.dart
+++ b/lib/src/cli/common/target_os_type.dart
@@ -26,7 +26,7 @@ enum TargetOsType {
   windows,
 }
 
-// Cannot use Dart 2.17 enhanced enums, due to stupid issue with build_cli :-/
+// Cannot use Dart 2.17 enhanced enums, due to an issue with build_cli :-/
 enum Flavor {
   flutter,
   dart,

--- a/lib/src/cli/install/options.dart
+++ b/lib/src/cli/install/options.dart
@@ -30,7 +30,7 @@ class Options {
   Flavor flavor;
 
   // use to debug install command
-  @CliOption(hide: true)
+  @CliOption(hide: true, defaultsTo: false)
   bool debug;
 
   Options({this.targetOsType, this.flavor = Flavor.dart, this.debug = false});

--- a/lib/src/cli/install/options.dart
+++ b/lib/src/cli/install/options.dart
@@ -23,19 +23,17 @@ part 'options.g.dart';
 
 @CliOptions()
 class Options {
-  @CliOption(help: "Required for Flutter. The target OS to install binaries for.", abbr: "t")
+  @CliOption(help: 'The target OS to install binaries for.', abbr: 't')
   TargetOsType? targetOsType;
 
-  // packageName defaults to `realm_dart` since "realm" is always set by the build scripts.
-  // The `Install` command when used by end users will not require the package name argument
-  @CliOption(defaultsTo: 'realm_dart', help: "Optional. The realm package name to install binaries for.", abbr: "p", allowed: ['realm', 'realm_dart'])
-  final String? packageName;
+  @CliOption(help: 'The flavor to install binaries for.', abbr: 'f', defaultsTo: Flavor.dart)
+  Flavor flavor;
 
-  @CliOption(hide: true, defaultsTo: false)
-  //use to debug install command
-  bool? debug;
-  
-  Options({this.targetOsType, this.packageName, this.debug});
+  // use to debug install command
+  @CliOption(hide: true)
+  bool debug;
+
+  Options({this.targetOsType, this.flavor = Flavor.dart, this.debug = false});
 }
 
 String get usage => _$parserForOptions.usage;

--- a/lib/src/cli/install/options.g.dart
+++ b/lib/src/cli/install/options.g.dart
@@ -28,8 +28,11 @@ Options _$parseOptionsResult(ArgResults result) => Options(
         _$TargetOsTypeEnumMapBuildCli,
         result['target-os-type'] as String?,
       ),
-      packageName: result['package-name'] as String?,
-      debug: result['debug'] as bool?,
+      flavor: _$enumValueHelper(
+        _$FlavorEnumMapBuildCli,
+        result['flavor'] as String,
+      ),
+      debug: result['debug'] as bool,
     );
 
 const _$TargetOsTypeEnumMapBuildCli = <TargetOsType, String>{
@@ -40,23 +43,27 @@ const _$TargetOsTypeEnumMapBuildCli = <TargetOsType, String>{
   TargetOsType.windows: 'windows'
 };
 
+const _$FlavorEnumMapBuildCli = <Flavor, String>{
+  Flavor.flutter: 'flutter',
+  Flavor.dart: 'dart'
+};
+
 ArgParser _$populateOptionsParser(ArgParser parser) => parser
   ..addOption(
     'target-os-type',
     abbr: 't',
-    help: 'Required for Flutter. The target OS to install binaries for.',
+    help: 'The target OS to install binaries for.',
     allowed: ['android', 'ios', 'linux', 'macos', 'windows'],
   )
   ..addOption(
-    'package-name',
-    abbr: 'p',
-    help: 'Optional. The realm package name to install binaries for.',
-    defaultsTo: 'realm_dart',
-    allowed: ['realm', 'realm_dart'],
+    'flavor',
+    abbr: 'f',
+    help: 'The flavor to install binaries for.',
+    defaultsTo: 'dart',
+    allowed: ['flutter', 'dart'],
   )
   ..addFlag(
     'debug',
-    defaultsTo: false,
     hide: true,
   );
 

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -2080,36 +2080,40 @@ class _RealmCore {
   }
 
   String getAppDirectory() {
-    if (!isFlutterPlatform || Platform.environment.containsKey('FLUTTER_TEST')) {
-      return Directory.current.absolute.path; // dart or flutter test
+    try {
+      if (!isFlutterPlatform || Platform.environment.containsKey('FLUTTER_TEST')) {
+        return Directory.current.absolute.path; // dart or flutter test
+      }
+
+      // Flutter from here on..
+
+      if (Platform.isAndroid || Platform.isIOS) {
+        return getFilesPath();
+      }
+
+      if (Platform.isLinux) {
+        String appSupportDir = PlatformEx.fromEnvironment(
+          "XDG_DATA_HOME",
+          defaultValue: PlatformEx.fromEnvironment(
+            "HOME",
+            defaultValue: Directory.current.absolute.path,
+          ),
+        );
+        return path.join(appSupportDir, ".local/share", _getAppDirectoryFromPlugin());
+      }
+
+      if (Platform.isMacOS) {
+        return _getAppDirectoryFromPlugin();
+      }
+
+      if (Platform.isWindows) {
+        return _getAppDirectoryFromPlugin();
+      }
+
+      throw UnsupportedError("Platform ${Platform.operatingSystem} is not supported");
+    } catch (e) {
+      throw RealmException('Cannot get app directory. Error: $e');
     }
-
-    // Flutter from here on..
-
-    if (Platform.isAndroid || Platform.isIOS) {
-      return getFilesPath();
-    }
-
-    if (Platform.isLinux) {
-      String appSupportDir = PlatformEx.fromEnvironment(
-        "XDG_DATA_HOME",
-        defaultValue: PlatformEx.fromEnvironment(
-          "HOME",
-          defaultValue: Directory.current.absolute.path,
-        ),
-      );
-      return path.join(appSupportDir, ".local/share", _getAppDirectoryFromPlugin());
-    }
-
-    if (Platform.isMacOS) {
-      return _getAppDirectoryFromPlugin();
-    }
-
-    if (Platform.isWindows) {
-      return _getAppDirectoryFromPlugin();
-    }
-
-    throw UnsupportedError("Platform ${Platform.operatingSystem} is not supported");
   }
 
   Future<void> deleteUser(App app, User user) {

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -2081,7 +2081,6 @@ class _RealmCore {
 
   String getAppDirectory() {
     if (!isFlutterPlatform || Platform.environment.containsKey('FLUTTER_TEST')) {
-      // return path.basenameWithoutExtension(File.fromUri(Platform.script).absolute.path);
       return Directory.current.absolute.path; // dart or flutter test
     }
 


### PR DESCRIPTION
- Avoid opening plugin lib when running `flutter test`
- Allow running `dart run realm install` in flutter project to install realm lib for unit tests
- Use new --flavor flag

Fixes #791, fixes #870 