### PR TITLE
use Dart 3.0.6 for linux CI

### DIFF
--- a/.github/workflows/dart-desktop-tests.yml
+++ b/.github/workflows/dart-desktop-tests.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       runner:
-        description: GitHub runnar image to execute on.
+        description: GitHub runner image to execute on.
         required: true
         type: string
       architecture:
@@ -58,7 +58,7 @@ jobs:
       - name : Setup Dart SDK
         uses: dart-lang/setup-dart@main
         with:
-          sdk: stable
+          sdk: ${{ contains(inputs.os, 'linux') && '3.0.6' || 'stable'}}
           architecture: ${{ inputs.architecture == 'arm' && 'arm64' || 'x64'}}
 
       - name: Install dependencies


### PR DESCRIPTION
Temporarily use old Dart version for CI, until https://github.com/dart-lang/sdk/issues/53267 is fixed