### PR TITLE
Bump json_annotation version to fix generator tests

### DIFF
--- a/flutter/realm_flutter/pubspec.yaml
+++ b/flutter/realm_flutter/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   collection: ^1.16.0
   crypto: ^3.0.0
   ffi: ^2.0.1
-  json_annotation: ^4.4.0
+  json_annotation: ^4.7.0
   logging: ^1.0.0
   meta: ^1.1.8
   package_config: ^2.0.0

--- a/lib/src/cli/metrics/metrics.g.dart
+++ b/lib/src/cli/metrics/metrics.g.dart
@@ -40,6 +40,7 @@ Properties _$PropertiesFromJson(Map<String, dynamic> json) => Properties(
 Map<String, dynamic> _$PropertiesToJson(Properties instance) {
   final val = <String, dynamic>{
     'token': instance.token,
+    'distinct_id': _digestToJson(instance.distinctId),
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -48,7 +49,6 @@ Map<String, dynamic> _$PropertiesToJson(Properties instance) {
     }
   }
 
-  writeNotNull('distinct_id', _digestToJson(instance.distinctId));
   writeNotNull('Anonymized MAC Address',
       const DigestConverter().toJson(instance.anonymizedMacAddress));
   writeNotNull('Anonymized Bundle ID',
@@ -61,7 +61,7 @@ Map<String, dynamic> _$PropertiesToJson(Properties instance) {
   val['Realm Version'] = instance.realmVersion;
   val['Host OS Type'] = instance.hostOsType;
   val['Host OS Version'] = instance.hostOsVersion;
-  writeNotNull('Target OS Type', _$TargetOsTypeEnumMap[instance.targetOsType]);
+  val['Target OS Type'] = _$TargetOsTypeEnumMap[instance.targetOsType];
   writeNotNull('Target OS Version', instance.targetOsVersion);
   return val;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   collection: ^1.16.0
   crypto: ^3.0.0
   ffi: ^2.0.1
-  json_annotation: ^4.6.0
+  json_annotation: ^4.7.0
   logging: ^1.0.0
   meta: ^1.1.8
   package_config: ^2.0.0


### PR DESCRIPTION
Increase json_annotation version to ^4.7.0.
Regenerate metrics.g.dart