### PR TITLE
Avoid StreamController.broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Fixed a realm generator issue, when used in concert with MobX. ([#1372](https://github.com/realm/realm-dart/pull/1372))
 * Fix failed assertion for unknown app server errors (Core upgrade, since v12.9.0).
 * Testing the size of a collection of links against zero would sometimes fail (sometimes = "difficult to explain"). (Core upgrade, since v13.15.1)
-* getProgressStream no longer returns a broadcast stream. ([#1375](https://github.com/realm/realm-dart/pull/1375))
+* `Session.getProgressStream` now returns a regular stream, instead of a broadcast stream. ([#1375](https://github.com/realm/realm-dart/pull/1375))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fixed a realm generator issue, when used in concert with MobX. ([#1372](https://github.com/realm/realm-dart/pull/1372))
 * Fix failed assertion for unknown app server errors (Core upgrade, since v12.9.0).
 * Testing the size of a collection of links against zero would sometimes fail (sometimes = "difficult to explain"). (Core upgrade, since v13.15.1)
+* getProgressStream no longer returns a broadcast stream. ([#1375](https://github.com/realm/realm-dart/pull/1375))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -81,16 +81,18 @@ class Session implements Finalizable {
 }
 
 /// A type containing information about the progress state at a given instant.
-typedef SyncProgress = ({
+class SyncProgress {
   /// The number of bytes that have been transferred since subscribing for progress notifications.
-  int transferredBytes,
+  final int transferredBytes;
 
   /// The total number of bytes that have to be transferred since subscribing for progress notifications.
   /// The difference between that number and [transferredBytes] gives you the number of bytes not yet
   /// transferred. If the difference is 0, then all changes at the instant the callback fires have been
   /// successfully transferred.
-  int transferableBytes,
-});
+  final int transferableBytes;
+
+  const SyncProgress({required this.transferredBytes, required this.transferableBytes});
+}
 
 /// A type containing information about the transition of a connection state from one value to another.
 class ConnectionStateChange {
@@ -124,7 +126,7 @@ extension SessionInternal on Session {
   }
 
   static SyncProgress createSyncProgress(int transferredBytes, int transferableBytes) =>
-      (transferredBytes: transferredBytes, transferableBytes: transferableBytes);
+      SyncProgress(transferredBytes: transferredBytes, transferableBytes: transferableBytes);
 }
 
 abstract interface class ProgressNotificationsController {
@@ -149,7 +151,7 @@ class SessionProgressNotificationsController implements ProgressNotificationsCon
 
   @override
   void onProgress(int transferredBytes, int transferableBytes) {
-    _streamController.add((transferredBytes: transferredBytes, transferableBytes: transferableBytes));
+    _streamController.add(SyncProgress(transferredBytes: transferredBytes, transferableBytes: transferableBytes));
 
     if (transferredBytes >= transferableBytes && _mode == ProgressMode.forCurrentlyOutstandingWork) {
       _streamController.close();


### PR DESCRIPTION
There are a number of reasons to prefer not to use broadcast stream here.

1. You can always turn a normal stream into a broadcast stream with `asBroadcast`, but it is impossible to go the other way.
2. We are not actually sharing the progress stream (and hence the backing `StreamController`). Each call to `getProgressStream` will create a new one anyway, so unless the user explicitly shares the returned stream there is no sharing. Fx. our own tests pass just fine, when converting to a normal stream.
3. The `SessionProgressNotificationController` owning the `StreamController` (and hence the `Stream`) is passed to native and become a GC root, preventing the GC to collect until realm-core releases it. Unlike single-subscriber streams which are constructed for one-time-use, a broadcast stream is useful to pass around a be subscribed multiple times. If a single cancel call is missed, we have leak.
4. A pause on a subscription on a broadcast stream will cause events to be lost while paused. Recall that dart will implicitly pause stream during `await for` loops. I believe it is important that people opt-in to this.