### PR TITLE
Export migration class and callback function

### DIFF
--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -69,6 +69,7 @@ export "configuration.dart"
         InitialDataCallback,
         InMemoryConfiguration,
         LocalConfiguration,
+        MigrationCallback,
         RealmSchema,
         SchemaObject,
         ShouldCompactCallback,
@@ -83,6 +84,7 @@ export 'results.dart' show RealmResults, RealmResultsChanges;
 export 'subscription.dart' show Subscription, SubscriptionSet, SubscriptionSetState, MutableSubscriptionSet;
 export 'user.dart' show User, UserState, UserIdentity, ApiKeyClient, ApiKey;
 export 'session.dart' show Session, SessionState, ConnectionState, ProgressDirection, ProgressMode, SyncProgress, ConnectionStateChange;
+export 'migration.dart' show Migration;
 
 /// A [Realm] instance represents a `Realm` database.
 ///


### PR DESCRIPTION
Export `Migration` and `MigrationCallback` so that they show up in the generated reference docs.