### PR TITLE
Don't assume api key order in fetchAll

### DIFF
--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -230,7 +230,8 @@ Future<void> main([List<String>? args]) async {
     final fetched = await user.apiKeys.fetchAll();
 
     for (var i = 0; i < 5; i++) {
-      expectApiKey(fetched[i], original[i]);
+      final fetchedKey = fetched.firstWhere((key) => key.id == original[i].id);
+      expectApiKey(fetchedKey, original[i]);
     }
   });
 
@@ -335,12 +336,14 @@ Future<void> main([List<String>? args]) async {
     await disableAndVerifyApiKey(user, first.id);
 
     final fetched = await user.apiKeys.fetchAll();
+    final fetchedFirst = fetched.firstWhere((key) => key.id == first.id);
 
-    expect(fetched[0].id, first.id);
-    expect(fetched[0].isEnabled, false);
+    expect(fetchedFirst.id, first.id);
+    expect(fetchedFirst.isEnabled, false);
 
-    expect(fetched[1].id, second.id);
-    expect(fetched[1].isEnabled, true);
+    final fetchedSecond = fetched.firstWhere((key) => key.id == second.id);
+    expect(fetchedSecond.id, second.id);
+    expect(fetchedSecond.isEnabled, true);
   });
 
   baasTest('User.apiKeys.enable reenables key', (configuration) async {
@@ -356,20 +359,26 @@ Future<void> main([List<String>? args]) async {
     await disableAndVerifyApiKey(user, first.id);
 
     final fetched = await user.apiKeys.fetchAll();
-    expect(fetched[0].id, first.id);
-    expect(fetched[0].isEnabled, false);
+    final fetchedFirst = fetched.firstWhere((key) => key.id == first.id);
+    expect(fetchedFirst.id, first.id);
+    expect(fetchedFirst.isEnabled, false);
 
-    expect(fetched[1].id, second.id);
-    expect(fetched[1].isEnabled, true);
+    final fetchedSecond = fetched.firstWhere((key) => key.id == second.id);
+    expect(fetchedSecond.id, second.id);
+    expect(fetchedSecond.isEnabled, true);
 
     await enableAndVerifyApiKey(user, first.id);
 
     final refetched = await user.apiKeys.fetchAll();
-    expect(refetched[0].id, first.id);
-    expect(refetched[0].isEnabled, true);
+    final refetchedFirst = refetched.firstWhere((k) => k.id == first.id);
 
-    expect(refetched[1].id, second.id);
-    expect(refetched[1].isEnabled, true);
+    expect(refetchedFirst.id, first.id);
+    expect(refetchedFirst.isEnabled, true);
+
+    final refetchedSecond = refetched.firstWhere((k) => k.id == second.id);
+
+    expect(refetchedSecond.id, second.id);
+    expect(refetchedSecond.isEnabled, true);
   });
 
   baasTest('User.apiKeys can login with generated key', (configuration) async {

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -76,7 +76,7 @@ Future<void> main([List<String>? args]) async {
 
     expect(user1.state, UserState.loggedIn);
     expect(user1.identities.length, 1);
-    expect(user1.identities.singleWhere((identity) => identity.provider == AuthProviderType.anonymous).provider, isNotNull);
+    expect(user1.identities.singleWhere((identity) => identity.provider == AuthProviderType.anonymous), isA<UserIdentity>());
 
     final authProvider = EmailPasswordAuthProvider(app);
     final username = "${generateRandomString(20)}@realm.io";
@@ -85,8 +85,8 @@ Future<void> main([List<String>? args]) async {
 
     await user1.linkCredentials(Credentials.emailPassword(username, password));
     expect(user1.identities.length, 2);
-    expect(user1.identities.singleWhere((identity) => identity.provider == AuthProviderType.emailPassword).provider, isNotNull);
-    expect(user1.identities.singleWhere((identity) => identity.provider == AuthProviderType.anonymous).provider, isNotNull);
+    expect(user1.identities.singleWhere((identity) => identity.provider == AuthProviderType.emailPassword), isA<UserIdentity>());
+    expect(user1.identities.singleWhere((identity) => identity.provider == AuthProviderType.anonymous), isA<UserIdentity>());
 
     final user2 = await app.logIn(Credentials.emailPassword(username, password));
     expect(user1, user2);
@@ -336,13 +336,11 @@ Future<void> main([List<String>? args]) async {
     await disableAndVerifyApiKey(user, first.id);
 
     final fetched = await user.apiKeys.fetchAll();
-    final fetchedFirst = fetched.singleWhere((key) => key.id == first.id);
 
-    expect(fetchedFirst.id, first.id);
+    final fetchedFirst = fetched.singleWhere((key) => key.id == first.id);
     expect(fetchedFirst.isEnabled, false);
 
     final fetchedSecond = fetched.singleWhere((key) => key.id == second.id);
-    expect(fetchedSecond.id, second.id);
     expect(fetchedSecond.isEnabled, true);
   });
 
@@ -361,11 +359,9 @@ Future<void> main([List<String>? args]) async {
     final fetched = await user.apiKeys.fetchAll();
 
     final fetchedFirst = fetched.singleWhere((key) => key.id == first.id);
-    expect(fetchedFirst.id, first.id);
     expect(fetchedFirst.isEnabled, false);
 
     final fetchedSecond = fetched.singleWhere((key) => key.id == second.id);
-    expect(fetchedSecond.id, second.id);
     expect(fetchedSecond.isEnabled, true);
 
     await enableAndVerifyApiKey(user, first.id);
@@ -373,11 +369,9 @@ Future<void> main([List<String>? args]) async {
     final refetched = await user.apiKeys.fetchAll();
 
     final refetchedFirst = refetched.singleWhere((k) => k.id == first.id);
-    expect(refetchedFirst.id, first.id);
     expect(refetchedFirst.isEnabled, true);
 
     final refetchedSecond = refetched.singleWhere((k) => k.id == second.id);
-    expect(refetchedSecond.id, second.id);
     expect(refetchedSecond.isEnabled, true);
   });
 

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -230,7 +230,7 @@ Future<void> main([List<String>? args]) async {
     final fetched = await user.apiKeys.fetchAll();
 
     for (var i = 0; i < 5; i++) {
-      final fetchedKey = fetched.firstWhere((key) => key.id == original[i].id);
+      final fetchedKey = fetched.singleWhere((key) => key.id == original[i].id);
       expectApiKey(fetchedKey, original[i]);
     }
   });
@@ -336,12 +336,12 @@ Future<void> main([List<String>? args]) async {
     await disableAndVerifyApiKey(user, first.id);
 
     final fetched = await user.apiKeys.fetchAll();
-    final fetchedFirst = fetched.firstWhere((key) => key.id == first.id);
+    final fetchedFirst = fetched.singleWhere((key) => key.id == first.id);
 
     expect(fetchedFirst.id, first.id);
     expect(fetchedFirst.isEnabled, false);
 
-    final fetchedSecond = fetched.firstWhere((key) => key.id == second.id);
+    final fetchedSecond = fetched.singleWhere((key) => key.id == second.id);
     expect(fetchedSecond.id, second.id);
     expect(fetchedSecond.isEnabled, true);
   });
@@ -359,24 +359,24 @@ Future<void> main([List<String>? args]) async {
     await disableAndVerifyApiKey(user, first.id);
 
     final fetched = await user.apiKeys.fetchAll();
-    final fetchedFirst = fetched.firstWhere((key) => key.id == first.id);
+
+    final fetchedFirst = fetched.singleWhere((key) => key.id == first.id);
     expect(fetchedFirst.id, first.id);
     expect(fetchedFirst.isEnabled, false);
 
-    final fetchedSecond = fetched.firstWhere((key) => key.id == second.id);
+    final fetchedSecond = fetched.singleWhere((key) => key.id == second.id);
     expect(fetchedSecond.id, second.id);
     expect(fetchedSecond.isEnabled, true);
 
     await enableAndVerifyApiKey(user, first.id);
 
     final refetched = await user.apiKeys.fetchAll();
-    final refetchedFirst = refetched.firstWhere((k) => k.id == first.id);
 
+    final refetchedFirst = refetched.singleWhere((k) => k.id == first.id);
     expect(refetchedFirst.id, first.id);
     expect(refetchedFirst.isEnabled, true);
 
-    final refetchedSecond = refetched.firstWhere((k) => k.id == second.id);
-
+    final refetchedSecond = refetched.singleWhere((k) => k.id == second.id);
     expect(refetchedSecond.id, second.id);
     expect(refetchedSecond.isEnabled, true);
   });


### PR DESCRIPTION
This should fix our newly failing tests.