### PR TITLE
remove _RealmLogger wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 * Realm.logger now prints by default to the console from the first Isolate that initializes a Realm in the application. ([#1226](https://github.com/realm/realm-dart/pull/1226)).
   Calling `Realm.logger.clearListeners()` or `Realm.logger.level = RealmLogLevel.off` will turn off logging. If that is the first isolate it will stop the default printing logger.
   The default logger can be replaced with a custom implementation using `Realm.logger = CustomLogger()` from the first Isolate.
-  Any new spawned Isolates that work with Realm will get a new `Realm.logger` instance but will not `print` by default. 
+  Any new spawned Isolates that work with Realm will get a new `Realm.logger` instance but will not `print` by default.
   `Realm.logger.level` allows changing the log level per isolate.
 * Add logging at the Storage level (Core upgrade).
 * Performance improvement for the following queries (Core upgrade):
-    * Significant (~75%) improvement when counting (query count) the number of exact matches (with no other query conditions) on a String/int/Uuid/ObjectId property that has an index. This improvement will be especially noticiable if there are a large number of results returned (duplicate values).
+    * Significant (~75%) improvement when counting (query count) the number of exact matches (with no other query conditions) on a String/int/Uuid/ObjectId property that has an index. This improvement will be especially noticeable if there are a large number of results returned (duplicate values).
     * Significant (~99%) improvement when querying for an exact match on a Timestamp property that has an index.
     * Significant (~99%) improvement when querying for a case insensitive match on a Mixed property that has an index.
     * Moderate (~25%) improvement when querying for an exact match on a Boolean property that has an index.

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -80,6 +80,7 @@ class _RealmCore {
 
   final encryptionKeySize = 64;
   late final Logger defaultRealmLogger;
+  late StreamSubscription<Level?> realmLoggerLevelChangedSubscipiton;
   // ignore: unused_field
   static late final _RealmCore _instance;
 
@@ -94,7 +95,7 @@ class _RealmCore {
 
   Logger _initDefaultLogger(Scheduler scheduler) {
     final logger = Logger.detached('Realm')..level = Level.INFO;
-    logger.onLevelChanged.listen((logLevel) => loggerSetLogLevel(logLevel ?? RealmLogLevel.off, scheduler.nativePort));
+    realmLoggerLevelChangedSubscipiton = logger.onLevelChanged.listen((logLevel) => loggerSetLogLevel(logLevel ?? RealmLogLevel.off, scheduler.nativePort));
 
     bool isDefaultLogger = _realmLib.realm_dart_init_core_logger(logger.level.toInt());
     if (isDefaultLogger) {
@@ -105,7 +106,7 @@ class _RealmCore {
 
     return logger;
   }
-  
+
   // for debugging only. Enable in realm_dart.cpp
   // void invokeGC() {
   //   _realmLib.realm_dart_gc();

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -94,6 +94,7 @@ class _RealmCore {
 
   Logger _initDefaultLogger(Scheduler scheduler) {
     final logger = Logger.detached('Realm')..level = Level.INFO;
+    logger.onLevelChanged.listen((logLevel) => loggerSetLogLevel(logLevel ?? RealmLogLevel.off, scheduler.nativePort));
 
     bool isDefaultLogger = _realmLib.realm_dart_init_core_logger(logger.level.toInt());
     if (isDefaultLogger) {
@@ -104,6 +105,7 @@ class _RealmCore {
 
     return logger;
   }
+  
   // for debugging only. Enable in realm_dart.cpp
   // void invokeGC() {
   //   _realmLib.realm_dart_gc();

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -501,8 +501,11 @@ class Realm implements Finalizable {
     }
 
     _logger.clearListeners();
+    realmCore.realmLoggerLevelChangedSubscipiton.cancel();
     _logger = value;
-    _logger.onLevelChanged.listen((logLevel) => realmCore.loggerSetLogLevel(logLevel ?? RealmLogLevel.off, scheduler.nativePort));
+    realmCore.loggerSetLogLevel(_logger.level, scheduler.nativePort);
+    realmCore.realmLoggerLevelChangedSubscipiton =
+        _logger.onLevelChanged.listen((logLevel) => realmCore.loggerSetLogLevel(logLevel ?? RealmLogLevel.off, scheduler.nativePort));
   }
 
   /// Used to shutdown Realm and allow the process to correctly release native resources and exit.

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -487,7 +487,7 @@ class Realm implements Finalizable {
     return realmCore.realmEquals(this, other);
   }
 
-  static Logger _logger = _RealmLogger(realmCore.defaultRealmLogger);
+  static Logger _logger = realmCore.defaultRealmLogger;
 
   /// The logger to use for Realm logging in this `Isolate`
   /// The default log level is [RealmLogLevel.info].
@@ -496,8 +496,13 @@ class Realm implements Finalizable {
   }
 
   static set logger(Logger value) {
+    if (_logger == value) {
+      return;
+    }
+
     _logger.clearListeners();
-    _logger = (value is _RealmLogger) ? value : _RealmLogger(value);
+    _logger = value;
+    _logger.onLevelChanged.listen((logLevel) => realmCore.loggerSetLogLevel(logLevel ?? RealmLogLevel.off, scheduler.nativePort));
   }
 
   /// Used to shutdown Realm and allow the process to correctly release native resources and exit.
@@ -948,93 +953,3 @@ class MigrationRealm extends DynamicRealm {
 /// * syncProgress - an object of [SyncProgress] that contains `transferredBytes` and `transferableBytes`.
 /// {@category Realm}
 typedef ProgressCallback = void Function(SyncProgress syncProgress);
-
-// A Logger wrapper that allows setting the log level in Realm Core
-//// @nodoc
-class _RealmLogger implements Logger {
-  final Logger _logger;
-
-  _RealmLogger(this._logger) {
-    realmCore.loggerSetLogLevel(_logger.level, scheduler.nativePort);
-  }
-
-  @override
-  Level get level => _logger.level;
-
-  @override
-  set level(Level? value) {
-    _logger.level = value;
-    realmCore.loggerSetLogLevel(value ?? Level.OFF, scheduler.nativePort);
-  }
-
-  @override
-  Map<String, Logger> get children => _logger.children;
-
-  @override
-  void clearListeners() {
-    _logger.clearListeners();
-  }
-
-  @override
-  void config(Object? message, [Object? error, StackTrace? stackTrace]) {
-    _logger.config(message, error, stackTrace);
-  }
-
-  @override
-  void fine(Object? message, [Object? error, StackTrace? stackTrace]) {
-    _logger.fine(message, error, stackTrace);
-  }
-
-  @override
-  void finer(Object? message, [Object? error, StackTrace? stackTrace]) {
-    _logger.finer(message, error, stackTrace);
-  }
-
-  @override
-  void finest(Object? message, [Object? error, StackTrace? stackTrace]) {
-    _logger.finest(message, error, stackTrace);
-  }
-
-  @override
-  String get fullName => _logger.fullName;
-
-  @override
-  void info(Object? message, [Object? error, StackTrace? stackTrace]) {
-    _logger.info(message, error, stackTrace);
-  }
-
-  @override
-  bool isLoggable(Level value) => _logger.isLoggable(value);
-
-  @override
-  void log(Level logLevel, Object? message, [Object? error, StackTrace? stackTrace, Zone? zone]) {
-    _logger.log(logLevel, message, error, stackTrace, zone);
-  }
-
-  @override
-  String get name => _logger.name;
-
-  @override
-  Stream<LogRecord> get onRecord => _logger.onRecord;
-
-  @override
-  Logger? get parent => _logger.parent;
-
-  @override
-  void severe(Object? message, [Object? error, StackTrace? stackTrace]) {
-    _logger.severe(message, error, stackTrace);
-  }
-
-  @override
-  void shout(Object? message, [Object? error, StackTrace? stackTrace]) {
-    _logger.shout(message, error, stackTrace);
-  }
-
-  @override
-  void warning(Object? message, [Object? error, StackTrace? stackTrace]) {
-    _logger.warning(message, error, stackTrace);
-  }
-  
-  @override
-  Stream<Level?> get onLevelChanged => _logger.onLevelChanged;
-}

--- a/src/realm_dart_logger.cpp
+++ b/src/realm_dart_logger.cpp
@@ -30,7 +30,7 @@ bool is_core_logger_callback_set = false;
 std::map<Dart_Port, realm_log_level_e> dart_send_ports;
 realm_log_level_e current_core_log_level;
 
-realm_log_level_e calucale_minimum_log_level() {
+realm_log_level_e calculate_minimum_log_level() {
     std::lock_guard<std::recursive_mutex> lock(dart_logger_mutex);
     auto min_element = std::min_element(dart_send_ports.begin(), dart_send_ports.end(),
         [](std::pair<Dart_Port, realm_log_level_e> const& prev, std::pair<Dart_Port, realm_log_level_e> const& next) {
@@ -49,7 +49,7 @@ RLM_API void realm_dart_release_logger(Dart_Port port) {
     if (dart_send_ports.find(port) != dart_send_ports.end())
     {
         dart_send_ports.erase(port);
-        auto minimum_level = calucale_minimum_log_level();
+        auto minimum_level = calculate_minimum_log_level();
         realm_set_log_level(minimum_level);
     }
 }
@@ -101,7 +101,7 @@ RLM_API void realm_dart_set_log_level(realm_log_level_e level, Dart_Port port) {
     auto port_item = dart_send_ports.find(port);
     if (port_item == dart_send_ports.end() || port_item->second != level) {
         dart_send_ports[port] = level;
-        auto minimum_level = calucale_minimum_log_level();
+        auto minimum_level = calculate_minimum_log_level();
         realm_set_log_level(minimum_level);
     }
 }


### PR DESCRIPTION
Removes `_RealmLogger` wrapper. 

Reminder to all: We should really be careful not to implement classes from dependencies unless we are sure we can't be broken by a minor dependency update.