### PR TITLE
kn/results skip performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* Support efficient `skip` on `RealmResults` ([#1391](https://github.com/realm/realm-dart/pull/1391))
 
 ### Fixed
 * None

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -216,18 +216,16 @@ class _RealmResultsIterator<T extends Object?> implements Iterator<T> {
         _index = -1;
 
   @override
-  T get current => _current as T;
+  T get current => _current ??= _results[_index];
 
   @override
   bool moveNext() {
     int length = _results.length;
+    _current = null;
     _index++;
     if (_index >= length) {
-      _current = null;
       return false;
     }
-    _current = _results[_index];
-
     return true;
   }
 }

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -219,9 +219,9 @@ class _RealmResultsIterator<T extends Object?> implements Iterator<T> {
   int _index;
   T? _current;
 
-  _RealmResultsIterator(RealmResults<T> results, {int index = 0})
+  _RealmResultsIterator(RealmResults<T> results)
       : _results = results,
-        _index = index - 1;
+        _index = -1;
 
   @override
   T get current => _current ??= _results[_index];

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -30,11 +30,13 @@ import 'realm_object.dart';
 class RealmResults<T extends Object?> extends Iterable<T> with RealmEntity implements Finalizable {
   final RealmObjectMetadata? _metadata;
   final RealmResultsHandle _handle;
+  final int _skipOffset; // to support skip efficiently
 
   final _supportsSnapshot = <T>[] is List<RealmObjectBase?>;
 
-  RealmResults._(this._handle, Realm realm, this._metadata) {
+  RealmResults._(this._handle, Realm realm, this._metadata, [this._skipOffset = 0]) {
     setRealm(realm);
+    assert(length >= 0);
   }
 
   /// Gets a value indicating whether this collection is still valid to use.
@@ -47,11 +49,11 @@ class RealmResults<T extends Object?> extends Iterable<T> with RealmEntity imple
   @override
   T elementAt(int index) {
     if (this is RealmResults<RealmObjectBase>) {
-      final handle = realmCore.resultsGetObjectAt(this, index);
+      final handle = realmCore.resultsGetObjectAt(this, _skipOffset + index);
       final accessor = RealmCoreAccessor(metadata, realm.isInMigration);
       return RealmObjectInternal.create(T, realm, handle, accessor) as T;
     } else {
-      return realmCore.resultsGetElementAt(this, index) as T;
+      return realmCore.resultsGetElementAt(this, _skipOffset + index) as T;
     }
   }
 
@@ -72,7 +74,7 @@ class RealmResults<T extends Object?> extends Iterable<T> with RealmEntity imple
 
   /// The number of values in this `Results` collection.
   @override
-  int get length => realmCore.getResultsCount(this);
+  int get length => realmCore.getResultsCount(this) - _skipOffset;
 
   @override
   T get first {
@@ -100,6 +102,12 @@ class RealmResults<T extends Object?> extends Iterable<T> with RealmEntity imple
       throw RealmStateError('No element');
     }
     return this[0];
+  }
+
+  @override
+  RealmResults<T> skip(int count) {
+    RangeError.checkValueInInterval(count, 0, length, "count");
+    return RealmResults<T>._(_handle, realm, _metadata, _skipOffset + count);
   }
 
   /// Creates a frozen snapshot of this query.
@@ -211,9 +219,9 @@ class _RealmResultsIterator<T extends Object?> implements Iterator<T> {
   int _index;
   T? _current;
 
-  _RealmResultsIterator(RealmResults<T> results)
+  _RealmResultsIterator(RealmResults<T> results, {int index = 0})
       : _results = results,
-        _index = -1;
+        _index = index - 1;
 
   @override
   T get current => _current ??= _results[_index];

--- a/test/results_test.dart
+++ b/test/results_test.dart
@@ -939,4 +939,33 @@ Future<void> main([List<String>? args]) async {
       );
     }
   });
+
+  test('_RealmResultsIterator', () {
+    // behavior of normal iterator
+    final list = [1];
+    final it = list.iterator;
+    // you are not supposed to call current before first moveNext
+    expect(() => it.current, throwsA(isA<TypeError>()));
+    expect(it.moveNext(), isTrue);
+    expect(it.moveNext(), isFalse);
+    // you are not supposed to call current, if moveNext return false
+    expect(() => it.current, throwsA(isA<TypeError>()));
+
+    // behavior of _RealmResultsIterator
+    final config = Configuration.local([Task.schema]);
+    final realm = getRealm(config);
+    realm.write(() {
+      realm.add(Task(ObjectId()));
+    });
+    final results = realm.all<Task>();
+    expect(results.length, 1);
+    final rit = results.iterator;
+
+    // you are not supposed to call current before first moveNext
+    expect(() => rit.current, throwsA(isA<RealmException>()));
+    expect(rit.moveNext(), isTrue);
+    expect(rit.moveNext(), isFalse);
+    // you are not supposed to call current, if moveNext return false
+    expect(() => rit.current, throwsA(isA<RealmException>()));
+  });
 }

--- a/test/results_test.dart
+++ b/test/results_test.dart
@@ -18,11 +18,10 @@
 
 // ignore_for_file: unused_local_variable
 
-import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:ffi/ffi.dart';
 import 'package:test/test.dart' hide test, throws;
+
 import '../lib/realm.dart';
 import 'test.dart';
 


### PR DESCRIPTION
This makes `skip` a simple integer addition, and defer handle construction as long as possible.

- Fetch handle in _RealmResultsIterator.current lazily (it may never be called for a given index)
- Support efficient skip on RealmResults

This came about due to https://www.mongodb.com/community/forums/t/do-relationship-properties-get-populated-during-tolist/242260.

`skip` is useful if you wan't to do pagination for various reasons, even though realm doesn't require it. In this case to support an existing data access layer previously build on another DB.

Fixes: #1392 