### PR TITLE
Cancel in-flight workflows when a commit is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,11 @@ env:
   BAAS_PROJECT_ID: ${{ secrets.ATLAS_QA_PROJECT_ID}}
   REALM_CI: true
 
-jobs:
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
+jobs:
   deploy-cluster:
     runs-on: ubuntu-latest
     name: Deploy Cluster


### PR DESCRIPTION
This makes it so existing workflows runs are canceled when a new workflow starts for the same branch.