### PR TITLE
Support RealmValue (aka mixed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Add List.move extension method that moves an element from one index to another. Delegates to ManagedRealmList.move for managed lists. This allows notifications to correctly report moves, as opposed to reporting moves as deletes + inserts. ([#1037](https://github.com/realm/realm-dart/issues/1037))
 * Support setting `shouldDeleteIfMigrationNeeded` when creating a `Configuration.local`. ([#1049](https://github.com/realm/realm-dart/issues/1049))
 * Add `unknown` error code to all SyncErrors: `SyncSessionErrorCode.unknown`, `SyncConnectionErrorCode.unknown`, `SyncClientErrorCode.unknown`, `GeneralSyncErrorCode.unknown`. Use `unknown` error code instead of throwing a RealmError. ([#1052](https://github.com/realm/realm-dart/pull/1052))
-* Support `RealmValue` that allows users to store different types in the same field. ([#1051](https://github.com/realm/realm-dart/pull/1051))
+* Add support for `RealmValue` data type. This new type can represent any valid Realm data type, including objects. Lists of `RealmValue` are also supported, but `RealmValue` itself cannot contain collections. Please note that a property of type `RealmValue` cannot be nullable, but can contain null, represented by the value `RealmValue.nullValue()`. ([#1051](https://github.com/realm/realm-dart/pull/1051))
 
 ### Fixed
 * Support mapping into `SyncSessionErrorCode` for "Compensating write" with error code 231. ([#1022](https://github.com/realm/realm-dart/pull/1022))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add List.move extension method that moves an element from one index to another. Delegates to ManagedRealmList.move for managed lists. This allows notifications to correctly report moves, as opposed to reporting moves as deletes + inserts. ([#1037](https://github.com/realm/realm-dart/issues/1037))
 * Support setting `shouldDeleteIfMigrationNeeded` when creating a `Configuration.local`. ([#1049](https://github.com/realm/realm-dart/issues/1049))
 * Add `unknown` error code to all SyncErrors: `SyncSessionErrorCode.unknown`, `SyncConnectionErrorCode.unknown`, `SyncClientErrorCode.unknown`, `GeneralSyncErrorCode.unknown`. Use `unknown` error code instead of throwing a RealmError. ([#1052](https://github.com/realm/realm-dart/pull/1052))
+* Support `RealmValue` that allows users to store different types in the same field. ([#1051](https://github.com/realm/realm-dart/pull/1051))
 
 ### Fixed
 * Support mapping into `SyncSessionErrorCode` for "Compensating write" with error code 231. ([#1022](https://github.com/realm/realm-dart/pull/1022))

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -131,8 +131,26 @@ class RealmValue {
   const RealmValue.realmObject(RealmObjectBaseMarker o) : this._(o);
   const RealmValue.dateTime(DateTime timestamp) : this._(timestamp);
   const RealmValue.objectId(ObjectId id) : this._(id);
-  const RealmValue.decimal128(Decimal128 decimal) : this._(decimal);
+  // const RealmValue.decimal128(Decimal128 decimal) : this._(decimal); // Not supported yet
   const RealmValue.uuid(Uuid uuid) : this._(uuid);
+
+  factory RealmValue.from(Object o) {
+    if (o is bool ||
+        o is String ||
+        o is int ||
+        o is Float ||
+        o is double ||
+        o is Uint8List ||
+        o is RealmObjectBaseMarker ||
+        o is DateTime ||
+        o is ObjectId ||
+        // o is Decimal128 || // not supported yet
+        o is Uuid) {
+      return RealmValue._(o);
+    } else {
+      throw ArgumentError.value(o, 'o', 'Unsupported type');
+    }
+  }
 }
 
 /// The category of a [SyncError].

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -46,7 +46,7 @@ enum RealmPropertyType {
   _3, // ignore: unused_field, constant_identifier_names
   binary,
   _5, // ignore: unused_field, constant_identifier_names
-  mixed,
+  mixed(Mapping<RealmValue>(indexable: true)),
   _7, // ignore: unused_field, constant_identifier_names
   timestamp(Mapping<DateTime>(indexable: true)),
   float,
@@ -114,25 +114,25 @@ class EmbeddedObjectMarker extends RealmObjectBaseMarker {}
 
 // Union type
 /// @nodoc
-class RealmAny {
-  final dynamic value;
+class RealmValue {
+  final Object value;
   T as<T>() => value as T; // better for code completion
 
   // This is private, so user cannot accidentally construct an invalid instance
-  const RealmAny._(this.value);
+  const RealmValue._(this.value);
 
-  const RealmAny.bool(bool b) : this._(b);
-  const RealmAny.string(String text) : this._(text);
-  const RealmAny.int(int i) : this._(i);
-  const RealmAny.float(Float f) : this._(f);
-  const RealmAny.double(double d) : this._(d);
-  const RealmAny.uint8List(Uint8List data) : this._(data);
+  const RealmValue.bool(bool b) : this._(b);
+  const RealmValue.string(String text) : this._(text);
+  const RealmValue.int(int i) : this._(i);
+  const RealmValue.float(Float f) : this._(f);
+  const RealmValue.double(double d) : this._(d);
+  const RealmValue.uint8List(Uint8List data) : this._(data);
   // TODO: RealmObjectMarker introduced to avoid dependency inversion. It would be better if we could use RealmObject directly. https://github.com/realm/realm-dart/issues/701
-  const RealmAny.realmObject(RealmObjectBaseMarker o) : this._(o);
-  const RealmAny.dateTime(DateTime timestamp) : this._(timestamp);
-  const RealmAny.objectId(ObjectId id) : this._(id);
-  const RealmAny.decimal128(Decimal128 decimal) : this._(decimal);
-  const RealmAny.uuid(Uuid uuid) : this._(uuid);
+  const RealmValue.realmObject(RealmObjectBaseMarker o) : this._(o);
+  const RealmValue.dateTime(DateTime timestamp) : this._(timestamp);
+  const RealmValue.objectId(ObjectId id) : this._(id);
+  const RealmValue.decimal128(Decimal128 decimal) : this._(decimal);
+  const RealmValue.uuid(Uuid uuid) : this._(uuid);
 }
 
 /// The category of a [SyncError].

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -111,9 +111,6 @@ abstract class RealmObjectMarker implements RealmObjectBaseMarker {}
 /// @nodoc
 abstract class EmbeddedObjectMarker implements RealmObjectBaseMarker {}
 
-/// @nodoc
-abstract class AsymmetricObjectMarker implements RealmObjectBaseMarker {}
-
 /// A type that can represent any valid realm data type, except collections and embedded objects.
 ///
 /// You can use [RealmValue] to declare fields on realm models, in which case it must be non-nullable,

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -115,12 +115,13 @@ class EmbeddedObjectMarker extends RealmObjectBaseMarker {}
 // Union type
 /// @nodoc
 class RealmValue {
-  final Object value;
+  final Object? value;
   T as<T>() => value as T; // better for code completion
 
   // This is private, so user cannot accidentally construct an invalid instance
   const RealmValue._(this.value);
 
+  const RealmValue.nullValue() : this._(null);
   const RealmValue.bool(bool b) : this._(b);
   const RealmValue.string(String text) : this._(text);
   const RealmValue.int(int i) : this._(i);
@@ -134,8 +135,9 @@ class RealmValue {
   // const RealmValue.decimal128(Decimal128 decimal) : this._(decimal); // Not supported yet
   const RealmValue.uuid(Uuid uuid) : this._(uuid);
 
-  factory RealmValue.from(Object o) {
-    if (o is bool ||
+  factory RealmValue.from(Object? o) {
+    if (o == null ||
+        o is bool ||
         o is String ||
         o is int ||
         o is Float ||
@@ -151,6 +153,18 @@ class RealmValue {
       throw ArgumentError.value(o, 'o', 'Unsupported type');
     }
   }
+
+  @override
+  operator ==(Object? other) {
+    if (other is RealmValue) {
+      return value == other.value;
+    } else {
+      return value == other;
+    }
+  }
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// The category of a [SyncError].

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -125,9 +125,8 @@ class RealmValue {
   const RealmValue.bool(bool b) : this._(b);
   const RealmValue.string(String text) : this._(text);
   const RealmValue.int(int i) : this._(i);
-  const RealmValue.float(Float f) : this._(f);
   const RealmValue.double(double d) : this._(d);
-  const RealmValue.uint8List(Uint8List data) : this._(data);
+  // const RealmValue.uint8List(Uint8List data) : this._(data);
   // TODO: RealmObjectMarker introduced to avoid dependency inversion. It would be better if we could use RealmObject directly. https://github.com/realm/realm-dart/issues/701
   const RealmValue.realmObject(RealmObjectBaseMarker o) : this._(o);
   const RealmValue.dateTime(DateTime timestamp) : this._(timestamp);
@@ -142,7 +141,7 @@ class RealmValue {
         o is int ||
         o is Float ||
         o is double ||
-        o is Uint8List ||
+        // o is Uint8List ||
         o is RealmObjectBaseMarker ||
         o is DateTime ||
         o is ObjectId ||

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 import 'dart:ffi';
-import 'dart:typed_data';
 import 'package:objectid/objectid.dart';
 import 'package:sane_uuid/uuid.dart';
 
@@ -104,13 +103,13 @@ class RealmStateError extends StateError implements RealmError {
 class Decimal128 {} // TODO Support decimal128 datatype https://github.com/realm/realm-dart/issues/725
 
 /// @nodoc
-class RealmObjectBaseMarker {}
+abstract class RealmObjectBaseMarker {}
 
 /// @nodoc
-class RealmObjectMarker extends RealmObjectBaseMarker {}
+abstract class RealmObjectMarker extends RealmObjectBaseMarker {}
 
 /// @nodoc
-class EmbeddedObjectMarker extends RealmObjectBaseMarker {}
+abstract class EmbeddedObjectMarker extends RealmObjectBaseMarker {}
 
 // Union type
 /// @nodoc
@@ -141,7 +140,6 @@ class RealmValue {
         o is int ||
         o is Float ||
         o is double ||
-        // o is Uint8List ||
         o is RealmObjectBaseMarker ||
         o is DateTime ||
         o is ObjectId ||

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -103,10 +103,37 @@ class RealmStateError extends StateError implements RealmError {
 class Decimal128 {} // TODO Support decimal128 datatype https://github.com/realm/realm-dart/issues/725
 
 /// @nodoc
-abstract class RealmObjectBaseMarker {}
+abstract class RealmObjectMarker {}
 
-// Union type
-/// @nodoc
+/// A type that can represent any valid realm data type, except collections and embedded objects.
+///
+/// You can use [RealmValue] to declare fields on realm models, in which case it must be non-nullable,
+/// but it can wrap a null-value. List of [RealmValue] (`List<RealmValue>`) are also legal.
+///
+/// [RealmValue] fields can be [Indexed]
+///
+/// ```dart
+/// @RealmModel()
+/// class _AnythingGoes {
+///   @Indexed()
+///   late RealmValue any;
+///   late List<RealmValue> manyAny;
+/// }
+///
+/// void main() {
+///   final realm = Realm(Configuration.local([AnythingGoes.schema]));
+///   realm.write(() {
+///     final something = realm.add(AnythingGoes(any: RealmValue.string('text')));
+///     something.manyAny.addAll([
+///       null,
+///       true,
+///       'text',
+///       42,
+///       3.14,
+///     ].map(RealmValue.from));
+///   });
+/// }
+/// ```
 class RealmValue {
   final Object? value;
   Type get type => value.runtimeType;
@@ -120,14 +147,14 @@ class RealmValue {
   const RealmValue.string(String text) : this._(text);
   const RealmValue.int(int i) : this._(i);
   const RealmValue.double(double d) : this._(d);
-  // const RealmValue.uint8List(Uint8List data) : this._(data);
   // TODO: RealmObjectMarker introduced to avoid dependency inversion. It would be better if we could use RealmObject directly. https://github.com/realm/realm-dart/issues/701
-  const RealmValue.realmObject(RealmObjectBaseMarker o) : this._(o);
+  const RealmValue.realmObject(RealmObjectMarker o) : this._(o);
   const RealmValue.dateTime(DateTime timestamp) : this._(timestamp);
   const RealmValue.objectId(ObjectId id) : this._(id);
   // const RealmValue.decimal128(Decimal128 decimal) : this._(decimal); // not supported yet
   const RealmValue.uuid(Uuid uuid) : this._(uuid);
 
+  /// Will throw [ArgumentError]
   factory RealmValue.from(Object? o) {
     if (o == null ||
         o is bool ||
@@ -135,7 +162,7 @@ class RealmValue {
         o is int ||
         o is Float ||
         o is double ||
-        o is RealmObjectBaseMarker ||
+        o is RealmObjectMarker ||
         o is DateTime ||
         o is ObjectId ||
         // o is Decimal128 || // not supported yet

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -105,16 +105,11 @@ class Decimal128 {} // TODO Support decimal128 datatype https://github.com/realm
 /// @nodoc
 abstract class RealmObjectBaseMarker {}
 
-/// @nodoc
-abstract class RealmObjectMarker extends RealmObjectBaseMarker {}
-
-/// @nodoc
-abstract class EmbeddedObjectMarker extends RealmObjectBaseMarker {}
-
 // Union type
 /// @nodoc
 class RealmValue {
   final Object? value;
+  Type get type => value.runtimeType;
   T as<T>() => value as T; // better for code completion
 
   // This is private, so user cannot accidentally construct an invalid instance
@@ -130,7 +125,7 @@ class RealmValue {
   const RealmValue.realmObject(RealmObjectBaseMarker o) : this._(o);
   const RealmValue.dateTime(DateTime timestamp) : this._(timestamp);
   const RealmValue.objectId(ObjectId id) : this._(id);
-  // const RealmValue.decimal128(Decimal128 decimal) : this._(decimal); // Not supported yet
+  // const RealmValue.decimal128(Decimal128 decimal) : this._(decimal); // not supported yet
   const RealmValue.uuid(Uuid uuid) : this._(uuid);
 
   factory RealmValue.from(Object? o) {

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -103,7 +103,16 @@ class RealmStateError extends StateError implements RealmError {
 class Decimal128 {} // TODO Support decimal128 datatype https://github.com/realm/realm-dart/issues/725
 
 /// @nodoc
-abstract class RealmObjectMarker {}
+abstract class RealmObjectBaseMarker {}
+
+/// @nodoc
+abstract class RealmObjectMarker implements RealmObjectBaseMarker {}
+
+/// @nodoc
+abstract class EmbeddedObjectMarker implements RealmObjectBaseMarker {}
+
+/// @nodoc
+abstract class AsymmetricObjectMarker implements RealmObjectBaseMarker {}
 
 /// A type that can represent any valid realm data type, except collections and embedded objects.
 ///
@@ -177,13 +186,15 @@ class RealmValue {
   operator ==(Object? other) {
     if (other is RealmValue) {
       return value == other.value;
-    } else {
-      return value == other;
     }
+    return value == other;
   }
 
   @override
   int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'RealmValue.from($value)';
 }
 
 /// The category of a [SyncError].

--- a/generator/lib/src/dart_type_ex.dart
+++ b/generator/lib/src/dart_type_ex.dart
@@ -30,7 +30,7 @@ import 'type_checkers.dart';
 extension DartTypeEx on DartType {
   bool isExactly<T>() => TypeChecker.fromRuntime(T).isExactlyType(this);
 
-  bool get isRealmAny => const TypeChecker.fromRuntime(RealmAny).isAssignableFromType(this);
+  bool get isRealmValue => const TypeChecker.fromRuntime(RealmValue).isAssignableFromType(this);
   bool get isRealmCollection => realmCollectionType != RealmCollectionType.none;
   bool get isRealmModel => element2 != null ? realmModelChecker.annotationsOfExact(element2!).isNotEmpty : false;
 
@@ -108,7 +108,7 @@ extension DartTypeEx on DartType {
     if (isDartCoreBool) return RealmPropertyType.bool;
     if (isDartCoreString) return RealmPropertyType.string;
     if (isExactly<Uint8List>()) return RealmPropertyType.binary;
-    if (isRealmAny) return RealmPropertyType.mixed;
+    if (isRealmValue) return RealmPropertyType.mixed;
     if (isExactly<DateTime>()) return RealmPropertyType.timestamp;
     if (isExactly<Float>()) return RealmPropertyType.float;
     if (isDartCoreNum || isDartCoreDouble) return RealmPropertyType.double;

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -265,10 +265,10 @@ extension FieldElementEx on FieldElement {
         // Validate mixed (RealmValue)
         else if (realmType == RealmPropertyType.mixed && type.isNullable) {
           throw RealmInvalidGenerationSourceError(
-            'RealmValue fields must be nullable',
+            'RealmValue fields cannot be nullable',
             primarySpan: typeSpan(file),
-            primaryLabel: '$modelTypeName is not nullable',
-            todo: 'Change type to $modelTypeName?',
+            primaryLabel: '$modelTypeName is nullable',
+            todo: 'Change type to $modelTypeName',
             element: this,
           );
         }

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -263,17 +263,14 @@ extension FieldElementEx on FieldElement {
         }
 
         // Validate mixed (RealmValue)
-        else if (realmType == RealmPropertyType.mixed && !type.isNullable) {
-          final itemType = type.basicType;
-          if (!itemType.isRealmModel) {
-            throw RealmInvalidGenerationSourceError(
-              'RealmValue fields must be nullable',
-              primarySpan: typeSpan(file),
-              primaryLabel: '$modelTypeName is not nullable',
-              todo: 'Change type to $modelTypeName?',
-              element: this,
-            );
-          }
+        else if (realmType == RealmPropertyType.mixed && type.isNullable) {
+          throw RealmInvalidGenerationSourceError(
+            'RealmValue fields must be nullable',
+            primarySpan: typeSpan(file),
+            primaryLabel: '$modelTypeName is not nullable',
+            todo: 'Change type to $modelTypeName?',
+            element: this,
+          );
         }
       }
 

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -268,7 +268,7 @@ extension FieldElementEx on FieldElement {
             'RealmValue fields cannot be nullable',
             primarySpan: typeSpan(file),
             primaryLabel: '$modelTypeName is nullable',
-            todo: 'Change type to $modelTypeName',
+            todo: 'Change type to ${modelType.asNonNullable}',
             element: this,
           );
         }

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -262,12 +262,12 @@ extension FieldElementEx on FieldElement {
           }
         }
 
-        // Validate mixed (RealmAny)
+        // Validate mixed (RealmValue)
         else if (realmType == RealmPropertyType.mixed && !type.isNullable) {
           final itemType = type.basicType;
           if (!itemType.isRealmModel) {
             throw RealmInvalidGenerationSourceError(
-              'RealmAny fields must be nullable',
+              'RealmValue fields must be nullable',
               primarySpan: typeSpan(file),
               primaryLabel: '$modelTypeName is not nullable',
               todo: 'Change type to $modelTypeName?',

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -133,12 +133,12 @@ extension FieldElementEx on FieldElement {
 
       // Validate indexes
       if ((((primaryKey ?? indexed) != null) && !(type.realmType?.mapping.indexable ?? false)) || //
-          (primaryKey != null && type.isDartCoreBool)) {
+          (primaryKey != null && (type.isDartCoreBool || type.isExactly<RealmValue>()))) {
         final file = span!.file;
         final annotation = (primaryKey ?? indexed)!.annotation;
         final listOfValidTypes = RealmPropertyType.values //
             .map((t) => t.mapping)
-            .where((m) => m.indexable && (m.type != bool || primaryKey == null))
+            .where((m) => m.indexable && ((m.type != bool && m.type != RealmValue) || primaryKey == null))
             .map((m) => m.type);
 
         throw RealmInvalidGenerationSourceError(

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -84,7 +84,6 @@ extension FieldElementEx on FieldElement {
       // Check for as-of-yet unsupported type
       if (type.isDartCoreSet || //
           type.isDartCoreMap ||
-          type.isRealmAny ||
           type.isExactly<Decimal128>()) {
         throw RealmInvalidGenerationSourceError(
           'Field type not supported yet',
@@ -257,6 +256,20 @@ extension FieldElementEx on FieldElement {
               'Realm object references must be nullable',
               primarySpan: typeSpan(file),
               primaryLabel: 'is not nullable',
+              todo: 'Change type to $modelTypeName?',
+              element: this,
+            );
+          }
+        }
+
+        // Validate mixed (RealmAny)
+        else if (realmType == RealmPropertyType.mixed && !type.isNullable) {
+          final itemType = type.basicType;
+          if (!itemType.isRealmModel) {
+            throw RealmInvalidGenerationSourceError(
+              'RealmAny fields must be nullable',
+              primarySpan: typeSpan(file),
+              primaryLabel: '$modelTypeName is not nullable',
               todo: 'Change type to $modelTypeName?',
               element: this,
             );

--- a/generator/lib/src/realm_field_info.dart
+++ b/generator/lib/src/realm_field_info.dart
@@ -66,6 +66,13 @@ class RealmFieldInfo {
 
   String get mappedTypeName => fieldElement.mappedTypeName;
 
+  String get initializer {
+    if (type.isDartCoreList) return ' = const []';
+    if (isMixed) return ' = const RealmValue.nullValue()';
+    if (hasDefaultValue) return ' = ${fieldElement.initializerExpression}';
+    return ''; // no initializer
+  }
+
   RealmCollectionType get realmCollectionType => type.realmCollectionType;
 
   Iterable<String> toCode() sync* {

--- a/generator/lib/src/realm_field_info.dart
+++ b/generator/lib/src/realm_field_info.dart
@@ -46,9 +46,10 @@ class RealmFieldInfo {
   bool get isRealmCollection => type.isRealmCollection;
   bool get isLate => fieldElement.isLate;
   bool get hasDefaultValue => fieldElement.hasInitializer;
-  bool get optional => type.basicType.isNullable;
+  bool get optional => type.basicType.isNullable || realmType == RealmPropertyType.mixed;
   bool get isRequired => !(hasDefaultValue || optional);
   bool get isRealmBacklink => realmType == RealmPropertyType.linkingObjects;
+  bool get isMixed => realmType == RealmPropertyType.mixed;
   bool get isComputed => isRealmBacklink; // only computed, so far
 
   String get name => fieldElement.name;

--- a/generator/lib/src/realm_model_info.dart
+++ b/generator/lib/src/realm_model_info.dart
@@ -51,11 +51,8 @@ class RealmModelInfo {
         final collections = fields.where((f) => f.isRealmCollection).toList();
         if (notRequired.isNotEmpty || collections.isNotEmpty) {
           yield '{';
-          yield* notRequired.map(
-            (f) =>
-                '${f.mappedTypeName} ${f.name}${f.hasDefaultValue ? ' = ${f.fieldElement.initializerExpression}' : (f.isMixed ? ' = const RealmValue.nullValue()' : '')},',
-          );
-          yield* collections.map((c) => 'Iterable<${c.type.basicMappedName}> ${c.name} = const [],');
+          yield* notRequired.map((f) => '${f.mappedTypeName} ${f.name}${f.initializer},');
+          yield* collections.map((c) => 'Iterable<${c.type.basicMappedName}> ${c.name}${c.initializer},');
           yield '}';
         }
 

--- a/generator/lib/src/realm_model_info.dart
+++ b/generator/lib/src/realm_model_info.dart
@@ -48,10 +48,13 @@ class RealmModelInfo {
         yield* required.map((f) => '${f.mappedTypeName} ${f.name},');
 
         final notRequired = allSettable.where((f) => !f.isRequired && !f.isPrimaryKey);
-        final collections = fields.where((f) => f.type.isRealmCollection).toList();
+        final collections = fields.where((f) => f.isRealmCollection).toList();
         if (notRequired.isNotEmpty || collections.isNotEmpty) {
           yield '{';
-          yield* notRequired.map((f) => '${f.mappedTypeName} ${f.name}${f.hasDefaultValue ? ' = ${f.fieldElement.initializerExpression}' : ''},');
+          yield* notRequired.map(
+            (f) =>
+                '${f.mappedTypeName} ${f.name}${f.hasDefaultValue ? ' = ${f.fieldElement.initializerExpression}' : (f.isMixed ? ' = const RealmValue.nullValue()' : '')},',
+          );
           yield* collections.map((c) => 'Iterable<${c.type.basicMappedName}> ${c.name} = const [],');
           yield '}';
         }

--- a/generator/test/error_test_data/not_an_indexable_type.expected
+++ b/generator/test/error_test_data/not_an_indexable_type.expected
@@ -1,5 +1,5 @@
 Realm only supports the @Indexed() annotation on fields of type
-int, bool, String, DateTime, ObjectId, Uuid
+int, bool, String, RealmValue, DateTime, ObjectId, Uuid
 as well as their nullable versions
 
 in: asset:pkg/test/error_test_data/not_an_indexable_type.dart:8:8

--- a/generator/test/error_test_data/nullable_realm_value.dart
+++ b/generator/test/error_test_data/nullable_realm_value.dart
@@ -1,0 +1,8 @@
+import 'package:realm_common/realm_common.dart';
+
+//part 'nullable_list.g.dart';
+
+@RealmModel()
+class _Bad {
+  RealmValue? wrong;
+}

--- a/generator/test/error_test_data/nullable_realm_value.expected
+++ b/generator/test/error_test_data/nullable_realm_value.expected
@@ -1,0 +1,12 @@
+RealmValue fields cannot be nullable
+
+in: asset:pkg/test/error_test_data/nullable_realm_value.dart:7:3
+  ╷
+5 │ @RealmModel()
+6 │ class _Bad {
+  │       ━━━━ in realm model for 'Bad'
+7 │   RealmValue? wrong;
+  │   ^^^^^^^^^^^ RealmValue? is nullable
+  ╵
+Change type to RealmValue
+

--- a/generator/test/error_test_data/realm_value_not_allowed_as_primary_key.dart
+++ b/generator/test/error_test_data/realm_value_not_allowed_as_primary_key.dart
@@ -1,0 +1,8 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel()
+@MapTo('Bad')
+class _Foo {
+  @PrimaryKey()
+  late RealmValue bad;
+}

--- a/generator/test/error_test_data/realm_value_not_allowed_as_primary_key.expected
+++ b/generator/test/error_test_data/realm_value_not_allowed_as_primary_key.expected
@@ -1,0 +1,16 @@
+Realm only supports the @PrimaryKey() annotation on fields of type
+int, String, DateTime, ObjectId, Uuid
+as well as their nullable versions
+
+in: asset:pkg/test/error_test_data/realm_value_not_allowed_as_primary_key.dart:7:8
+  ╷
+3 │ @RealmModel()
+4 │ @MapTo('Bad')
+5 │ class _Foo {
+  │       ━━━━ in realm model for 'Foo'
+6 │   @PrimaryKey()
+7 │   late RealmValue bad;
+  │        ^^^^^^^^^^ RealmValue is not a valid type here
+  ╵
+Change the type of 'bad', or remove the @PrimaryKey() annotation
+

--- a/generator/test/good_test_data/all_types.dart
+++ b/generator/test/good_test_data/all_types.dart
@@ -17,7 +17,6 @@ class _Bar {
   @Indexed()
   late bool aBool, another; // both are indexed!
   var data = Uint8List(16);
-  // late RealmValue any; // not supported yet
   @MapTo('tidspunkt')
   @Indexed()
   var timestamp = DateTime.now();

--- a/generator/test/good_test_data/all_types.dart
+++ b/generator/test/good_test_data/all_types.dart
@@ -40,7 +40,8 @@ class _Bar {
   @Backlink(#bar)
   late Iterable<_Foo> foos;
 
-  late RealmValue? any;
+  late RealmValue any;
+  late List<RealmValue> manyAny;
 }
 
 @RealmModel()

--- a/generator/test/good_test_data/all_types.dart
+++ b/generator/test/good_test_data/all_types.dart
@@ -17,7 +17,7 @@ class _Bar {
   @Indexed()
   late bool aBool, another; // both are indexed!
   var data = Uint8List(16);
-  // late RealmAny any; // not supported yet
+  // late RealmValue any; // not supported yet
   @MapTo('tidspunkt')
   @Indexed()
   var timestamp = DateTime.now();
@@ -39,6 +39,8 @@ class _Bar {
 
   @Backlink(#bar)
   late Iterable<_Foo> foos;
+
+  late RealmValue? any;
 }
 
 @RealmModel()

--- a/generator/test/good_test_data/all_types.expected
+++ b/generator/test/good_test_data/all_types.expected
@@ -63,6 +63,7 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
     double aDouble = 0.0,
     Foo? foo,
     String? anOptionalString,
+    RealmValue? any,
     Iterable<int> list = const [],
   }) {
     if (!_defaultsSet) {
@@ -82,6 +83,7 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
     RealmObjectBase.set(this, 'objectId', objectId);
     RealmObjectBase.set(this, 'uuid', uuid);
     RealmObjectBase.set(this, 'anOptionalString', anOptionalString);
+    RealmObjectBase.set(this, 'any', any);
     RealmObjectBase.set<RealmList<int>>(this, 'list', RealmList<int>(list));
   }
 
@@ -151,6 +153,11 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
       RealmObjectBase.set(this, 'anOptionalString', value);
 
   @override
+  RealmValue? get any => RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue?;
+  @override
+  set any(RealmValue? value) => RealmObjectBase.set(this, 'any', value);
+
+  @override
   RealmResults<Foo> get foos =>
       RealmObjectBase.get<Foo>(this, 'foos') as RealmResults<Foo>;
   @override
@@ -184,6 +191,7 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
           collectionType: RealmCollectionType.list),
       SchemaProperty('anOptionalString', RealmPropertyType.string,
           optional: true, indexed: true),
+      SchemaProperty('any', RealmPropertyType.mixed, optional: true),
       SchemaProperty('foos', RealmPropertyType.linkingObjects,
           linkOriginProperty: 'bar',
           collectionType: RealmCollectionType.list,

--- a/generator/test/good_test_data/all_types.expected
+++ b/generator/test/good_test_data/all_types.expected
@@ -56,15 +56,16 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
     String name,
     bool aBool,
     bool another,
-    ObjectId objectId, 
+    ObjectId objectId,
     Uuid uuid, {
     Uint8List data = Uint8List(16),
     DateTime timestamp = DateTime.now(),
     double aDouble = 0.0,
     Foo? foo,
     String? anOptionalString,
-    RealmValue? any,
+    RealmValue any = const RealmValue.nullValue(),
     Iterable<int> list = const [],
+    Iterable<RealmValue> manyAny = const [],
   }) {
     if (!_defaultsSet) {
       _defaultsSet = RealmObjectBase.setDefaults<Bar>({
@@ -85,6 +86,8 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
     RealmObjectBase.set(this, 'anOptionalString', anOptionalString);
     RealmObjectBase.set(this, 'any', any);
     RealmObjectBase.set<RealmList<int>>(this, 'list', RealmList<int>(list));
+    RealmObjectBase.set<RealmList<RealmValue>>(
+        this, 'manyAny', RealmList<RealmValue>(manyAny));
   }
 
   Bar._();
@@ -134,8 +137,7 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
   set objectId(ObjectId value) => RealmObjectBase.set(this, 'objectId', value);
 
   @override
-  Uuid get uuid =>
-      RealmObjectBase.get<Uuid>(this, 'uuid') as Uuid;
+  Uuid get uuid => RealmObjectBase.get<Uuid>(this, 'uuid') as Uuid;
   @override
   set uuid(Uuid value) => RealmObjectBase.set(this, 'uuid', value);
 
@@ -153,15 +155,23 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
       RealmObjectBase.set(this, 'anOptionalString', value);
 
   @override
-  RealmValue? get any => RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue?;
+  RealmValue get any =>
+      RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue;
   @override
-  set any(RealmValue? value) => RealmObjectBase.set(this, 'any', value);
+  set any(RealmValue value) => RealmObjectBase.set(this, 'any', value);
+
+  @override
+  RealmList<RealmValue> get manyAny =>
+      RealmObjectBase.get<RealmValue>(this, 'manyAny') as RealmList<RealmValue>;
+  @override
+  set manyAny(covariant RealmList<RealmValue> value) =>
+      throw RealmUnsupportedSetError();
 
   @override
   RealmResults<Foo> get foos =>
       RealmObjectBase.get<Foo>(this, 'foos') as RealmResults<Foo>;
   @override
-  set foos(covariant RealmResults<Foo> value) => 
+  set foos(covariant RealmResults<Foo> value) =>
       throw RealmUnsupportedSetError();
 
   @override
@@ -192,6 +202,8 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
       SchemaProperty('anOptionalString', RealmPropertyType.string,
           optional: true, indexed: true),
       SchemaProperty('any', RealmPropertyType.mixed, optional: true),
+      SchemaProperty('manyAny', RealmPropertyType.mixed,
+          optional: true, collectionType: RealmCollectionType.list),
       SchemaProperty('foos', RealmPropertyType.linkingObjects,
           linkOriginProperty: 'bar',
           collectionType: RealmCollectionType.list,
@@ -271,4 +283,3 @@ class PrimitiveTypes extends _PrimitiveTypes
     ]);
   }
 }
-

--- a/generator/test/good_test_data/indexable_types.dart
+++ b/generator/test/good_test_data/indexable_types.dart
@@ -28,4 +28,6 @@ class _Indexable {
   late DateTime aDateTime;
   @Indexed()
   DateTime? aNullableDateTime;
+  @Indexed()
+  late RealmValue aRealmValue;
 }

--- a/generator/test/good_test_data/indexable_types.expected
+++ b/generator/test/good_test_data/indexable_types.expected
@@ -17,6 +17,7 @@ class Indexable extends _Indexable
     ObjectId? aNullableObjectId,
     Uuid? aNullableUuid,
     DateTime? aNullableDateTime,
+    RealmValue aRealmValue = const RealmValue.nullValue(),
   }) {
     RealmObjectBase.set(this, 'aBool', aBool);
     RealmObjectBase.set(this, 'aNullableBool', aNullableBool);
@@ -30,6 +31,7 @@ class Indexable extends _Indexable
     RealmObjectBase.set(this, 'aNullableUuid', aNullableUuid);
     RealmObjectBase.set(this, 'aDateTime', aDateTime);
     RealmObjectBase.set(this, 'aNullableDateTime', aNullableDateTime);
+    RealmObjectBase.set(this, 'aRealmValue', aRealmValue);
   }
 
   Indexable._();
@@ -111,6 +113,13 @@ class Indexable extends _Indexable
       RealmObjectBase.set(this, 'aNullableDateTime', value);
 
   @override
+  RealmValue get aRealmValue =>
+      RealmObjectBase.get<RealmValue>(this, 'aRealmValue') as RealmValue;
+  @override
+  set  aRealmValue(RealmValue value) =>
+      RealmObjectBase.set(this, 'aRealmValue', value);
+
+  @override
   Stream<RealmObjectChanges<Indexable>> get changes =>
       RealmObjectBase.getChanges<Indexable>(this);
 
@@ -136,6 +145,8 @@ class Indexable extends _Indexable
       SchemaProperty('aNullableUuid', RealmPropertyType.uuid, optional: true, indexed: true),
       SchemaProperty('aDateTime', RealmPropertyType.timestamp, indexed: true),
       SchemaProperty('aNullableDateTime', RealmPropertyType.timestamp,
+          optional: true, indexed: true),
+      SchemaProperty('aRealmValue', RealmPropertyType.mixed, 
           optional: true, indexed: true),
     ]);
   }

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -111,12 +111,13 @@ class ManagedRealmList<T extends Object?> with RealmEntity, ListMixin<T> impleme
     }
 
     try {
-      final value = realmCore.listGetElementAt(this, index);
-
+      var value = realmCore.listGetElementAt(this, index);
       if (value is RealmObjectHandle) {
-        return realm.createObject(T, value, _metadata!) as T;
+        value = realm.createObject(T, value, _metadata!);
       }
-
+      if (T == RealmValue) {
+        value = RealmValue.from(value);
+      }
       return value as T;
     } on Exception catch (e) {
       throw RealmException("Error getting value at index $index. Error: $e");

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -2680,6 +2680,8 @@ void _intoRealmValue(Object? value, Pointer<realm_value_t> realm_value, Allocato
       realm_value.ref.values.timestamp.seconds = seconds;
       realm_value.ref.values.timestamp.nanoseconds = nanoseconds;
       realm_value.ref.type = realm_value_type.RLM_TYPE_TIMESTAMP;
+    } else if (value is RealmValue) {
+      return _intoRealmValue(value.value, realm_value, allocator);
     } else {
       throw RealmException("Property type ${value.runtimeType} not supported");
     }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -838,6 +838,10 @@ class _RealmCore {
     });
   }
 
+  int getClassKey(RealmObjectHandle handle) {
+    return _realmLib.realm_object_get_table(handle._pointer);
+  }
+
   RealmObjectHandle getOrCreateRealmObjectWithPrimaryKey(Realm realm, int classKey, Object? primaryKey) {
     return using((Arena arena) {
       final realm_value = _toRealmValue(primaryKey, arena);
@@ -2681,7 +2685,7 @@ void _intoRealmValue(Object? value, Pointer<realm_value_t> realm_value, Allocato
       realm_value.ref.values.timestamp.nanoseconds = nanoseconds;
       realm_value.ref.type = realm_value_type.RLM_TYPE_TIMESTAMP;
     } else if (value is RealmValue) {
-      return _intoRealmValue(value.value, realm_value, allocator);
+      return _intoRealmValue(value.value, realm_value, allocator); // TODO(kasper): Get rid of this. RealmValue abstraction handled at higher level
     } else {
       throw RealmException("Property type ${value.runtimeType} not supported");
     }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -2685,7 +2685,7 @@ void _intoRealmValue(Object? value, Pointer<realm_value_t> realm_value, Allocato
       realm_value.ref.values.timestamp.nanoseconds = nanoseconds;
       realm_value.ref.type = realm_value_type.RLM_TYPE_TIMESTAMP;
     } else if (value is RealmValue) {
-      return _intoRealmValue(value.value, realm_value, allocator); // TODO(kasper): Get rid of this. RealmValue abstraction handled at higher level
+      return _intoRealmValue(value.value, realm_value, allocator);
     } else {
       throw RealmException("Property type ${value.runtimeType} not supported");
     }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -201,6 +201,7 @@ class _RealmCore {
         _realmLib.realm_config_set_max_number_of_active_versions(configHandle._pointer, config.maxNumberOfActiveVersions!);
       }
       if (config is LocalConfiguration) {
+        //_realmLib.realm_config_set_schema_mode(configHandle._pointer, realm_schema_mode.RLM_SCHEMA_MODE_ADDITIVE_DISCOVERED);
         if (config.initialDataCallback != null) {
           _realmLib.realm_config_set_data_initialization_function(
             configHandle._pointer,
@@ -2714,6 +2715,7 @@ extension on Pointer<realm_value_t> {
       case realm_value_type.RLM_TYPE_LINK:
         final objectKey = ref.values.link.target;
         final classKey = ref.values.link.target_table;
+        if (realm.metadata.getByClassKeyIfExists(classKey) == null) return null; // temprorary workaround to avoid crash on assertion
         return realmCore._getObject(realm, classKey, objectKey);
       case realm_value_type.RLM_TYPE_BINARY:
         throw Exception("Not implemented");

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -43,6 +43,7 @@ export 'package:realm_common/realm_common.dart'
         ObjectId,
         ObjectType,
         PrimaryKey,
+        RealmValue,
         RealmClosedError,
         RealmCollectionType,
         RealmError,

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -767,8 +767,9 @@ class RealmLogLevel {
 
 /// @nodoc
 class RealmMetadata {
-  final Map<Type, RealmObjectMetadata> _typeMap = <Type, RealmObjectMetadata>{};
-  final Map<String, RealmObjectMetadata> _stringMap = <String, RealmObjectMetadata>{};
+  final _typeMap = <Type, RealmObjectMetadata>{};
+  final _stringMap = <String, RealmObjectMetadata>{};
+  final _classKeyMap = <int, RealmObjectMetadata>{};
 
   RealmMetadata._(Iterable<RealmObjectMetadata> objectMetadatas) {
     for (final metadata in objectMetadatas) {
@@ -777,6 +778,7 @@ class RealmMetadata {
       } else {
         _stringMap[metadata.schema.name] = metadata;
       }
+      _classKeyMap[metadata.classKey] = metadata;
     }
   }
 
@@ -803,17 +805,14 @@ class RealmMetadata {
     return metadata;
   }
 
+  RealmObjectMetadata? getByClassKeyIfExists(int key) => _classKeyMap[key];
+
   Tuple<Type, RealmObjectMetadata> getByClassKey(int key) {
-    final type = _typeMap.entries.firstWhereOrNull((e) => e.value.classKey == key);
-    if (type != null) {
-      return Tuple(type.key, type.value);
+    final meta = _classKeyMap[key];
+    if (meta != null) {
+      final type = _typeMap.entries.firstWhereOrNull((e) => e.value.classKey == key)?.key ?? RealmObjectBase;
+      return Tuple(type, meta);
     }
-
-    final metadata = _stringMap.values.firstWhereOrNull((e) => e.classKey == key);
-    if (metadata != null) {
-      return Tuple(RealmObjectBase, metadata);
-    }
-
     throw RealmError("Object with classKey $key not found in the current Realm's schema.");
   }
 }

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -281,7 +281,7 @@ extension RealmEntityInternal on RealmEntity {
 ///
 /// [RealmObject] should not be used directly as it is part of the generated class hierarchy. ex: `MyClass extends _MyClass with RealmObject`.
 /// {@category Realm}
-mixin RealmObjectBase on RealmEntity implements RealmObjectBaseMarker, Finalizable {
+mixin RealmObjectBase on RealmEntity implements RealmObjectMarker, Finalizable {
   RealmObjectHandle? _handle;
   RealmAccessor _accessor = RealmValuesAccessor();
   static final Map<Type, RealmObjectBase Function()> _factories = <Type, RealmObjectBase Function()>{

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -281,7 +281,7 @@ extension RealmEntityInternal on RealmEntity {
 ///
 /// [RealmObject] should not be used directly as it is part of the generated class hierarchy. ex: `MyClass extends _MyClass with RealmObject`.
 /// {@category Realm}
-mixin RealmObjectBase on RealmEntity implements RealmObjectMarker, Finalizable {
+mixin RealmObjectBase on RealmEntity implements RealmObjectBaseMarker, Finalizable {
   RealmObjectHandle? _handle;
   RealmAccessor _accessor = RealmValuesAccessor();
   static final Map<Type, RealmObjectBase Function()> _factories = <Type, RealmObjectBase Function()>{
@@ -432,10 +432,10 @@ mixin RealmObjectBase on RealmEntity implements RealmObjectMarker, Finalizable {
 }
 
 /// @nodoc
-mixin RealmObject on RealmObjectBase {}
+mixin RealmObject on RealmObjectBase implements RealmObjectMarker {}
 
 /// @nodoc
-mixin EmbeddedObject on RealmObjectBase {}
+mixin EmbeddedObject on RealmObjectBase implements EmbeddedObjectMarker {}
 
 extension EmbeddedObjectExtension on EmbeddedObject {
   /// Retrieve the [parent] object of this embedded object.

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -177,7 +177,7 @@ class RealmCoreAccessor implements RealmAccessor {
       Object? value = realmCore.getProperty(object, propertyMeta.key);
 
       if (T == RealmValue) {
-        return value == null ? null : RealmValue.from(value);
+        return RealmValue.from(value);
       }
 
       if (value is RealmObjectHandle) {

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -185,7 +185,7 @@ class RealmCoreAccessor implements RealmAccessor {
         late RealmObjectMetadata targetMetadata;
 
         if (propertyMeta.propertyType == RealmPropertyType.mixed) {
-          final tuple = meta.getByClassKey(realmCore.getClassKey(object.handle));
+          final tuple = meta.getByClassKey(realmCore.getClassKey(value));
           type = tuple.item1;
           targetMetadata = tuple.item2;
         } else {

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -150,8 +150,13 @@ class RealmCoreAccessor implements RealmAccessor {
           final handle = realmCore.getBacklinks(object, sourceMeta.classKey, sourceProperty.key);
           return RealmResultsInternal.create<T>(handle, object.realm, sourceMeta);
         }
+
         final handle = realmCore.getListProperty(object, propertyMeta.key);
         final listMetadata = propertyMeta.objectType == null ? null : object.realm.metadata.getByName(propertyMeta.objectType!);
+
+        if (propertyMeta.propertyType == RealmPropertyType.mixed) {
+          return object.realm.createList<RealmValue>(handle, metadata);
+        }
 
         // listMetadata is not null when we have list of RealmObjects. If the API was
         // called with a generic object arg - get<Object> we construct a list of
@@ -170,6 +175,10 @@ class RealmCoreAccessor implements RealmAccessor {
       }
 
       Object? value = realmCore.getProperty(object, propertyMeta.key);
+
+      if (T == RealmValue) {
+        return value == null ? null : RealmValue.from(value);
+      }
 
       if (value is RealmObjectHandle) {
         final targetMetadata = propertyMeta.objectType != null ? object.realm.metadata.getByName(propertyMeta.objectType!) : object.realm.metadata.getByType(T);

--- a/test/indexed_test.dart
+++ b/test/indexed_test.dart
@@ -63,7 +63,7 @@ class _NoIndexes {
 
 typedef QueryBuilder<T, U> = RealmResults<T> Function(U value);
 
-Future<void> main([List<String>? args]) async {
+void main([List<String>? args]) {
   test('Indexed faster', () {
     final config = Configuration.local([WithIndexes.schema, NoIndexes.schema]);
     Realm.deleteRealm(config.path);

--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -25,6 +25,11 @@ import 'test.dart';
 
 part 'realm_value_test.g.dart';
 
+@RealmModel(ObjectType.embeddedObject)
+class _TuckedIn {
+  int x = 42;
+}
+
 @RealmModel()
 class _AnythingGoes {
   @Indexed()
@@ -47,7 +52,7 @@ void main() {
       Uuid.v4(),
     ];
 
-    final config = Configuration.inMemory([AnythingGoes.schema]);
+    final config = Configuration.inMemory([AnythingGoes.schema, TuckedIn.schema]);
     final realm = getRealm(config);
 
     for (final x in values) {
@@ -60,6 +65,10 @@ void main() {
 
     test('Illegal value', () {
       expect(() => realm.write(() => realm.add(AnythingGoes(oneAny: RealmValue.from(<int>[1, 2])))), throwsArgumentError);
+    });
+
+    test('Embedded object not allowed in RealmValue', () {
+      expect(() => realm.write(() => realm.add(AnythingGoes(oneAny: RealmValue.from(TuckedIn())))), throwsArgumentError);
     });
 
     for (final x in values) {

--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -27,41 +27,56 @@ part 'realm_value_test.g.dart';
 class _AnythingGoes {
   @Indexed()
   late RealmValue any;
+  late List<RealmValue> manyAny;
 }
 
 void main() {
-  test('Roundtrip', () {
-    final config = Configuration.inMemory([AnythingGoes.schema]);
-    final realm = getRealm(config);
-    final something = realm.write(() => realm.add(AnythingGoes(any: RealmValue.bool(true))));
-    expect(something.any.as<bool>(), true);
+  group('any', () {
+    test('Roundtrip', () {
+      final config = Configuration.inMemory([AnythingGoes.schema]);
+      final realm = getRealm(config);
+      final something = realm.write(() => realm.add(AnythingGoes(any: RealmValue.bool(true))));
+      expect(something.any.as<bool>(), true);
+    });
+
+    test('Illegal value', () {
+      final config = Configuration.inMemory([AnythingGoes.schema]);
+      final realm = getRealm(config);
+      expect(() => realm.write(() => realm.add(AnythingGoes(any: RealmValue.from(<int>[1, 2])))), throwsArgumentError);
+    });
+
+    test('Switch', () {
+      final something = AnythingGoes(any: RealmValue.int(1));
+      switch (something.any.value?.runtimeType) {
+        case null:
+          break;
+        case int:
+        case String:
+      }
+    });
+
+    test('If-switch', () {
+      final something = AnythingGoes(any: RealmValue.double(3.14));
+      final value = something.any.value;
+
+      if (value == null) {
+      } else if (value is int) {
+        value + 1;
+      } else if (value is String) {
+        value.substring(2);
+      }
+    });
   });
 
-  test('Illegal value', () {
-    final config = Configuration.inMemory([AnythingGoes.schema]);
-    final realm = getRealm(config);
-    expect(() => realm.write(() => realm.add(AnythingGoes(any: RealmValue.from(<int>[1, 2])))), throwsArgumentError);
-  });
+  group('manyAny', () {
+    test('foo', () {
+      final config = Configuration.inMemory([AnythingGoes.schema]);
+      final realm = getRealm(config);
 
-  test('Switch', () {
-    final something = AnythingGoes(any: RealmValue.int(1));
-    switch (something.any.value?.runtimeType) {
-      case null:
-        break;
-      case int:
-      case String:
-    }
-  });
+      final something = realm.write(() => realm.add(AnythingGoes(manyAny: [RealmValue.bool(true), RealmValue.int(42)])));
 
-  test('If-switch', () {
-    final something = AnythingGoes(any: RealmValue.double(3.14));
-    final value = something.any.value;
-
-    if (value == null) {
-    } else if (value is int) {
-      value + 1;
-    } else if (value is String) {
-      value.substring(2);
-    }
+      expect(something.manyAny.map((e) => e.value), [true, 42]);
+      expect(something.manyAny, [RealmValue.bool(true), RealmValue.int(42)]);
+    });
   });
 }

--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import 'dart:math';
+
 import 'package:test/test.dart' hide test, throws;
 import '../lib/realm.dart';
 
@@ -26,87 +28,130 @@ part 'realm_value_test.g.dart';
 @RealmModel()
 class _AnythingGoes {
   @Indexed()
-  late RealmValue any;
+  late RealmValue oneAny;
   late List<RealmValue> manyAny;
 }
 
 void main() {
   group('RealmValue', () {
-    final config = Configuration.inMemory([AnythingGoes.schema]);
-    final realm = getRealm(config);
-
-    for (final x in <Object?>[
+    final now = DateTime.now().toUtc();
+    final values = <Object?>[
       null,
       true,
       'text',
       42,
       3.14,
-//      AnythingGoes(),
-      DateTime.now().toUtc(),
-      ObjectId.fromTimestamp(DateTime.now()),
+      AnythingGoes(),
+      now,
+      ObjectId.fromTimestamp(now),
       Uuid.v4(),
-    ]) {
+    ];
+
+    final config = Configuration.inMemory([AnythingGoes.schema]);
+    final realm = getRealm(config);
+
+    for (final x in values) {
       test('Roundtrip ${x.runtimeType} $x', () {
-        final something = realm.write(() => realm.add(AnythingGoes(any: RealmValue.from(x))));
-        expect(something.any.value, x);
-        expect(something.any, RealmValue.from(x));
+        final something = realm.write(() => realm.add(AnythingGoes(oneAny: RealmValue.from(x))));
+        expect(something.oneAny.value, x);
+        expect(something.oneAny, RealmValue.from(x));
       });
     }
 
     test('Illegal value', () {
-      expect(() => realm.write(() => realm.add(AnythingGoes(any: RealmValue.from(<int>[1, 2])))), throwsArgumentError);
+      expect(() => realm.write(() => realm.add(AnythingGoes(oneAny: RealmValue.from(<int>[1, 2])))), throwsArgumentError);
     });
 
-    test('Switch', () {
-      final something = AnythingGoes(any: RealmValue.int(1));
-      final v = something.any.value;
-      switch (v?.runtimeType) {
-        case null:
-          break;
-        case int:
-          (v as int) + 2;
-          break;
+    for (final x in values) {
+      test('Switch $x', () {
+        final something = AnythingGoes(oneAny: RealmValue.from(x));
+        final value = something.oneAny.value;
+        switch (something.oneAny.type) {
+          case Null:
+            expect(value, isA<void>());
+            break;
+          case bool:
+            expect(value, isA<bool>());
+            break;
+          case String:
+            expect(value, isA<String>());
+            break;
+          case int:
+            expect(value, isA<int>());
+            break;
+          case double:
+            expect(value, isA<double>());
+            break;
+          case AnythingGoes: // RealmObject won't work with switch
+            expect(value, isA<AnythingGoes>());
+            expect(value, isA<RealmObject>());
+            break;
+          case DateTime:
+            expect(value, isA<DateTime>());
+            break;
+          case ObjectId:
+            expect(value, isA<ObjectId>());
+            break;
+          case Uuid:
+            expect(value, isA<Uuid>());
+            break;
+          default:
+            fail('${something.oneAny} not handled correctly in switch');
+        }
+      });
+    }
 
-        case String:
-      }
-    });
-
-    test('If-is', () {
-      final something = AnythingGoes(any: RealmValue.double(3.14));
-      final value = something.any.value;
-
-      if (value == null) {
-      } else if (value is int) {
-        value + 1;
-      } else if (value is String) {
-        value.substring(2);
-      }
-    });
+    for (final x in values) {
+      test('If-is $x', () {
+        final something = AnythingGoes(oneAny: RealmValue.from(x));
+        final value = something.oneAny.value;
+        final type = something.oneAny.type;
+        if (value == null) {
+          expect(type, Null);
+        } else if (value is int) {
+          expect(type, int);
+        } else if (value is String) {
+          expect(type, String);
+        } else if (value is bool) {
+          expect(type, bool);
+        } else if (value is double) {
+          expect(type, double);
+        } else if (value is DateTime) {
+          expect(type, DateTime);
+        } else if (value is Uuid) {
+          expect(type, Uuid);
+        } else if (value is ObjectId) {
+          expect(type, ObjectId);
+        } else if (value is AnythingGoes) {
+          expect(type, AnythingGoes);
+        } else {
+          fail('$value not handled correctly in if-is');
+        }
+      });
+    }
   });
 
   group('List<RealmValue>', () {
+    final now = DateTime.now().toUtc();
+    final values = <Object?>[
+      null,
+      true,
+      'text',
+      42,
+      3.14,
+      AnythingGoes(),
+      now,
+      ObjectId.fromTimestamp(now),
+      Uuid.v4(),
+    ];
+
+    final config = Configuration.inMemory([AnythingGoes.schema]);
+    final realm = getRealm(config);
+
     test('Roundtrip', () {
-      final config = Configuration.inMemory([AnythingGoes.schema]);
-      final realm = getRealm(config);
-
-      final now = DateTime.now().toUtc();
-      final oid = ObjectId.fromTimestamp(now);
-      final uuid = Uuid.v4();
-
-      final something = realm.write(() => realm.add(AnythingGoes(manyAny: [
-            const RealmValue.nullValue(),
-            const RealmValue.bool(true),
-            const RealmValue.string('text'),
-            const RealmValue.int(42),
-            const RealmValue.double(3.14),
-//            RealmValue.realmObject(AnythingGoes()),
-            RealmValue.dateTime(now),
-            RealmValue.objectId(oid),
-            RealmValue.uuid(uuid),
-          ])));
-
-      expect(something.manyAny.map((e) => e.value), [null, true, 'text', 42, 3.14, now, oid, uuid]);
-      expect(something.manyAny, [null, true, 'text', 42, 3.14, now, oid, uuid].map((e) => RealmValue.from(e)));
+      final something = realm.write(() => realm.add(AnythingGoes(manyAny: values.map(RealmValue.from))));
+      expect(something.manyAny.map((e) => e.value), values);
+      expect(something.manyAny, values.map(RealmValue.from));
 //      expect(something.manyAny.cast<Object>(), [true, 42]);
     });
   });

--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -35,6 +35,11 @@ class _AnythingGoes {
   late List<RealmValue> manyAny;
 }
 
+@RealmModel()
+class _Stuff {
+  int i = 42;
+}
+
 void main() {
   group('RealmValue', () {
     final now = DateTime.now().toUtc();
@@ -136,6 +141,23 @@ void main() {
         }
       });
     }
+
+    test('Unknown embedded', () {
+      {
+        final config = Configuration.local([AnythingGoes.schema, Stuff.schema], path: 'unknown_embedded');
+        final realm = Realm(config);
+
+        realm.write(() => realm.add(AnythingGoes(oneAny: RealmValue.realmObject(Stuff()))));
+        realm.close();
+      }
+
+      // From here on Stuff is unknown
+      final config = Configuration.local([AnythingGoes.schema], path: 'unknown_embedded');
+      final realm = getRealm(config);
+
+      final something = realm.all<AnythingGoes>()[0];
+      expect(something.oneAny, isA<RealmObject>());
+    }, skip: 'This currently crashes!');
   });
 
   group('List<RealmValue>', () {

--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -26,7 +26,7 @@ part 'realm_value_test.g.dart';
 @RealmModel()
 class _AnythingGoes {
   @Indexed()
-  late RealmValue? any;
+  late RealmValue any;
 }
 
 void main() {
@@ -34,7 +34,7 @@ void main() {
     final config = Configuration.inMemory([AnythingGoes.schema]);
     final realm = getRealm(config);
     final something = realm.write(() => realm.add(AnythingGoes(any: RealmValue.bool(true))));
-    expect(something.any!.as<bool>(), true);
+    expect(something.any.as<bool>(), true);
   });
 
   test('Illegal value', () {
@@ -44,8 +44,8 @@ void main() {
   });
 
   test('Switch', () {
-    final something = AnythingGoes();
-    switch (something.any?.value.runtimeType) {
+    final something = AnythingGoes(any: RealmValue.int(1));
+    switch (something.any.value?.runtimeType) {
       case null:
         break;
       case int:
@@ -54,8 +54,9 @@ void main() {
   });
 
   test('If-switch', () {
-    final something = AnythingGoes();
-    final value = something.any?.value;
+    final something = AnythingGoes(any: RealmValue.double(3.14));
+    final value = something.any.value;
+
     if (value == null) {
     } else if (value is int) {
       value + 1;

--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -16,8 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import 'dart:math';
-
 import 'package:test/test.dart' hide test, throws;
 import '../lib/realm.dart';
 
@@ -161,7 +159,6 @@ void main() {
       final something = realm.write(() => realm.add(AnythingGoes(manyAny: values.map(RealmValue.from))));
       expect(something.manyAny.map((e) => e.value), values);
       expect(something.manyAny, values.map(RealmValue.from));
-//      expect(something.manyAny.cast<Object>(), [true, 42]);
     });
   });
 }

--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -37,6 +37,12 @@ void main() {
     expect(something.any!.as<bool>(), true);
   });
 
+  test('Illegal value', () {
+    final config = Configuration.inMemory([AnythingGoes.schema]);
+    final realm = getRealm(config);
+    expect(() => realm.write(() => realm.add(AnythingGoes(any: RealmValue.from(<int>[1, 2])))), throwsArgumentError);
+  });
+
   test('Switch', () {
     final something = AnythingGoes();
     switch (something.any?.value.runtimeType) {

--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -1,0 +1,60 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import 'package:test/test.dart' hide test, throws;
+import '../lib/realm.dart';
+
+import 'test.dart';
+
+part 'realm_value_test.g.dart';
+
+@RealmModel()
+class _AnythingGoes {
+  @Indexed()
+  late RealmValue? any;
+}
+
+void main() {
+  test('Roundtrip', () {
+    final config = Configuration.inMemory([AnythingGoes.schema]);
+    final realm = getRealm(config);
+    final something = realm.write(() => realm.add(AnythingGoes(any: RealmValue.bool(true))));
+    expect(something.any!.as<bool>(), true);
+  });
+
+  test('Switch', () {
+    final something = AnythingGoes();
+    switch (something.any?.value.runtimeType) {
+      case null:
+        break;
+      case int:
+      case String:
+    }
+  });
+
+  test('If-switch', () {
+    final something = AnythingGoes();
+    final value = something.any?.value;
+    if (value == null) {
+    } else if (value is int) {
+      value + 1;
+    } else if (value is String) {
+      value.substring(2);
+    }
+  });
+}

--- a/test/realm_value_test.g.dart
+++ b/test/realm_value_test.g.dart
@@ -91,3 +91,41 @@ class AnythingGoes extends _AnythingGoes
     ]);
   }
 }
+
+class Stuff extends _Stuff with RealmEntity, RealmObjectBase, RealmObject {
+  static var _defaultsSet = false;
+
+  Stuff({
+    int i = 42,
+  }) {
+    if (!_defaultsSet) {
+      _defaultsSet = RealmObjectBase.setDefaults<Stuff>({
+        'i': 42,
+      });
+    }
+    RealmObjectBase.set(this, 'i', i);
+  }
+
+  Stuff._();
+
+  @override
+  int get i => RealmObjectBase.get<int>(this, 'i') as int;
+  @override
+  set i(int value) => RealmObjectBase.set(this, 'i', value);
+
+  @override
+  Stream<RealmObjectChanges<Stuff>> get changes =>
+      RealmObjectBase.getChanges<Stuff>(this);
+
+  @override
+  Stuff freeze() => RealmObjectBase.freezeObject<Stuff>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Stuff._);
+    return const SchemaObject(ObjectType.realmObject, Stuff, 'Stuff', [
+      SchemaProperty('i', RealmPropertyType.int),
+    ]);
+  }
+}

--- a/test/realm_value_test.g.dart
+++ b/test/realm_value_test.g.dart
@@ -9,10 +9,10 @@ part of 'realm_value_test.dart';
 class AnythingGoes extends _AnythingGoes
     with RealmEntity, RealmObjectBase, RealmObject {
   AnythingGoes({
-    RealmValue any = const RealmValue.nullValue(),
+    RealmValue oneAny = const RealmValue.nullValue(),
     Iterable<RealmValue> manyAny = const [],
   }) {
-    RealmObjectBase.set(this, 'any', any);
+    RealmObjectBase.set(this, 'oneAny', oneAny);
     RealmObjectBase.set<RealmList<RealmValue>>(
         this, 'manyAny', RealmList<RealmValue>(manyAny));
   }
@@ -20,10 +20,10 @@ class AnythingGoes extends _AnythingGoes
   AnythingGoes._();
 
   @override
-  RealmValue get any =>
-      RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue;
+  RealmValue get oneAny =>
+      RealmObjectBase.get<RealmValue>(this, 'oneAny') as RealmValue;
   @override
-  set any(RealmValue value) => RealmObjectBase.set(this, 'any', value);
+  set oneAny(RealmValue value) => RealmObjectBase.set(this, 'oneAny', value);
 
   @override
   RealmList<RealmValue> get manyAny =>
@@ -45,7 +45,7 @@ class AnythingGoes extends _AnythingGoes
     RealmObjectBase.registerFactory(AnythingGoes._);
     return const SchemaObject(
         ObjectType.realmObject, AnythingGoes, 'AnythingGoes', [
-      SchemaProperty('any', RealmPropertyType.mixed,
+      SchemaProperty('oneAny', RealmPropertyType.mixed,
           optional: true, indexed: true),
       SchemaProperty('manyAny', RealmPropertyType.mixed,
           optional: true, collectionType: RealmCollectionType.list),

--- a/test/realm_value_test.g.dart
+++ b/test/realm_value_test.g.dart
@@ -6,6 +6,45 @@ part of 'realm_value_test.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
+class TuckedIn extends _TuckedIn
+    with RealmEntity, RealmObjectBase, EmbeddedObject {
+  static var _defaultsSet = false;
+
+  TuckedIn({
+    int x = 42,
+  }) {
+    if (!_defaultsSet) {
+      _defaultsSet = RealmObjectBase.setDefaults<TuckedIn>({
+        'x': 42,
+      });
+    }
+    RealmObjectBase.set(this, 'x', x);
+  }
+
+  TuckedIn._();
+
+  @override
+  int get x => RealmObjectBase.get<int>(this, 'x') as int;
+  @override
+  set x(int value) => RealmObjectBase.set(this, 'x', value);
+
+  @override
+  Stream<RealmObjectChanges<TuckedIn>> get changes =>
+      RealmObjectBase.getChanges<TuckedIn>(this);
+
+  @override
+  TuckedIn freeze() => RealmObjectBase.freezeObject<TuckedIn>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(TuckedIn._);
+    return const SchemaObject(ObjectType.embeddedObject, TuckedIn, 'TuckedIn', [
+      SchemaProperty('x', RealmPropertyType.int),
+    ]);
+  }
+}
+
 class AnythingGoes extends _AnythingGoes
     with RealmEntity, RealmObjectBase, RealmObject {
   AnythingGoes({

--- a/test/realm_value_test.g.dart
+++ b/test/realm_value_test.g.dart
@@ -10,8 +10,11 @@ class AnythingGoes extends _AnythingGoes
     with RealmEntity, RealmObjectBase, RealmObject {
   AnythingGoes({
     RealmValue any = const RealmValue.nullValue(),
+    Iterable<RealmValue> manyAny = const [],
   }) {
     RealmObjectBase.set(this, 'any', any);
+    RealmObjectBase.set<RealmList<RealmValue>>(
+        this, 'manyAny', RealmList<RealmValue>(manyAny));
   }
 
   AnythingGoes._();
@@ -21,6 +24,13 @@ class AnythingGoes extends _AnythingGoes
       RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue;
   @override
   set any(RealmValue value) => RealmObjectBase.set(this, 'any', value);
+
+  @override
+  RealmList<RealmValue> get manyAny =>
+      RealmObjectBase.get<RealmValue>(this, 'manyAny') as RealmList<RealmValue>;
+  @override
+  set manyAny(covariant RealmList<RealmValue> value) =>
+      throw RealmUnsupportedSetError();
 
   @override
   Stream<RealmObjectChanges<AnythingGoes>> get changes =>
@@ -37,6 +47,8 @@ class AnythingGoes extends _AnythingGoes
         ObjectType.realmObject, AnythingGoes, 'AnythingGoes', [
       SchemaProperty('any', RealmPropertyType.mixed,
           optional: true, indexed: true),
+      SchemaProperty('manyAny', RealmPropertyType.mixed,
+          optional: true, collectionType: RealmCollectionType.list),
     ]);
   }
 }

--- a/test/realm_value_test.g.dart
+++ b/test/realm_value_test.g.dart
@@ -1,0 +1,42 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'realm_value_test.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class AnythingGoes extends _AnythingGoes
+    with RealmEntity, RealmObjectBase, RealmObject {
+  AnythingGoes({
+    RealmValue? any,
+  }) {
+    RealmObjectBase.set(this, 'any', any);
+  }
+
+  AnythingGoes._();
+
+  @override
+  RealmValue? get any =>
+      RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue?;
+  @override
+  set any(RealmValue? value) => RealmObjectBase.set(this, 'any', value);
+
+  @override
+  Stream<RealmObjectChanges<AnythingGoes>> get changes =>
+      RealmObjectBase.getChanges<AnythingGoes>(this);
+
+  @override
+  AnythingGoes freeze() => RealmObjectBase.freezeObject<AnythingGoes>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(AnythingGoes._);
+    return const SchemaObject(
+        ObjectType.realmObject, AnythingGoes, 'AnythingGoes', [
+      SchemaProperty('any', RealmPropertyType.mixed,
+          optional: true, indexed: true),
+    ]);
+  }
+}

--- a/test/realm_value_test.g.dart
+++ b/test/realm_value_test.g.dart
@@ -9,7 +9,7 @@ part of 'realm_value_test.dart';
 class AnythingGoes extends _AnythingGoes
     with RealmEntity, RealmObjectBase, RealmObject {
   AnythingGoes({
-    RealmValue? any,
+    RealmValue any = const RealmValue.nullValue(),
   }) {
     RealmObjectBase.set(this, 'any', any);
   }
@@ -17,10 +17,10 @@ class AnythingGoes extends _AnythingGoes
   AnythingGoes._();
 
   @override
-  RealmValue? get any =>
-      RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue?;
+  RealmValue get any =>
+      RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue;
   @override
-  set any(RealmValue? value) => RealmObjectBase.set(this, 'any', value);
+  set any(RealmValue value) => RealmObjectBase.set(this, 'any', value);
 
   @override
   Stream<RealmObjectChanges<AnythingGoes>> get changes =>


### PR DESCRIPTION
Support `RealmValue` that allows users to store different types in the same field
```dart
@RealmModel()
class _AnythingGoes {
  @Indexed()
  late RealmValue any;
  late List<RealmValue> manyAny;
}

void main() {
  final realm = Realm(Configuration.local([AnythingGoes.schema]));

  final something = realm.write(() => realm.add(AnythingGoes(any: RealmValue.string('text'))));

  realm.write(() {
    something.manyAny.addAll([null, true, 'text', 42, 3.14].map(RealmValue.from));
  });
}
```
Resolves: #684 