### PR TITLE
[Flutter] package the dylib as a vendored library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ flutter/realm_flutter/android/.idea/
 flutter/realm_flutter/android/.cxx/
 flutter/realm_flutter/pubspec.lock
 flutter/realm_flutter/.gradle/
+flutter/realm_flutter/macos/librealm_dart.dylib
 /default.realm*
 /test/default.realm
 /test/default.realm.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* Fix codesigning errors when publishing to the macOS App Store. ([#1153](https://github.com/realm/realm-dart/issues/1153))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/flutter/realm_flutter/.pubignore
+++ b/flutter/realm_flutter/.pubignore
@@ -22,7 +22,7 @@ android/src/main/cpp/lib/
 ios/realm_flutter_ios.xcframework
 
 # Ignore mac binary directory. This gets created by Install command on build of projects
-#macos/librealm_dart.dylib.txt
+macos/librealm_dart.dylib
 
 # Ignore windows binaries directory. This gets created by Install command on build of projects
 windows/binary/

--- a/flutter/realm_flutter/example/macos/Podfile
+++ b/flutter/realm_flutter/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.11'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/flutter/realm_flutter/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/flutter/realm_flutter/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -280,6 +280,7 @@
 		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -406,7 +407,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -485,7 +486,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -532,7 +533,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/flutter/realm_flutter/macos/librealm_dart.dylib
+++ b/flutter/realm_flutter/macos/librealm_dart.dylib
@@ -1,1 +1,0 @@
-../../../binary/macos/librealm_dart.dylib

--- a/flutter/realm_flutter/macos/realm.podspec
+++ b/flutter/realm_flutter/macos/realm.podspec
@@ -2,11 +2,30 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint realm.podspec` to validate before publishing.
 #
-
 realmPackageDir = File.expand_path(__dir__)
+# puts "realmPackageDir: #{realmPackageDir}"
+
+realmLibName = "librealm_dart.dylib"
+
+# Check if the build is running in the realm-dart repo
+# We need to create an absolute symlink to librealm_dart.dylib otherwises
+# Cocoapods and Xcode build look for different files from different base directories while handling `vendored_libraries`
+realmLibraryPath = "#{realmPackageDir}/#{realmLibName}";
+if realmLibraryPath.include?("flutter/realm_flutter") && !File.exist?(realmLibraryPath)
+  absoluteRealRealmLibPath = File.realpath("#{realmPackageDir}/../../../binary/macos/#{realmLibName}")
+
+  if !File.exist?(absoluteRealRealmLibPath)
+    raise "Realm macos library does not exists in realm-dart repo at path #{absoluteRealRealmLibPath}"
+  end
+    
+  # create an absolute symlink to realm flutter macos lib librealm_dart.dylib
+  File.symlink(absoluteRealRealmLibPath, realmLibraryPath); 
+end
+
 # This works cause realm plugin is always accessed through the .symlinks directory.
 # For example the tests app refers to the realm plugin using this path .../realm-dart/flutter/realm_flutter/tests/macos/Flutter/ephemeral/.symlinks/plugins/realm/macos
-# project_dir = File.expand_path("../../../../../../", realmPackageDir)
+#project_dir = File.expand_path("../../../../../../", realmPackageDir)
+#puts "project dir is #{project_dir}"
 
 Pod::Spec.new do |s|
   s.name                      = 'realm'
@@ -19,13 +38,13 @@ Pod::Spec.new do |s|
   s.license                   = { :file => '../LICENSE' }
   s.author                    = { 'Realm' => 'help@realm.io' }
   s.source                    = { :path => '.' }
-  s.source_files              = 'Classes/**/*'
+  s.source_files               = 'Classes/**/*'
   s.dependency                  'FlutterMacOS'
 
   s.platform                  = :osx, '10.11'
-  s.pod_target_xcconfig       = { 'DEFINES_MODULE' => 'YES' }
+  s.pod_target_xcconfig        = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version             = '5.0'
-  s.vendored_libraries        = 'librealm_dart.dylib'
+  s.vendored_libraries        = "#{realmLibName}"
   s.prepare_command           = "touch #{realmPackageDir}/librealm_dart.dylib" #librealm_dart.dylib is needed before the build is started
   s.script_phases             = [
                                   { :name => 'Download Realm Flutter iOS Binaries',

--- a/flutter/realm_flutter/macos/realm.podspec
+++ b/flutter/realm_flutter/macos/realm.podspec
@@ -19,13 +19,13 @@ Pod::Spec.new do |s|
   s.license                   = { :file => '../LICENSE' }
   s.author                    = { 'Realm' => 'help@realm.io' }
   s.source                    = { :path => '.' }
-  s.source_files               = 'Classes/**/*'
+  s.source_files              = 'Classes/**/*'
   s.dependency                  'FlutterMacOS'
 
   s.platform                  = :osx, '10.11'
-  s.pod_target_xcconfig        = { 'DEFINES_MODULE' => 'YES' }
+  s.pod_target_xcconfig       = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version             = '5.0'
-  s.resources                 = 'librealm_dart.dylib'
+  s.vendored_libraries        = 'librealm_dart.dylib'
   s.prepare_command           = "touch #{realmPackageDir}/librealm_dart.dylib" #librealm_dart.dylib is needed before the build is started
   s.script_phases             = [
                                   { :name => 'Download Realm Flutter iOS Binaries',

--- a/flutter/realm_flutter/tests/macos/Podfile
+++ b/flutter/realm_flutter/tests/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.11'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/flutter/realm_flutter/tests/macos/Runner.xcodeproj/project.pbxproj
+++ b/flutter/realm_flutter/tests/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -256,6 +256,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -404,7 +405,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -483,7 +484,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -530,7 +531,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -27,7 +27,7 @@ String _getBinaryPath(String libName) {
     return '$_exeDirName/lib/$libName';
   }
   if (Platform.isMacOS) {
-    return '$_exeDirName/../Frameworks/realm.framework/Resources/$libName';
+    return '$_exeDirName/../Frameworks/$libName';
   }
   if (Platform.isIOS) {
     return '$_exeDirName/Frameworks/realm_dart.framework/$libName';


### PR DESCRIPTION
This lets CocoaPods set up the correct linking and code signing steps in Xcode.

Fixes #1153 