### PR TITLE
`package:http` now supports more versions: `>=0.13.0 <2.0.0`.

### DIFF
--- a/flutter/realm_flutter/pubspec.yaml
+++ b/flutter/realm_flutter/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
     path: ../../generator
   tar: ^0.5.4
   build_runner: ^2.1.0
-  http: ^1.0.0
+  http: '>=0.13.0 <2.0.0'
   cancellation_token: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Like other packages, realm should support more versions of the http package.


https://pub.dev/packages/http/changelog
https://github.com/getsentry/sentry-dart/blob/1596141c018a1029c280be2e0a0b2cd4849239ec/dart/pubspec.yaml#L15C1-L16C1
https://github.com/grpc/grpc-dart/pull/629
https://github.com/firebase/flutterfire/blob/81156d1062d3eb3c6c83833887ca054cf66cfa13/packages/firebase_storage/firebase_storage_web/pubspec.yaml#L21