### PR TITLE
Collections in mixed

### DIFF
--- a/test/realm_value_test.dart
+++ b/test/realm_value_test.dart
@@ -59,7 +59,10 @@ Future<void> main([List<String>? args]) async {
       ObjectId.fromTimestamp(now),
       Uuid.v4(),
       Decimal128.fromDouble(128.128),
-      Uint8List.fromList([1, 2, 0])
+      Uint8List.fromList([1, 2, 0]),
+      [1, 2, 3],
+      {1, 2, 3},
+      {'a': 1, 'b': 2},
     ];
 
     for (final x in values) {
@@ -80,7 +83,7 @@ Future<void> main([List<String>? args]) async {
     test('Illegal value', () {
       final config = Configuration.local([AnythingGoes.schema, Stuff.schema, TuckedIn.schema]);
       final realm = getRealm(config);
-      expect(() => realm.write(() => realm.add(AnythingGoes(oneAny: RealmValue.from(<int>[1, 2])))), throwsArgumentError);
+      expect(() => realm.write(() => realm.add(AnythingGoes(oneAny: RealmValue.from((1, 2))))), throwsArgumentError); // records not supported
     });
 
     test('Embedded object not allowed in RealmValue', () {


### PR DESCRIPTION
Allow `RealmValue`s (mixed) to contain collections, and support a convenient syntax for constructing `RealmValue`s of nested collections, and drilling into these to extract values.

Here is the suggested interface:
```dart
  final any = RealmValue.from([
    1,
    2,
    {
      'x': {1, 2}
    },
  ]);

  // access list element at index 2,
  // then map element with key 'x',
  // then set element 1, if it exists
  // assuming an int, or null if not found
  final x = any[2]['x'][1].as<int?>();
  assert(x == 1);

  // or, a bit shorter
  final y = any[2]['x'][1]<int?>();
  assert(y == 1);

  // or, shorter yet
  int? z = any[2]['x'][1]();
  assert(z == 1);

  // or, if you are sure
  int w = any[2]['x'][1](); // <-- shortest
  assert(w == 1);

  // or, using a list of indexes
  int u = any[[2, 'x', 1]]();
  assert(u == 1);

  // which allows for a different layout
  int v = any[[
    2,
    'x',
    1,
  ]]();
  assert(v == 1);
```

The code-behind is not done yet