### PR TITLE
Fix flutter tests after 3.10 update

### DIFF
--- a/flutter/realm_flutter/tests/pubspec.yaml
+++ b/flutter/realm_flutter/tests/pubspec.yaml
@@ -28,9 +28,6 @@ dev_dependencies:
   test: ^1.20.1
   timezone: ^0.9.0
 
-dependency_overrides:
-  test_api: 0.4.17
-
 flutter:
   uses-material-design: true
   assets:

--- a/flutter/realm_flutter/tests/test_driver/app_test.dart
+++ b/flutter/realm_flutter/tests/test_driver/app_test.dart
@@ -38,5 +38,6 @@ void main(List<String> args) {
 }
 
 String getArgFromEnvVariable(String argName) {
-  return " --$argName ${Platform.environment[argName]}";
+  final argValue = Platform.environment[argName];
+  return argValue == null ? '' : " --$argName $argValue";
 }


### PR DESCRIPTION
- Drop dependency override for test_api
- Fix `getArgFromEnvVariable`

