### PR TITLE
RealmResultsChanges.isCleared 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* `RealmResultsChanges.isCleared` is deprecated. It's value was not set correctly. It is fixed to return true if the results `isEmpty`. We are considering changing this API in future releases.
+* `RealmResultsChanges.isCleared` is deprecated. Its value was not set correctly. It is fixed to return true if the results `isEmpty` ([#1265](https://github.com/realm/realm-dart/pull/1265)). We are considering changing this API in future releases ([#1278](https://github.com/realm/realm-dart/issues/1278)).
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* `RealmResultsChanges.isCleared` is deprecated. Its value was not set correctly. It is fixed to return true if the results `isEmpty` ([#1265](https://github.com/realm/realm-dart/pull/1265)). We are considering changing this API in future releases ([#1278](https://github.com/realm/realm-dart/issues/1278)).
+* Fixed `RealmResultsChanges.isCleared` which was never set. It now returns `true` if the results collection is empty in the notification callback. This field is also marked as `deprecated` and will be removed in future. Use `RealmResultsChanges.results.isEmpty` instead.([#1265](https://github.com/realm/realm-dart/pull/1265)). ([#1278](https://github.com/realm/realm-dart/issues/1278)).
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* `RealmResultsChanges.isCleared` is deprecated. It's value was not set correctly. It is fixed to return true if the results `isEmpty`. We are considering changing this API in future releases.
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -137,6 +137,10 @@ class RealmResultsChanges<T extends Object?> extends RealmCollectionChanges {
   final RealmResults<T> results;
 
   RealmResultsChanges._(super.handle, this.results);
+
+  @override
+  @Deprecated("`isCleared` is deprecated. Use `isEmpty` of the results collection instead.")
+  bool get isCleared => results.isEmpty;
 }
 
 /// @nodoc

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -1222,4 +1222,20 @@ Future<void> main([List<String>? args]) async {
       if (count > 1) fail('Should only receive one event');
     }
   });
+
+  test('List.asResults().isCleared notifications', () async {
+    final config = Configuration.local([Team.schema, Person.schema]);
+    final realm = getRealm(config);
+    final team = Team('Team 1', players: [Person('Alice'), Person('Bob')]);
+    realm.write(() => realm.add(team));
+    final playersAsResults = team.players.asResults();
+
+    expectLater(
+        playersAsResults.changes,
+        emitsInOrder(<Matcher>[
+          isA<RealmResultsChanges<Person>>().having((changes) => changes.inserted, 'inserted', <int>[]), // always an empty event on subscription
+          isA<RealmResultsChanges<Person>>().having((changes) => changes.isCleared, 'isCleared', true),
+        ]));
+    realm.write(() => team.players.clear());
+  });
 }

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -1229,7 +1229,6 @@ Future<void> main([List<String>? args]) async {
     final team = Team('Team 1', players: [Person('Alice'), Person('Bob')]);
     realm.write(() => realm.add(team));
     final playersAsResults = team.players.asResults();
-
     expectLater(
         playersAsResults.changes,
         emitsInOrder(<Matcher>[
@@ -1237,5 +1236,6 @@ Future<void> main([List<String>? args]) async {
           isA<RealmResultsChanges<Person>>().having((changes) => changes.isCleared, 'isCleared', true),
         ]));
     realm.write(() => team.players.clear());
+    expect(playersAsResults.length, 0);
   });
 }

--- a/test/results_test.dart
+++ b/test/results_test.dart
@@ -620,21 +620,6 @@ Future<void> main([List<String>? args]) async {
     expect(team.players, [alice, bob]); // Alice is capital 'a'
   });
 
-test('List.asResults().isCleared notifications', () async {
-    final config = Configuration.local([Team.schema, Person.schema]);
-    final realm = getRealm(config);
-    final team = Team('Team 1', players: [Person('Alice'), Person('Bob')]);
-    realm.write(() => realm.add(team));
-    final playersAsResults = team.players.asResults();
-
-    expectLater(
-        playersAsResults.changes,
-        emitsInOrder(<Matcher>[
-          isA<RealmResultsChanges<Person>>().having((changes) => changes.isCleared, 'isCleared', true),
-        ]));
-    realm.write(() => team.players.clear());
-  });
-
   test('Results.query with remapped property', () {
     final config = Configuration.local([RemappedClass.schema]);
     final realm = getRealm(config);

--- a/test/results_test.dart
+++ b/test/results_test.dart
@@ -620,6 +620,21 @@ Future<void> main([List<String>? args]) async {
     expect(team.players, [alice, bob]); // Alice is capital 'a'
   });
 
+test('List.asResults().isCleared notifications', () async {
+    final config = Configuration.local([Team.schema, Person.schema]);
+    final realm = getRealm(config);
+    final team = Team('Team 1', players: [Person('Alice'), Person('Bob')]);
+    realm.write(() => realm.add(team));
+    final playersAsResults = team.players.asResults();
+
+    expectLater(
+        playersAsResults.changes,
+        emitsInOrder(<Matcher>[
+          isA<RealmResultsChanges<Person>>().having((changes) => changes.isCleared, 'isCleared', true),
+        ]));
+    realm.write(() => team.players.clear());
+  });
+
   test('Results.query with remapped property', () {
     final config = Configuration.local([RemappedClass.schema]);
     final realm = getRealm(config);


### PR DESCRIPTION
Deprecate `isCleared` for `RealmResults`.
Fixes #1189
Related to https://github.com/realm/realm-dart/issues/1278