### PR TITLE
Bump github-actions commits sha

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           submodules: false
       - name: Enforce Changelog
-        uses: dangoslen/changelog-enforcer@c0b9fd225180a405c5f21f7a74b99e2eccc3e951
+        uses: dangoslen/changelog-enforcer@e6d07da252590d17a4c8f11d23a4b4f862499f7e
         with:
           skipLabels: no-changelog
           missingUpdateErrorMessage: Please add an entry in CHANGELOG.md or apply the 'no-changelog' label to skip this check.

--- a/.github/workflows/update-samples.yml
+++ b/.github/workflows/update-samples.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: 'Get release version'
         id: release-version
-        uses: pozetroninc/github-action-get-latest-release@06da55dc399d06375d2d1fe57542398d5bd989c6
+        uses: pozetroninc/github-action-get-latest-release@d1dafdb6e338bdab109e6afce581a01858680dfb
         with:
           repository: ${{ github.repository }}
 


### PR DESCRIPTION
Related to #971
To avoid CI warnings we are update actions to use Node 16 and action-core@1.10.0
Only `coverallsapp` action is not updated and causes two warnings.