### PR TITLE
Exit with an error code when generate command fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 * Added more validations when using `User.apiKeys` to return more meaningful errors when the user cannot perform API key actions - e.g. when the user has been logged in with API key credentials or when the user has been logged out. (Issue [#950](https://github.com/realm/realm-dart/issues/950))
-* Fixed `dart run realm_dart generate` and `flutter pub run realm generate` commands to exit with an error code when generation fails. Execution is now terminated when the command is run in a batch with other commands.
+* Fixed `dart run realm_dart generate` and `flutter pub run realm generate` commands to exit with the correct error code on failure.
 
 ### Compatibility
 * Realm Studio: 12.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Added more validations when using `User.apiKeys` to return more meaningful errors when the user cannot perform API key actions - e.g. when the user has been logged in with API key credentials or when the user has been logged out. (Issue [#950](https://github.com/realm/realm-dart/issues/950))
+* Fixed `dart run realm_dart generate` and `flutter pub run realm generate` commands to exit with an error code when generation fails. Execution is now terminated when the command is run in a batch with other commands.
 
 ### Compatibility
 * Realm Studio: 12.0.0 or later.

--- a/lib/src/cli/generate/generate_command.dart
+++ b/lib/src/cli/generate/generate_command.dart
@@ -51,9 +51,9 @@ class GenerateCommand extends Command<void> {
     ]);
 
     await stdout.addStream(process.stdout);
-    var exitCode = await process.exitCode;
-    if (exitCode != 0) {
-      exit(exitCode);
+    final exitCode = await process.exitCode;
+   exit(exitCode);
+   
     }
   }
 }

--- a/lib/src/cli/generate/generate_command.dart
+++ b/lib/src/cli/generate/generate_command.dart
@@ -42,10 +42,18 @@ class GenerateCommand extends Command<void> {
       'run',
       'build_runner',
       // prioritize clean, then watch, then build
-      options.clean ? 'clean' : options.watch ? 'watch' : 'build',
+      options.clean
+          ? 'clean'
+          : options.watch
+              ? 'watch'
+              : 'build',
       ...[if (!options.clean) '--delete-conflicting-outputs'], // not legal option to clean
     ]);
-    
+
     await stdout.addStream(process.stdout);
+    var exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      exit(exitCode);
+    }
   }
 }

--- a/lib/src/cli/generate/generate_command.dart
+++ b/lib/src/cli/generate/generate_command.dart
@@ -52,8 +52,6 @@ class GenerateCommand extends Command<void> {
 
     await stdout.addStream(process.stdout);
     final exitCode = await process.exitCode;
-   exit(exitCode);
-   
-    }
+    exit(exitCode);
   }
 }


### PR DESCRIPTION
Fix `dart run realm_dart generate` command to exit with an error code when generation fails.
Otherwise, it does not terminate the execution of the command batch.
The CI for generating models for the samples after the new realm is released didn't fail on generating error.
Fixes #956