### PR TITLE
Set the correct schema mode for disconnectedSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed a wrong mapping for `AuthProviderType` returned by `User.provider` for google, facebook and apple credentials.
 * Opening an unencrypted file with an encryption key would sometimes report a misleading error message that indicated that the problem was something other than a decryption failure (Core upgrade)
 * Fix a rare deadlock which could occur when closing a synchronized Realm immediately after committing a write transaction when the sync worker thread has also just finished processing a changeset from the server. (Core upgrade)
+* Fixed an issue with `Configuration.disconnectedSync` where changing the schema could result in migration exception. (PR [#999](https://github.com/realm/realm-dart/pull/999))
 
 ### Compatibility
 * Realm Studio: 12.0.0 or later.

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -228,6 +228,7 @@ class _RealmCore {
           _realmLib.realm_release(syncConfigPtr.cast());
         }
       } else if (config is DisconnectedSyncConfiguration) {
+        _realmLib.realm_config_set_schema_mode(configHandle._pointer, realm_schema_mode.RLM_SCHEMA_MODE_ADDITIVE_EXPLICIT);
         _realmLib.realm_config_set_force_sync_history(configPtr, true);
       }
       if (config.encryptionKey != null) {


### PR DESCRIPTION
Noticed that while looking at https://docs.google.com/document/d/17cqTiriugPEJQjvk58t7kwcr9Cdkat5Le7khJOZju5k/edit#. Need to write some tests for it though.