### PR TITLE
Add a force flag to install

### DIFF
--- a/lib/src/cli/install/install_command.dart
+++ b/lib/src/cli/install/install_command.dart
@@ -183,7 +183,7 @@ class InstallCommand extends Command<void> {
     final realmPackagePath = await getRealmPackagePath();
     final realmPubspec = await parsePubspec(realmPackagePath);
 
-    if (await shouldSkipInstall(realmPubspec)) {
+    if (!options.force && await shouldSkipInstall(realmPubspec)) {
       return;
     }
 

--- a/lib/src/cli/install/options.dart
+++ b/lib/src/cli/install/options.dart
@@ -30,10 +30,13 @@ class Options {
   Flavor flavor;
 
   // use to debug install command
-  @CliOption(hide: true, defaultsTo: false)
+  @CliOption(hide: true, help: 'Download binary from http://localhost:8000/.', defaultsTo: false)
   bool debug;
 
-  Options({this.targetOsType, this.flavor = Flavor.dart, this.debug = false});
+  @CliOption(hide: true, help: 'Force install, even if we would normally skip it.', defaultsTo: false)
+  bool force;
+
+  Options({this.targetOsType, this.flavor = Flavor.dart, this.force = false, this.debug = false});
 }
 
 String get usage => _$parserForOptions.usage;

--- a/lib/src/cli/install/options.g.dart
+++ b/lib/src/cli/install/options.g.dart
@@ -32,6 +32,7 @@ Options _$parseOptionsResult(ArgResults result) => Options(
         _$FlavorEnumMapBuildCli,
         result['flavor'] as String,
       ),
+      force: result['force'] as bool,
       debug: result['debug'] as bool,
     );
 
@@ -64,6 +65,12 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
   )
   ..addFlag(
     'debug',
+    help: 'Download binary from http://localhost:8000/.',
+    hide: true,
+  )
+  ..addFlag(
+    'force',
+    help: 'Force install, even if we would normally skip it.',
     hide: true,
   );
 


### PR DESCRIPTION
This allows us to force install the shared library even if we would
normally skip it. This is useful if you wan't to run tests against a
released version without actually building the realm again.
