### PR TITLE
Fix double unlock, and lock order race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* Fixed a double unlock and race condition during client reset callbacks. ([#1335](https://github.com/realm/realm-dart/pull/1335))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/src/realm_dart_sync.cpp
+++ b/src/realm_dart_sync.cpp
@@ -181,19 +181,16 @@ bool invoke_dart_and_await_result(realm::util::UniqueFunction<void(realm::util::
     std::condition_variable condition;
     std::mutex mutex;
     bool success = false;
-    bool completed = false;
 
     realm::util::UniqueFunction unlockFunc = [&](bool result) {
         std::unique_lock lock(mutex);
         success = result;
-        completed = true;
-        lock.unlock();
         condition.notify_one();
     };
-    (*userCallback)(&unlockFunc);
-
+    
     std::unique_lock lock(mutex);
-    condition.wait(lock, [&] { return completed; });
+    (*userCallback)(&unlockFunc);
+    condition.wait(lock);
 
     return success;
 }


### PR DESCRIPTION
- Ensure that caller always locks mutex first. Previously callee could theoretically get it first, causing the later condition wait to hang forever.
- Avoid double unlock which has undefined behaviour for pthread. Previously both an explicit call to unlock, and the destructor would unlock the mutex.

These issues where found while investigating #1328. 

fix #1328 