### PR TITLE
Reorder AuthProviderType values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * None
 
 ### Fixed
-* None
+* Fixed a wrong mapping for `AuthProviderType` returned by `User.provider` for google, facebook and apple credentials.
 
 ### Compatibility
 * Realm Studio: 12.0.0 or later.

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -139,6 +139,8 @@ extension CredentialsInternal on Credentials {
   }
 
   RealmAppCredentialsHandle get handle => _handle;
+
+  AuthProviderType readProviderFromCore() => realmCore.userGetCredentialsProviderType(this);
 }
 
 /// A class, encapsulating functionality for users, logged in with [Credentials.emailPassword()].

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -140,7 +140,8 @@ extension CredentialsInternal on Credentials {
 
   RealmAppCredentialsHandle get handle => _handle;
 
-  AuthProviderType readProviderFromCore() => realmCore.userGetCredentialsProviderType(this);
+  /// This should be only used for testing
+  AuthProviderType get credentialsProviderType => realmCore.userGetCredentialsProviderType(this);
 }
 
 /// A class, encapsulating functionality for users, logged in with [Credentials.emailPassword()].

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -64,15 +64,8 @@ extension AuthProviderTypeInternal on AuthProviderType {
   static AuthProviderType getByValue(int value) {
     if (value == AuthProviderType._anonymousNoReuse._value) {
       return AuthProviderType.anonymous;
-    } else {
-      for (final type in AuthProviderType.values) {
-        if (type._value == value) {
-          return type;
-        }
-      }
     }
-
-    throw ArgumentError('Invalid AuthProviderType value: $value');
+    return AuthProviderType.values.firstWhere((v) => v._value == value);
   }
 }
 

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -80,60 +80,43 @@ extension AuthProviderTypeInternal on AuthProviderType {
 /// {@category Application}
 class Credentials implements Finalizable {
   final RealmAppCredentialsHandle _handle;
-  final AuthProviderType provider;
 
   /// Returns a [Credentials] object that can be used to authenticate an anonymous user.
   /// Setting [reuseCredentials] to [false] will create a new anonymous user, upon [App.logIn].
   /// [Anonymous Authentication Docs](https://docs.mongodb.com/realm/authentication/anonymous)
-  Credentials.anonymous({bool reuseCredentials = true})
-      : _handle = realmCore.createAppCredentialsAnonymous(reuseCredentials),
-        provider = AuthProviderType.anonymous;
+  Credentials.anonymous({bool reuseCredentials = true}) : _handle = realmCore.createAppCredentialsAnonymous(reuseCredentials);
 
   /// Returns a [Credentials] object that can be used to authenticate a user with a Google account using an id token.
-  Credentials.apple(String idToken)
-      : _handle = realmCore.createAppCredentialsApple(idToken),
-        provider = AuthProviderType.apple;
+  Credentials.apple(String idToken) : _handle = realmCore.createAppCredentialsApple(idToken);
 
   /// Returns a [Credentials] object that can be used to authenticate a user with their email and password.
   /// A user can login with email and password only after they have registered their account and verified their
   /// email.
   /// [Email/Password Authentication Docs](https://docs.mongodb.com/realm/authentication/email-password)
-  Credentials.emailPassword(String email, String password)
-      : _handle = realmCore.createAppCredentialsEmailPassword(email, password),
-        provider = AuthProviderType.emailPassword;
+  Credentials.emailPassword(String email, String password) : _handle = realmCore.createAppCredentialsEmailPassword(email, password);
 
   /// Returns a [Credentials] object that can be used to authenticate a user with a custom JWT.
   /// [Custom-JWT Authentication Docs](https://docs.mongodb.com/realm/authentication/custom-jwt)
-  Credentials.jwt(String token)
-      : _handle = realmCore.createAppCredentialsJwt(token),
-        provider = AuthProviderType.jwt;
+  Credentials.jwt(String token) : _handle = realmCore.createAppCredentialsJwt(token);
 
   /// Returns a [Credentials] object that can be used to authenticate a user with a Facebook account.
-  Credentials.facebook(String accessToken)
-      : _handle = realmCore.createAppCredentialsFacebook(accessToken),
-        provider = AuthProviderType.facebook;
+  Credentials.facebook(String accessToken) : _handle = realmCore.createAppCredentialsFacebook(accessToken);
 
   /// Returns a [Credentials] object that can be used to authenticate a user with a Google account using an authentication code.
-  Credentials.googleAuthCode(String authCode)
-      : _handle = realmCore.createAppCredentialsGoogleAuthCode(authCode),
-        provider = AuthProviderType.google;
+  Credentials.googleAuthCode(String authCode) : _handle = realmCore.createAppCredentialsGoogleAuthCode(authCode);
 
   /// Returns a [Credentials] object that can be used to authenticate a user with a Google account using an id token.
-  Credentials.googleIdToken(String idToken)
-      : _handle = realmCore.createAppCredentialsGoogleIdToken(idToken),
-        provider = AuthProviderType.google;
+  Credentials.googleIdToken(String idToken) : _handle = realmCore.createAppCredentialsGoogleIdToken(idToken);
 
   /// Returns a [Credentials] object that can be used to authenticate a user with a custom Function.
   /// [Custom Function Authentication Docs](https://www.mongodb.com/docs/atlas/app-services/authentication/custom-function/)
-  Credentials.function(String payload)
-      : _handle = realmCore.createAppCredentialsFunction(payload),
-        provider = AuthProviderType.function;
+  Credentials.function(String payload) : _handle = realmCore.createAppCredentialsFunction(payload);
 
   /// Returns a [Credentials] object that can be used to authenticate a user with an API key.
   /// To generate an API key, use [ApiKeyClient.create] or the App Services web UI.
-  Credentials.apiKey(String key)
-      : _handle = realmCore.createAppCredentialsApiKey(key),
-        provider = AuthProviderType.apiKey;
+  Credentials.apiKey(String key) : _handle = realmCore.createAppCredentialsApiKey(key);
+
+  AuthProviderType get provider => realmCore.userGetCredentialsProviderType(this);
 }
 
 /// @nodoc
@@ -144,9 +127,6 @@ extension CredentialsInternal on Credentials {
   }
 
   RealmAppCredentialsHandle get handle => _handle;
-
-  /// This should be only used for testing
-  AuthProviderType get credentialsProviderType => realmCore.userGetCredentialsProviderType(this);
 }
 
 /// A class, encapsulating functionality for users, logged in with [Credentials.emailPassword()].

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -31,7 +31,8 @@ enum AuthProviderType {
   anonymous(0),
 
   /// For authenticating without credentials using a new anonymous user.
-  anonymousNoReuse(1),
+  /// @nodoc
+  _anonymousNoReuse(1),
 
   /// Authenticate with Facebook account.
   facebook(2),
@@ -61,9 +62,13 @@ enum AuthProviderType {
 
 extension AuthProviderTypeInternal on AuthProviderType {
   static AuthProviderType getByValue(int value) {
-    for (final type in AuthProviderType.values) {
-      if (type._value == value) {
-        return type;
+    if (value == AuthProviderType._anonymousNoReuse._value) {
+      return AuthProviderType.anonymous;
+    } else {
+      for (final type in AuthProviderType.values) {
+        if (type._value == value) {
+          return type;
+        }
       }
     }
 
@@ -82,7 +87,7 @@ class Credentials implements Finalizable {
   /// [Anonymous Authentication Docs](https://docs.mongodb.com/realm/authentication/anonymous)
   Credentials.anonymous({bool reuseCredentials = true})
       : _handle = realmCore.createAppCredentialsAnonymous(reuseCredentials),
-        provider = reuseCredentials ? AuthProviderType.anonymous : AuthProviderType.anonymousNoReuse;
+        provider = AuthProviderType.anonymous;
 
   /// Returns a [Credentials] object that can be used to authenticate a user with a Google account using an id token.
   Credentials.apple(String idToken)

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -33,14 +33,14 @@ enum AuthProviderType {
   /// For authenticating without credentials using a new anonymous user.
   anonymousNoReuse(1),
 
-  /// Authenticate with Apple Id
-  apple(2),
-
   /// Authenticate with Facebook account.
-  facebook(3),
+  facebook(2),
 
   /// Authenticate with Google account
-  google(4),
+  google(3),
+
+  /// Authenticate with Apple Id
+  apple(4),
 
   /// For authenticating with JSON web token.
   jwt(5),

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1758,6 +1758,11 @@ class _RealmCore {
     return AuthProviderTypeInternal.getByValue(provider);
   }
 
+  AuthProviderType userGetCredentialsProviderType(Credentials credentials) {
+    final provider = _realmLib.realm_auth_credentials_get_provider(credentials.handle._pointer);
+    return AuthProviderTypeInternal.getByValue(provider);
+  }
+
   UserProfile userGetProfileData(User user) {
     final data = _realmLib.invokeGetPointer(() => _realmLib.realm_user_get_profile_data(user.handle._pointer));
     final dynamic profileData = jsonDecode(data.cast<Utf8>().toRealmDartString(freeRealmMemory: true)!);

--- a/test/credentials_test.dart
+++ b/test/credentials_test.dart
@@ -18,7 +18,7 @@
 
 import 'package:test/test.dart' hide test, throws;
 import '../lib/realm.dart';
-import '../lib/src/credentials.dart';
+import '../lib/src/credentials.dart' show CredentialsInternal;
 import 'test.dart';
 
 Future<void> main([List<String>? args]) async {
@@ -488,7 +488,7 @@ Future<void> main([List<String>? args]) async {
 
   test('Credentials providers', () {
     _checkCredentialsProvider(Credentials.anonymous(), AuthProviderType.anonymous);
-    _checkCredentialsProvider(Credentials.anonymous(reuseCredentials: false), AuthProviderType.anonymousNoReuse);
+    _checkCredentialsProvider(Credentials.anonymous(reuseCredentials: false), AuthProviderType.anonymous);
     _checkCredentialsProvider(Credentials.apiKey(""), AuthProviderType.apiKey);
     _checkCredentialsProvider(Credentials.apple(""), AuthProviderType.apple);
     _checkCredentialsProvider(Credentials.emailPassword("", ""), AuthProviderType.emailPassword);
@@ -502,5 +502,5 @@ Future<void> main([List<String>? args]) async {
 
 void _checkCredentialsProvider(Credentials anonymousCredentials, AuthProviderType providerType) {
   expect(anonymousCredentials.provider, providerType);
-  expect(anonymousCredentials.readProviderFromCore(), providerType);
+  expect(anonymousCredentials.credentialsProviderType, providerType);
 }

--- a/test/credentials_test.dart
+++ b/test/credentials_test.dart
@@ -18,6 +18,7 @@
 
 import 'package:test/test.dart' hide test, throws;
 import '../lib/realm.dart';
+import '../lib/src/credentials.dart';
 import 'test.dart';
 
 Future<void> main([List<String>? args]) async {
@@ -484,4 +485,22 @@ Future<void> main([List<String>? args]) async {
     expect(sameUser.identities[0].id, userId);
     expect(sameUser.provider, AuthProviderType.function);
   });
+
+  test('Credentials providers', () {
+    _checkCredentialsProvider(Credentials.anonymous(), AuthProviderType.anonymous);
+    _checkCredentialsProvider(Credentials.anonymous(reuseCredentials: false), AuthProviderType.anonymousNoReuse);
+    _checkCredentialsProvider(Credentials.apiKey(""), AuthProviderType.apiKey);
+    _checkCredentialsProvider(Credentials.apple(""), AuthProviderType.apple);
+    _checkCredentialsProvider(Credentials.emailPassword("", ""), AuthProviderType.emailPassword);
+    _checkCredentialsProvider(Credentials.facebook(""), AuthProviderType.facebook);
+    _checkCredentialsProvider(Credentials.function("{}"), AuthProviderType.function);
+    _checkCredentialsProvider(Credentials.googleAuthCode(""), AuthProviderType.google);
+    _checkCredentialsProvider(Credentials.googleIdToken(""), AuthProviderType.google);
+    _checkCredentialsProvider(Credentials.jwt(""), AuthProviderType.jwt);
+  });
+}
+
+void _checkCredentialsProvider(Credentials anonymousCredentials, AuthProviderType providerType) {
+  expect(anonymousCredentials.provider, providerType);
+  expect(anonymousCredentials.readProviderFromCore(), providerType);
 }

--- a/test/credentials_test.dart
+++ b/test/credentials_test.dart
@@ -38,6 +38,8 @@ Future<void> main([List<String>? args]) async {
 
     expect(user1, user2);
     expect(user1, isNot(user3));
+    expect(user1.provider, AuthProviderType.anonymous);
+    expect(user3.provider, AuthProviderType.anonymous);
   });
 
   test('Credentials email/password', () {

--- a/test/credentials_test.dart
+++ b/test/credentials_test.dart
@@ -18,7 +18,6 @@
 
 import 'package:test/test.dart' hide test, throws;
 import '../lib/realm.dart';
-import '../lib/src/credentials.dart' show CredentialsInternal;
 import 'test.dart';
 
 Future<void> main([List<String>? args]) async {
@@ -487,20 +486,15 @@ Future<void> main([List<String>? args]) async {
   });
 
   test('Credentials providers', () {
-    _checkCredentialsProvider(Credentials.anonymous(), AuthProviderType.anonymous);
-    _checkCredentialsProvider(Credentials.anonymous(reuseCredentials: false), AuthProviderType.anonymous);
-    _checkCredentialsProvider(Credentials.apiKey(""), AuthProviderType.apiKey);
-    _checkCredentialsProvider(Credentials.apple(""), AuthProviderType.apple);
-    _checkCredentialsProvider(Credentials.emailPassword("", ""), AuthProviderType.emailPassword);
-    _checkCredentialsProvider(Credentials.facebook(""), AuthProviderType.facebook);
-    _checkCredentialsProvider(Credentials.function("{}"), AuthProviderType.function);
-    _checkCredentialsProvider(Credentials.googleAuthCode(""), AuthProviderType.google);
-    _checkCredentialsProvider(Credentials.googleIdToken(""), AuthProviderType.google);
-    _checkCredentialsProvider(Credentials.jwt(""), AuthProviderType.jwt);
+    expect(Credentials.anonymous().provider, AuthProviderType.anonymous);
+    expect(Credentials.anonymous(reuseCredentials: false).provider, AuthProviderType.anonymous);
+    expect(Credentials.apiKey("").provider, AuthProviderType.apiKey);
+    expect(Credentials.apple("").provider, AuthProviderType.apple);
+    expect(Credentials.emailPassword("", "").provider, AuthProviderType.emailPassword);
+    expect(Credentials.facebook("").provider, AuthProviderType.facebook);
+    expect(Credentials.function("{}").provider, AuthProviderType.function);
+    expect(Credentials.googleAuthCode("").provider, AuthProviderType.google);
+    expect(Credentials.googleIdToken("").provider, AuthProviderType.google);
+    expect(Credentials.jwt("").provider, AuthProviderType.jwt);
   });
-}
-
-void _checkCredentialsProvider(Credentials anonymousCredentials, AuthProviderType providerType) {
-  expect(anonymousCredentials.provider, providerType);
-  expect(anonymousCredentials.credentialsProviderType, providerType);
 }


### PR DESCRIPTION
- Returned `user.provider` was wrong for facebook, google and apple. All the other providers were correct, because their numbers remains the same.

- When we login with `Credentials.anonymous(reuseCredentials: false)` the returned user.provider is also `AuthProviderType.anonymous` instead of `anonymousNoReuse`. To be discussed.

Fixes  #992