### PR TITLE
Generator fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,7 @@
             "name": "Dart: Attach to Process",
             "type": "dart",
             "request": "attach",
-            "observatoryUri": "http://127.0.0.1:8181/CvAvF39i-48=/",
+            "vmServiceUri": "http://127.0.0.1:5858",
             "packages": "package:realm/main.dart"
         },
         {

--- a/generator/README.md
+++ b/generator/README.md
@@ -65,7 +65,7 @@ class _Car {
 * Use a terminal to launch a debuggee with command
 
   ```
-  dart --observe --pause-isolates-on-start  --enable-vm-service:5858/127.0.0.1  --disable-service-auth-codes .dart_tool/build/entrypoint/build.dart build
+  dart run --observe --pause-isolates-on-start  --enable-vm-service:5858/127.0.0.1  --disable-service-auth-codes .dart_tool/build/entrypoint/build.dart build
   ```
 
 ##### The "Dart" name and logo and the "Flutter" name and logo are trademarks owned by Google.

--- a/generator/lib/src/class_element_ex.dart
+++ b/generator/lib/src/class_element_ex.dart
@@ -167,7 +167,7 @@ extension ClassElementEx on ClassElement {
     } catch (e, s) {
       // Fallback. Not perfect, but better than just forwarding original error.
       throw RealmInvalidGenerationSourceError(
-        '$e',
+        '$e \n $s',
         todo: //
             'Unexpected error. Please open an issue on: '
             'https://github.com/realm/realm-dart',

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -223,7 +223,7 @@ extension FieldElementEx on FieldElement {
     } catch (e, s) {
       // Fallback. Not perfect, but better than just forwarding original error.
       throw RealmInvalidGenerationSourceError(
-        '$e',
+        '$e \n $s',
         todo: //
             'Unexpected error. Please open an issue on: '
             'https://github.com/realm/realm-dart',

--- a/generator/test/test_util.dart
+++ b/generator/test/test_util.dart
@@ -15,16 +15,18 @@ Map<String, String> getListOfTestFiles(String directory) {
   for (var file in files) {
     if (_path.extension(file.path) == '.dart' && !file.path.endsWith('g.dart')) {
       var expectedFileName = _path.setExtension(file.path, '.expected');
-      if (!files.any((f) => f.path == expectedFileName)) expectedFileName = '';
+       if (!files.any((f) => f.path == expectedFileName)) {
+        throw "Expected file not found. $expectedFileName";
+      }
       result.addAll({_path.basename(file.path): _path.basename(expectedFileName)});
     }
   }
   return result;
 }
 
-Future<dynamic> generatorTestBuilder(String directoryName, String inputFileName, [String expectedFileName = ""]) async {
+Future<dynamic> generatorTestBuilder(String directoryName, String inputFileName, String? expectedFileName) async {
   return testBuilder(generateRealmObjects(), await getInputFileAsset('$directoryName/$inputFileName'),
-      outputs: expectedFileName.isNotEmpty ? await getExpectedFileAsset('$directoryName/$inputFileName', '$directoryName/$expectedFileName') : null,
+      outputs: expectedFileName != null ? await getExpectedFileAsset('$directoryName/$inputFileName', '$directoryName/$expectedFileName') : null,
       reader: await PackageAssetReader.currentIsolate());
 }
 
@@ -114,5 +116,5 @@ String _stringReplacements(String content) {
 }
 
 String getTestName(String file) {
-  return _path.basename(file.replaceAll('_', ' '));
+  return _path.basename(file);
 }

--- a/generator/test/test_util.dart
+++ b/generator/test/test_util.dart
@@ -24,7 +24,7 @@ Map<String, String> getListOfTestFiles(String directory) {
   return result;
 }
 
-Future<dynamic> generatorTestBuilder(String directoryName, String inputFileName, String? expectedFileName) async {
+Future<dynamic> generatorTestBuilder(String directoryName, String inputFileName, [String? expectedFileName]) async {
   return testBuilder(generateRealmObjects(), await getInputFileAsset('$directoryName/$inputFileName'),
       outputs: expectedFileName != null ? await getExpectedFileAsset('$directoryName/$inputFileName', '$directoryName/$expectedFileName') : null,
       reader: await PackageAssetReader.currentIsolate());


### PR DESCRIPTION
print the exception stacktrace if generator encounters an exception
throw on no expected file found. - previously if an expected file was not found the test did succeed. This is not ideal since the file might be there with the wrong name giving a false impression that the test succeeds or not there at all.
generator tests are named after the exact file name. - previously the underscore was removed. This mostly helps when filtering the test runs in the console