### PR TITLE
Guard against spurious awakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* Fixed a double unlock and race condition during client reset callbacks. ([#1335](https://github.com/realm/realm-dart/pull/1335))
+* Fixed an early unlock race condition during client reset callbacks. ([#1335](https://github.com/realm/realm-dart/pull/1335))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.


### PR DESCRIPTION
We do need the `completed` flag here to guard against spurious awake, such as can happen due to interrupts fx.

> When an unmasked, caught signal is delivered to a thread while the thread is waiting on a condition variable, then when the signal handler returns, the thread returns from the condition wait with a spurious wakeup (one not caused by a condition signal call from another thread).

https://docs.oracle.com/cd/E19683-01/806-6867/gen-24356/index.html

Still, we don't call the early `unique_lock::unlock` from [before](https://github.com/realm/realm-dart/pull/1335/files) as it would allow the `condition_variable::notify_one` to be called after `mutex` and `condition` is destroyed, if thread changes just after the unlock allowing calling thread to run function to completion.

This was issue was found during investigation of #1328. While this fixes a potential problem it is not clear it is related.