### PR TITLE
Iterate over expected values and compare with actual values, not vice versa

### DIFF
--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -367,10 +367,13 @@ Future<void> testLogger(
   await realm.syncSession.waitForDownload();
 
   // Check count of various levels
-  for (final e in messages.entries) {
-    expect(e.value.length, lessThanOrEqualTo(maxExpectedCounts[e.key] ?? maxInt), reason: 'Unexpected number of ${e.key} messages:\n  ${e.value.join("\n  ")}');
-    expect(e.value.length, greaterThanOrEqualTo(minExpectedCounts[e.key] ?? minInt),
-        reason: 'Unexpected number of ${e.key} messages:\n  ${e.value.join("\n  ")}');
+  for (final e in maxExpectedCounts.entries) {
+    final count = messages[e.key]?.length ?? 0;
+    expect(count, lessThanOrEqualTo(e.value), reason: 'To many ${e.key} messages:\n  ${messages[e.key]?.join("\n  ")}');
+  }
+  for (final e in minExpectedCounts.entries) {
+    final count = messages[e.key]?.length ?? 0;
+    expect(count, greaterThanOrEqualTo(e.value), reason: 'To few ${e.key} messages:\n  ${messages[e.key]?.join("\n  ")}');
   }
 }
 


### PR DESCRIPTION
Reversing the _join_ so that no-trace won't pass the test