### PR TITLE
add App.reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 **This project is in Release Candidate stage.**
 
 ### Enhancements
-* None
+* Add `App.reconnect` to reconnect ahead of schedule. Example of use in concert with `connectivity_plus` package:
+```dart
+Connectivity().onConnectivityChanged.listen((event) {
+  if (event != ConnectivityResult.none) {
+    app.reconnect();
+  }
+});
+```
 
 ### Fixed
 * None
@@ -19,7 +26,7 @@
 **This project is in Release Candidate stage.**
 
 ### Enhancements
-* Add supoprt for Realm set data type. ([#1102](https://github.com/realm/realm-dart/pull/1102))
+* Add support for Realm set data type. ([#1102](https://github.com/realm/realm-dart/pull/1102))
 * Exposed realm `writeCopy` API to copy a Realm file and optionally encrypt it with a different key. ([#1103](https://github.com/realm/realm-dart/pull/1103))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **This project is in Release Candidate stage.**
 
 ### Enhancements
-* Add `App.reconnect` to reconnect ahead of schedule. Example of use in concert with `connectivity_plus` package:
+* Add `App.reconnect()` providing a hint to Realm to reconnect all sync sessions.
 ```dart
 Connectivity().onConnectivityChanged.listen((event) {
   if (event != ConnectivityResult.none) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@
 
 ### Enhancements
 * Add `App.reconnect()` providing a hint to Realm to reconnect all sync sessions.
-```dart
-Connectivity().onConnectivityChanged.listen((event) {
-  if (event != ConnectivityResult.none) {
-    app.reconnect();
-  }
-});
-```
 
 ### Fixed
 * None

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -161,7 +161,7 @@ class App implements Finalizable {
     realmCore.switchUser(this, user);
   }
 
-  /// Instruct this app's sync client to immediately reconnect.
+  /// Provide a hint to this app's sync client to reconnect.
   /// Useful when the device has been offline and then receives a network reachability update.
   ///
   /// The sync client will always attempt to reconnect eventually, this is just a hint.

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -161,6 +161,14 @@ class App implements Finalizable {
     realmCore.switchUser(this, user);
   }
 
+  /// Instruct this app's sync client to immediately reconnect.
+  /// Useful when the device has been offline and then receives a network reachability update.
+  ///
+  /// The sync client will always attempt to reconnect eventually, this is just a hint.
+  void reconnect() {
+    realmCore.reconnect(this);
+  }
+
   /// Returns an instance of [EmailPasswordAuthProvider]
   EmailPasswordAuthProvider get emailPasswordAuthProvider => EmailPasswordAuthProviderInternal.create(this);
 }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1917,6 +1917,12 @@ class _RealmCore {
     });
   }
 
+  void reconnect(App application) {
+    _realmLib.realm_app_sync_client_reconnect(
+      application.handle._pointer,
+    );
+  }
+
   String? userGetCustomData(User user) {
     final customDataPtr = _realmLib.realm_user_get_custom_data(user.handle._pointer);
     return customDataPtr.cast<Utf8>().toRealmDartString(freeRealmMemory: true, treatEmptyAsNull: true);


### PR DESCRIPTION
Expose the ability to reconnect all syncSessions in one go with `App.reconnect`.

Typical use would be to reconnect when a NIC change state, fx using the `connectivity_plus` package:
```dart
Connectivity().onConnectivityChanged.listen((event) {
  if (event != ConnectivityResult.none) {
    app.reconnect();
  }
});
```

Fixes: #383 