### PR TITLE
RealmResults.elementAt is slow

### DIFF
--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -39,7 +39,11 @@ class RealmResults<T extends Object?> extends collection.IterableBase<T> with Re
   }
 
   /// Returns the element of type `T` at the specified [index].
-  T operator [](int index) {
+  T operator [](int index) => elementAt(index);
+
+  /// Returns the element of type `T` at the specified [index].
+  @override
+  T elementAt(int index) {
     if (this is RealmResults<RealmObjectBase>) {
       final handle = realmCore.resultsGetObjectAt(this, index);
       final accessor = RealmCoreAccessor(metadata, realm.isInMigration);


### PR DESCRIPTION
`Iterable.elementAt` must be overriden to get good performance.

Fixes: #1261 