### PR TITLE
Add ISRG X1 Root certificate (needed for Android 7.0 and earlier)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Fixed wrong assertion on query error that could result in a crash. (Core upgrade)
 * Use random tmp directory for download. ([#1060](https://github.com/realm/realm-dart/issues/1060))
 * Bump minimum Dart SDK version to 2.17.5 and Flutter SDK version to 3.0.3 due to an issue with the Dart virtual machine when implementing `Finalizable`. ([dart-lang/sdk#49075](https://github.com/dart-lang/sdk/issues/49075))
+* Pin certificate to ISRG X1 Root (root certificate used by lets-encrypt). ([#1087](https://github.com/realm/realm-dart/issues/1087))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 * Fixed wrong assertion on query error that could result in a crash. (Core upgrade)
 * Use random tmp directory for download. ([#1060](https://github.com/realm/realm-dart/issues/1060))
 * Bump minimum Dart SDK version to 2.17.5 and Flutter SDK version to 3.0.3 due to an issue with the Dart virtual machine when implementing `Finalizable`. ([dart-lang/sdk#49075](https://github.com/dart-lang/sdk/issues/49075))
-* Pin certificate to ISRG X1 Root (root certificate used by lets-encrypt). ([#1087](https://github.com/realm/realm-dart/issues/1087))
+* Add ISRG X1 Root certificate (used by lets-encrypt and hence MongoDB) to `SecurityContext` of the default `HttpClient`. This ensure we work out-of-the-box on older devices (in particular Android 7 and earlier). ([#1087](https://github.com/realm/realm-dart/issues/1087))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -27,8 +27,8 @@ import 'credentials.dart';
 import 'native/realm_core.dart';
 import 'user.dart';
 
-final _pinnedClient = () {
-  const isrgRootX1CertPEM = // The root certificate used by lets encrypt
+final _defaultClient = () {
+  const isrgRootX1CertPEM = // The root certificate used by lets encrypt and hence MongoDB
       '''
 subject=CN=ISRG Root X1,O=Internet Security Research Group,C=US
 issuer=CN=DST Root CA X3,O=Digital Signature Trust Co.
@@ -64,7 +64,7 @@ he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
 Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 -----END CERTIFICATE-----''';
 
-  final context = SecurityContext();
+  final context = SecurityContext(withTrustedRoots: true);
   context.setTrustedCertificatesBytes(const AsciiEncoder().convert(isrgRootX1CertPEM));
   return HttpClient(context: context);
 }();
@@ -143,7 +143,7 @@ class AppConfiguration {
     HttpClient? httpClient,
   })  : baseUrl = baseUrl ?? Uri.parse('https://realm.mongodb.com'),
         baseFilePath = baseFilePath ?? Directory(_path.dirname(Configuration.defaultRealmPath)),
-        httpClient = httpClient ?? _pinnedClient;
+        httpClient = httpClient ?? _defaultClient;
 }
 
 /// An [App] is the main client-side entry point for interacting with an [Atlas App Services](https://www.mongodb.com/docs/atlas/app-services/) application.

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -15,6 +15,7 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////
+import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
 
@@ -25,6 +26,48 @@ import '../realm.dart';
 import 'credentials.dart';
 import 'native/realm_core.dart';
 import 'user.dart';
+
+final _pinnedClient = () {
+  const isrgRootX1CertPEM = // The root certificate used by lets encrypt
+      '''
+subject=CN=ISRG Root X1,O=Internet Security Research Group,C=US
+issuer=CN=DST Root CA X3,O=Digital Signature Trust Co.
+-----BEGIN CERTIFICATE-----
+MIIFYDCCBEigAwIBAgIQQAF3ITfU6UK47naqPGQKtzANBgkqhkiG9w0BAQsFADA/
+MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
+DkRTVCBSb290IENBIFgzMB4XDTIxMDEyMDE5MTQwM1oXDTI0MDkzMDE4MTQwM1ow
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwggIiMA0GCSqGSIb3DQEB
+AQUAA4ICDwAwggIKAoICAQCt6CRz9BQ385ueK1coHIe+3LffOJCMbjzmV6B493XC
+ov71am72AE8o295ohmxEk7axY/0UEmu/H9LqMZshftEzPLpI9d1537O4/xLxIZpL
+wYqGcWlKZmZsj348cL+tKSIG8+TA5oCu4kuPt5l+lAOf00eXfJlII1PoOK5PCm+D
+LtFJV4yAdLbaL9A4jXsDcCEbdfIwPPqPrt3aY6vrFk/CjhFLfs8L6P+1dy70sntK
+4EwSJQxwjQMpoOFTJOwT2e4ZvxCzSow/iaNhUd6shweU9GNx7C7ib1uYgeGJXDR5
+bHbvO5BieebbpJovJsXQEOEO3tkQjhb7t/eo98flAgeYjzYIlefiN5YNNnWe+w5y
+sR2bvAP5SQXYgd0FtCrWQemsAXaVCg/Y39W9Eh81LygXbNKYwagJZHduRze6zqxZ
+Xmidf3LWicUGQSk+WT7dJvUkyRGnWqNMQB9GoZm1pzpRboY7nn1ypxIFeFntPlF4
+FQsDj43QLwWyPntKHEtzBRL8xurgUBN8Q5N0s8p0544fAQjQMNRbcTa0B7rBMDBc
+SLeCO5imfWCKoqMpgsy6vYMEG6KDA0Gh1gXxG8K28Kh8hjtGqEgqiNx2mna/H2ql
+PRmP6zjzZN7IKw0KKP/32+IVQtQi0Cdd4Xn+GOdwiK1O5tmLOsbdJ1Fu/7xk9TND
+TwIDAQABo4IBRjCCAUIwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYw
+SwYIKwYBBQUHAQEEPzA9MDsGCCsGAQUFBzAChi9odHRwOi8vYXBwcy5pZGVudHJ1
+c3QuY29tL3Jvb3RzL2RzdHJvb3RjYXgzLnA3YzAfBgNVHSMEGDAWgBTEp7Gkeyxx
++tvhS5B1/8QVYIWJEDBUBgNVHSAETTBLMAgGBmeBDAECATA/BgsrBgEEAYLfEwEB
+ATAwMC4GCCsGAQUFBwIBFiJodHRwOi8vY3BzLnJvb3QteDEubGV0c2VuY3J5cHQu
+b3JnMDwGA1UdHwQ1MDMwMaAvoC2GK2h0dHA6Ly9jcmwuaWRlbnRydXN0LmNvbS9E
+U1RST09UQ0FYM0NSTC5jcmwwHQYDVR0OBBYEFHm0WeZ7tuXkAXOACIjIGlj26Ztu
+MA0GCSqGSIb3DQEBCwUAA4IBAQAKcwBslm7/DlLQrt2M51oGrS+o44+/yQoDFVDC
+5WxCu2+b9LRPwkSICHXM6webFGJueN7sJ7o5XPWioW5WlHAQU7G75K/QosMrAdSW
+9MUgNTP52GE24HGNtLi1qoJFlcDyqSMo59ahy2cI2qBDLKobkx/J3vWraV0T9VuG
+WCLKTVXkcGdtwlfFRjlBz4pYg1htmf5X6DYO8A4jqv2Il9DjXA6USbW1FzXSLr9O
+he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
+Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
+-----END CERTIFICATE-----''';
+
+  final context = SecurityContext();
+  context.setTrustedCertificatesBytes(const AsciiEncoder().convert(isrgRootX1CertPEM));
+  return HttpClient(context: context);
+}();
 
 /// A class exposing configuration options for an [App]
 /// {@category Application}
@@ -100,7 +143,7 @@ class AppConfiguration {
     HttpClient? httpClient,
   })  : baseUrl = baseUrl ?? Uri.parse('https://realm.mongodb.com'),
         baseFilePath = baseFilePath ?? Directory(_path.dirname(Configuration.defaultRealmPath)),
-        httpClient = httpClient ?? HttpClient();
+        httpClient = httpClient ?? _pinnedClient;
 }
 
 /// An [App] is the main client-side entry point for interacting with an [Atlas App Services](https://www.mongodb.com/docs/atlas/app-services/) application.


### PR DESCRIPTION
The certificates from https://realm.mongodb.com/ are signed by lets-encrypt, which is dependent on the root certificate ISRG Root X1.

The list of platforms that support the ISRG Root X1 root certificate can be seen here: https://letsencrypt.org/docs/certificate-compatibility/. In particular you need Android >= 7.1.1

There is a dirty work-around to make these certificates work with old Android apps (>= 2.3.6), that you can read about here: https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/. Unfortunately I don't think this will work with BoringSSL that is used by Dart / Flutter.

Fixes: #1087 