### PR TITLE
kn/fix-notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed several cases where wrong type of exception was thrown (Core upgrade).
 * Fixed classification of InvalidQuery exception (Core upgrade).
 * Fix crash if secure transport returns an error with a non-zero length. (Core upgrade).
+* Fixes infinite-loop like issue with await-for-yield over change streams ([#1213](https://github.com/realm/realm-dart/pull/1213)).
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -47,7 +47,7 @@ abstract class RealmList<T extends Object?> with RealmEntity implements List<T>,
   RealmResults<T> asResults();
 
   factory RealmList._(RealmListHandle handle, Realm realm, RealmObjectMetadata? metadata) => ManagedRealmList._(handle, realm, metadata);
-  
+
   /// Creates an unmanaged RealmList from [items]
   factory RealmList(Iterable<T> items) => UnmanagedRealmList(items);
 
@@ -131,7 +131,7 @@ class ManagedRealmList<T extends Object?> with RealmEntity, ListMixin<T> impleme
       if (T == RealmValue) {
         value = RealmValue.from(value);
       }
-      
+
       return value as T;
     } on Exception catch (e) {
       throw RealmException("Error getting value at index $index. Error: $e");
@@ -332,7 +332,7 @@ class ListNotificationsController<T extends Object?> extends NotificationsContro
   }
 
   Stream<RealmListChanges<T>> createStream() {
-    streamController = StreamController<RealmListChanges<T>>(onListen: start, onPause: stop, onResume: start, onCancel: stop);
+    streamController = StreamController<RealmListChanges<T>>(onListen: start, onCancel: stop);
     return streamController.stream;
   }
 

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -576,7 +576,7 @@ class RealmObjectNotificationsController<T extends RealmObjectBase> extends Noti
   }
 
   Stream<RealmObjectChanges<T>> createStream() {
-    streamController = StreamController<RealmObjectChanges<T>>(onListen: start, onPause: stop, onResume: start, onCancel: stop);
+    streamController = StreamController<RealmObjectChanges<T>>(onListen: start, onCancel: stop);
     return streamController.stream;
   }
 

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -148,7 +148,7 @@ class ResultsNotificationsController<T extends Object?> extends NotificationsCon
   }
 
   Stream<RealmResultsChanges<T>> createStream() {
-    streamController = StreamController<RealmResultsChanges<T>>(onListen: start, onPause: stop, onResume: start, onCancel: stop);
+    streamController = StreamController<RealmResultsChanges<T>>(onListen: start, onCancel: stop);
     return streamController.stream;
   }
 

--- a/test/realm_object_test.dart
+++ b/test/realm_object_test.dart
@@ -693,4 +693,33 @@ Future<void> main([List<String>? args]) async {
       expect(() => obj.id = 'abc', throws<RealmException>('Primary key cannot be changed'));
     });
   });
+
+  test('RealmObject.changes - await for with yield ', () async {
+    final config = Configuration.local([Person.schema]);
+    final realm = getRealm(config);
+
+    final person = realm.write(() => realm.add(Person('Peter')));
+
+    final wait = const Duration(seconds: 1);
+
+    Stream<bool> trueWaitFalse() async* {
+      yield true;
+      await Future<void>.delayed(wait);
+      yield false; // nothing has happened in the meantime
+    }
+
+    // ignore: prefer_function_declarations_over_variables
+    final awaitForWithYield = () async* {
+      await for (final c in person.changes) {
+        yield c;
+      }
+    };
+
+    int count = 0;
+    await for (final c in awaitForWithYield().map((_) => trueWaitFalse()).switchLatest()) {
+      if (!c) break; // saw false after waiting
+      ++count; // saw true due to new event from changes
+      if (count > 1) fail('Should only receive one event');
+    }
+  });
 }

--- a/test/test.dart
+++ b/test/test.dart
@@ -708,3 +708,17 @@ Future<void> enableAllAutomaticRecovery() async {
     await client.setAutomaticRecoveryEnabled(appName, true);
   }
 }
+
+extension StreamEx<T> on Stream<Stream<T>> {
+  Stream<T> switchLatest() async* {
+    StreamSubscription<T>? inner;
+    final controller = StreamController<T>();
+    final outer = listen((stream) {
+      inner?.cancel();
+      inner = stream.listen(controller.add, onError: controller.addError, onDone: controller.close);
+    }, onError: controller.addError, onDone: controller.close);
+    yield* controller.stream;
+    await outer.cancel();
+    await inner?.cancel();
+  }
+}


### PR DESCRIPTION
The following simple program will loop until it crash
```dart
import 'package:realm_dart/realm.dart';

part 'main.g.dart';

@RealmModel()
class _Stuff {
  late int id;
}

extension<E> on Stream<E> {
  Stream<E> sideEffect() async* {
    await for (final event in this) {
      yield event;
    }
  }
}

Future<void> main() async {
  final realm = Realm(Configuration.local([Stuff.schema]));
  final stuff = realm.write(() => realm.add(Stuff(0)));
  await for (final change in stuff.changes.sideEffect()) {
    print(change); // <-- prints repeatedly despite no changes
  }
}
```
The reason is how our change streams pump first event on listen, and pause/resume is really just stop/start. Since the await-for-yield construct will pause the stream before yielding, we get a kind of infinite loop.

The fix is trivial - don't do anything on pause/resume, and just let stream controller buffer any events.

The test is a bit tricky. The run: https://github.com/realm/realm-dart/actions/runs/4442519290 shows the updated tests fail before fixing the issue.

Fixes: #1216 