### PR TITLE
Use random tmp destination for download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Writing to a read-only realm throws `RealmException` instead of blocking the isolate. ([#974](https://github.com/realm/realm-dart/pull/974))
 * Fix no notification for write transaction that contains only change to backlink property. (Core upgrade)
 * Fixed wrong assertion on query error that could result in a crash. (Core upgrade)
+* Use random tmp directory for download. ([#1060](https://github.com/realm/realm-dart/issues/1060))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/lib/src/cli/install/install_command.dart
+++ b/lib/src/cli/install/install_command.dart
@@ -122,7 +122,7 @@ class InstallCommand extends Command<void> {
       await destinationDir.create(recursive: true);
     }
 
-    final destinationFile = File(path.join(Directory.systemTemp.absolute.path, "realm-binary", archiveName));
+    final destinationFile = File(path.join(Directory.systemTemp.createTempSync('realm-binary-').absolute.path, archiveName));
     if (!await destinationFile.parent.exists()) {
       await destinationFile.parent.create(recursive: true);
     }
@@ -142,7 +142,7 @@ class InstallCommand extends Command<void> {
       await response.pipe(destinationFile.openWrite());
     }
     // TODO: Handle download errors in Install command catch https://github.com/realm/realm-dart/issues/696.
-     finally {
+    finally {
       client.close(force: true);
     }
 
@@ -231,7 +231,7 @@ class InstallCommand extends Command<void> {
     } else if (Platform.isMacOS) {
       return TargetOsType.macos;
     } else {
-      throw Exception("Unsuported platform ${Platform.operatingSystem}");
+      throw Exception("Unsupported platform ${Platform.operatingSystem}");
     }
   }
 


### PR DESCRIPTION
This avoid conflict between users on the same machine.

Fixes #1060 
