### PR TITLE
Lossen cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Sync errors included the error message twice (Core upgrade, since v13.16.0).
 * Fixes infinite-loop like issue with await-for-yield over realm set change streams. ([#1344](https://github.com/realm/realm-dart/issues/1344))
 * Fixed issue with using flexibleSync in flutter test. ([#1366](https://github.com/realm/realm-dart/pull/1366))
+* Fixed a realm generator issue, when used in concert with MobX. ([%1372](https://github.com/realm/realm-dart/pull/1372))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/generator/lib/src/class_element_ex.dart
+++ b/generator/lib/src/class_element_ex.dart
@@ -58,7 +58,7 @@ extension on Iterable<FieldElement> {
 }
 
 extension ClassElementEx on ClassElement {
-  ClassDeclaration get declarationAstNode => getDeclarationFromElement(this)!.node as ClassDeclaration;
+  AnnotatedNode get declarationAstNode => getDeclarationFromElement(this)!.node as AnnotatedNode;
 
   AnnotationValue? get realmModelInfo => annotationInfoOfExact(realmModelChecker);
 


### PR DESCRIPTION
Calling
```dart
ElementDeclarationResult? getDeclarationFromElement(Element element) {
  return session.resolvedLibrary.getElementDeclaration(element);
}
```
on a `ClassElement` is not guaranteed to return a result with a `node` of type `ClassDeclaration` (It can be a `ClassTypeAlias` as well), so the previous cast in `declarationAstNode` is not safe. However we don't actually only need a `AnnotatedNode` which is a common base for both `ClassDeclaration` and `ClassTypeAlias`.

Fix: #1285 