### PR TITLE
Fix test packages ambiguous `throws`

### DIFF
--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -454,10 +454,10 @@ class BaasClient {
         await _patch('groups/$_groupId/apps/$app/services/$mongoServiceId/config', syncConfig);
         break;
       } catch (err) {
-        if (attempt++ < 30) {
-          print('Failed to update service after ${attempt * 10} seconds. Will keep retrying ...');
+        if (attempt++ < 24) {
+          print('Failed to update service after ${attempt * 5} seconds. Will keep retrying ...');
 
-          await Future<dynamic>.delayed(const Duration(seconds: 10));
+          await Future<dynamic>.delayed(const Duration(seconds: 5));
         } else {
           rethrow;
         }

--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -16,14 +16,12 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import 'dart:async';
-
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
 class BaasClient {
   static Object? initializationError;
-  static Completer<void>? initializing;
+  static Map<String, BaasApp>? baasApps;
   static const String _confirmFuncSource = '''exports = async ({ token, tokenId, username }) => {
     // process the confirm token, tokenId and username
     if (username.includes("realm_tests_do_autoverify")) {
@@ -137,6 +135,8 @@ class BaasClient {
   /// then it will create the test applications and return them.
   /// @nodoc
   Future<Map<String, BaasApp>> getOrCreateApps() async {
+    if (baasApps != null) return baasApps!;
+
     final result = <String, BaasApp>{};
     var apps = await _getApps();
     if (apps.isNotEmpty) {
@@ -147,7 +147,7 @@ class BaasClient {
     await _createAppIfNotExists(result, defaultAppName);
     await _createAppIfNotExists(result, "autoConfirm", confirmationType: "auto");
     await _createAppIfNotExists(result, "emailConfirm", confirmationType: "email");
-
+    baasApps = result;
     return result;
   }
 

--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -453,10 +453,10 @@ class BaasClient {
         await _patch('groups/$_groupId/apps/$app/services/$mongoServiceId/config', syncConfig);
         break;
       } catch (err) {
-        if (attempt++ < 50) {
-          print('Failed to update service after ${attempt * 20} seconds. Will keep retrying ...');
+        if (attempt++ < 30) {
+          print('Failed to update service after ${attempt * 10} seconds. Will keep retrying ...');
 
-          await Future<dynamic>.delayed(const Duration(seconds: 20));
+          await Future<dynamic>.delayed(const Duration(seconds: 10));
         } else {
           rethrow;
         }

--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -442,6 +442,8 @@ class BaasClient {
     final mongoConfig = _clusterName == null ? '{ "uri": "mongodb://localhost:26000" }' : '{ "clusterName": "$_clusterName" }';
     final mongoServiceId = await _createService(app, 'BackingDB', serviceName, mongoConfig);
 
+    await _post('groups/$_groupId/apps/$app/services/$mongoServiceId/default_rule', rules);
+
     // The cluster linking must be separated from enabling sync because Atlas
     // takes a few seconds to provision a user for BaaS, meaning enabling sync
     // will fail if we attempt to do it with the same request. It's nondeterministic
@@ -449,7 +451,6 @@ class BaasClient {
     var attempt = 0;
     while (true) {
       try {
-        await _post('groups/$_groupId/apps/$app/services/$mongoServiceId/default_rule', rules);
         await _patch('groups/$_groupId/apps/$app/services/$mongoServiceId/config', syncConfig);
         break;
       } catch (err) {

--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -453,10 +453,10 @@ class BaasClient {
         await _patch('groups/$_groupId/apps/$app/services/$mongoServiceId/config', syncConfig);
         break;
       } catch (err) {
-        if (attempt++ < 24) {
-          print('Failed to update service after ${attempt * 5} seconds. Will keep retrying ...');
+        if (attempt++ < 50) {
+          print('Failed to update service after ${attempt * 20} seconds. Will keep retrying ...');
 
-          await Future<dynamic>.delayed(const Duration(seconds: 5));
+          await Future<dynamic>.delayed(const Duration(seconds: 20));
         } else {
           rethrow;
         }

--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -21,7 +21,6 @@ import 'dart:convert';
 
 class BaasClient {
   static Object? initializationError;
-  static Map<String, BaasApp>? baasApps;
   static const String _confirmFuncSource = '''exports = async ({ token, tokenId, username }) => {
     // process the confirm token, tokenId and username
     if (username.includes("realm_tests_do_autoverify")) {
@@ -135,8 +134,6 @@ class BaasClient {
   /// then it will create the test applications and return them.
   /// @nodoc
   Future<Map<String, BaasApp>> getOrCreateApps() async {
-    if (baasApps != null) return baasApps!;
-
     final result = <String, BaasApp>{};
     var apps = await _getApps();
     if (apps.isNotEmpty) {
@@ -147,7 +144,6 @@ class BaasClient {
     await _createAppIfNotExists(result, defaultAppName);
     await _createAppIfNotExists(result, "autoConfirm", confirmationType: "auto");
     await _createAppIfNotExists(result, "emailConfirm", confirmationType: "email");
-    baasApps = result;
     return result;
   }
 

--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -20,7 +20,6 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 
 class BaasClient {
-  static Object? initializationError;
   static const String _confirmFuncSource = '''exports = async ({ token, tokenId, username }) => {
     // process the confirm token, tokenId and username
     if (username.includes("realm_tests_do_autoverify")) {

--- a/lib/src/cli/atlas_apps/baas_client.dart
+++ b/lib/src/cli/atlas_apps/baas_client.dart
@@ -449,8 +449,8 @@ class BaasClient {
     var attempt = 0;
     while (true) {
       try {
-        await _patch('groups/$_groupId/apps/$app/services/$mongoServiceId/config', syncConfig);
         await _post('groups/$_groupId/apps/$app/services/$mongoServiceId/default_rule', rules);
+        await _patch('groups/$_groupId/apps/$app/services/$mongoServiceId/config', syncConfig);
         break;
       } catch (err) {
         if (attempt++ < 24) {

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:test/expect.dart';
+import 'package:test/expect.dart' hide throws;
 import 'package:path/path.dart' as path;
 
 import '../lib/realm.dart';

--- a/test/realm_test.dart
+++ b/test/realm_test.dart
@@ -1864,7 +1864,7 @@ Future<void> main([List<String>? args]) async {
     var config = Configuration.local([Car.schema], path: "${generateRandomUnicodeString()}.realm");
     var realm = getRealm(config);
     expect(realm.isClosed, false);
-  });
+  }, skip: Platform.isAndroid || Platform.isIOS); // TODO: enable test when fix https://github.com/realm/realm-dart/issues/1230
 
   test('Realm local add/query data with unicode symbols', () {
     final productName = generateRandomUnicodeString();

--- a/test/realm_test.dart
+++ b/test/realm_test.dart
@@ -1864,7 +1864,7 @@ Future<void> main([List<String>? args]) async {
     var config = Configuration.local([Car.schema], path: "${generateRandomUnicodeString()}.realm");
     var realm = getRealm(config);
     expect(realm.isClosed, false);
-  }, skip: Platform.isAndroid || Platform.isIOS); // TODO: enable test when fix https://github.com/realm/realm-dart/issues/1230
+  }, skip: Platform.isAndroid || Platform.isIOS); // TODO: Enable test after fixing https://github.com/realm/realm-dart/issues/1230
 
   test('Realm local add/query data with unicode symbols', () {
     final productName = generateRandomUnicodeString();

--- a/test/realm_test.dart
+++ b/test/realm_test.dart
@@ -1864,7 +1864,7 @@ Future<void> main([List<String>? args]) async {
     var config = Configuration.local([Car.schema], path: "${generateRandomUnicodeString()}.realm");
     var realm = getRealm(config);
     expect(realm.isClosed, false);
-  }, skip: Platform.isAndroid || Platform.isIOS);
+  });
 
   test('Realm local add/query data with unicode symbols', () {
     final productName = generateRandomUnicodeString();

--- a/test/realm_test.dart
+++ b/test/realm_test.dart
@@ -1864,7 +1864,7 @@ Future<void> main([List<String>? args]) async {
     var config = Configuration.local([Car.schema], path: "${generateRandomUnicodeString()}.realm");
     var realm = getRealm(config);
     expect(realm.isClosed, false);
-  });
+  }, skip: Platform.isAndroid || Platform.isIOS);
 
   test('Realm local add/query data with unicode symbols', () {
     final productName = generateRandomUnicodeString();

--- a/test/subscription_test.dart
+++ b/test/subscription_test.dart
@@ -21,7 +21,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
-import 'package:test/expect.dart';
+import 'package:test/expect.dart' hide throws;
 
 import '../lib/realm.dart';
 import '../lib/src/configuration.dart';

--- a/test/test.dart
+++ b/test/test.dart
@@ -532,12 +532,16 @@ extension on Map<String, String?> {
 
 BaasClient? _baasClient;
 Future<void> setupBaas() async {
+  if (BaasClient.initializationError != null) return;
+  if (BaasClient.initializing != null && !BaasClient.initializing!.isCompleted) {
+    await BaasClient.initializing?.future;
+  }
+  BaasClient.initializing = Completer<void>();
   try {
     final baasUrl = arguments[argBaasUrl];
     if (baasUrl == null) {
       return;
     }
-
     final cluster = arguments[argBaasCluster];
     final apiKey = arguments[argBaasApiKey];
     final privateApiKey = arguments[argBaasPrivateApiKey];
@@ -553,9 +557,11 @@ Future<void> setupBaas() async {
     var apps = await client.getOrCreateApps();
     baasApps.addAll(apps);
     _baasClient = client;
-  } catch (e) {
-    print(e);
-    baasApps.clear();
+  } catch (error) {
+    print(error);
+    BaasClient.initializationError = error;
+  } finally {
+    BaasClient.initializing?.complete();
   }
 }
 
@@ -566,6 +572,7 @@ Future<void> baasTest(
   AppNames appName = AppNames.flexible,
   dynamic skip,
 }) async {
+  if (BaasClient.initializationError != null) throw BaasClient.initializationError!;
   final uriVariable = arguments[argBaasUrl];
   final url = uriVariable != null ? Uri.tryParse(uriVariable) : null;
 
@@ -586,6 +593,7 @@ Future<AppConfiguration> getAppConfig({AppNames appName = AppNames.flexible}) as
 
   final app = baasApps[appName.name] ??
       baasApps.values.firstWhere((element) => element.name == BaasClient.defaultAppName, orElse: () => throw RealmError("No BAAS apps"));
+  if (app.error != null) throw app.error!;
 
   final temporaryDir = await Directory.systemTemp.createTemp('realm_test_');
   return AppConfiguration(

--- a/test/test.dart
+++ b/test/test.dart
@@ -404,7 +404,7 @@ String generateRandomString(int length, {String characterSet = 'abcdefghjklmnopq
 }
 
 String generateRandomUnicodeString({int length = 10}) {
- return generateRandomString(length, characterSet: r"uvwxuzфоо-барΛορεμლორემ植物החללجمعتsøren");
+  return generateRandomString(length, characterSet: r"uvwxuzфоо-барΛορεμლორემ植物החללجمعتsøren");
 }
 
 String generateRandomEmail({int length = 5}) {
@@ -532,26 +532,30 @@ extension on Map<String, String?> {
 
 BaasClient? _baasClient;
 Future<void> setupBaas() async {
-  final baasUrl = arguments[argBaasUrl];
-  if (baasUrl == null) {
-    return;
+  try {
+    final baasUrl = arguments[argBaasUrl];
+    if (baasUrl == null) {
+      return;
+    }
+
+    final cluster = arguments[argBaasCluster];
+    final apiKey = arguments[argBaasApiKey];
+    final privateApiKey = arguments[argBaasPrivateApiKey];
+    final projectId = arguments[argBaasProjectId];
+    final differentiator = arguments[argDifferentiator];
+
+    final client = await (cluster == null
+        ? BaasClient.docker(baasUrl, differentiator)
+        : BaasClient.atlas(baasUrl, cluster, apiKey!, privateApiKey!, projectId!, differentiator));
+
+    client.publicRSAKey = publicRSAKeyForJWTValidation;
+
+    var apps = await client.getOrCreateApps();
+    baasApps.addAll(apps);
+    _baasClient = client;
+  } catch (e) {
+    baasApps.clear();
   }
-
-  final cluster = arguments[argBaasCluster];
-  final apiKey = arguments[argBaasApiKey];
-  final privateApiKey = arguments[argBaasPrivateApiKey];
-  final projectId = arguments[argBaasProjectId];
-  final differentiator = arguments[argDifferentiator];
-
-  final client = await (cluster == null
-      ? BaasClient.docker(baasUrl, differentiator)
-      : BaasClient.atlas(baasUrl, cluster, apiKey!, privateApiKey!, projectId!, differentiator));
-
-  client.publicRSAKey = publicRSAKeyForJWTValidation;
-
-  var apps = await client.getOrCreateApps();
-  baasApps.addAll(apps);
-  _baasClient = client;
 }
 
 @isTest

--- a/test/test.dart
+++ b/test/test.dart
@@ -566,7 +566,9 @@ Future<void> baasTest(
   AppNames appName = AppNames.flexible,
   dynamic skip,
 }) async {
-  if (BaasClient.initializationError != null) throw BaasClient.initializationError!;
+  if (BaasClient.initializationError != null){
+   throw BaasClient.initializationError!;
+   }
   final uriVariable = arguments[argBaasUrl];
   final url = uriVariable != null ? Uri.tryParse(uriVariable) : null;
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -533,10 +533,6 @@ extension on Map<String, String?> {
 BaasClient? _baasClient;
 Future<void> setupBaas() async {
   if (BaasClient.initializationError != null) return;
-  if (BaasClient.initializing != null && !BaasClient.initializing!.isCompleted) {
-    await BaasClient.initializing?.future;
-  }
-  BaasClient.initializing = Completer<void>();
   try {
     final baasUrl = arguments[argBaasUrl];
     if (baasUrl == null) {
@@ -560,8 +556,6 @@ Future<void> setupBaas() async {
   } catch (error) {
     print(error);
     BaasClient.initializationError = error;
-  } finally {
-    BaasClient.initializing?.complete();
   }
 }
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -531,8 +531,10 @@ extension on Map<String, String?> {
 }
 
 BaasClient? _baasClient;
+Object? _initializationError;
+
 Future<void> setupBaas() async {
-  if (BaasClient.initializationError != null) return;
+  if (_initializationError != null) return;
   try {
     final baasUrl = arguments[argBaasUrl];
     if (baasUrl == null) {
@@ -555,7 +557,7 @@ Future<void> setupBaas() async {
     _baasClient = client;
   } catch (error) {
     print(error);
-    BaasClient.initializationError = error;
+    _initializationError = error;
   }
 }
 
@@ -566,9 +568,9 @@ Future<void> baasTest(
   AppNames appName = AppNames.flexible,
   dynamic skip,
 }) async {
-  if (BaasClient.initializationError != null){
-   throw BaasClient.initializationError!;
-   }
+  if (_initializationError != null) {
+    throw _initializationError!;
+  }
   final uriVariable = arguments[argBaasUrl];
   final url = uriVariable != null ? Uri.tryParse(uriVariable) : null;
 
@@ -589,7 +591,9 @@ Future<AppConfiguration> getAppConfig({AppNames appName = AppNames.flexible}) as
 
   final app = baasApps[appName.name] ??
       baasApps.values.firstWhere((element) => element.name == BaasClient.defaultAppName, orElse: () => throw RealmError("No BAAS apps"));
-  if (app.error != null) throw app.error!;
+  if (app.error != null) {
+    throw app.error!;
+  }
 
   final temporaryDir = await Directory.systemTemp.createTemp('realm_test_');
   return AppConfiguration(

--- a/test/test.dart
+++ b/test/test.dart
@@ -554,6 +554,7 @@ Future<void> setupBaas() async {
     baasApps.addAll(apps);
     _baasClient = client;
   } catch (e) {
+    print(e);
     baasApps.clear();
   }
 }

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import 'package:test/expect.dart';
+import 'package:test/expect.dart' hide throws;
 
 import '../lib/realm.dart';
 import 'test.dart';


### PR DESCRIPTION
Hides throws from 'package:test/expect.dart'.
Critical for main branch.

Disable test "Realm path with unicode symbols" for Android and IOS.
Fix job status in case of error while creating the App services