### PR TITLE
kn/asymmetric sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Enhancements
 * Support efficient `skip` on `RealmResults` ([#1391](https://github.com/realm/realm-dart/pull/1391))
 * Support efficient `indexOf` and `contains` on `RealmResults` ([#1394](https://github.com/realm/realm-dart/pull/1394))
+* Support asymmetric objects. ([#1400](https://github.com/realm/realm-dart/pull/1400))
+
 ### Fixed
 * None
 

--- a/common/lib/src/realm_common_base.dart
+++ b/common/lib/src/realm_common_base.dart
@@ -33,7 +33,7 @@ enum ObjectType {
   /// A special type of object used to facilitate unidirectional synchronization
   /// with Atlas App Services. It is used to push data to Realm without the ability
   /// to query or modify it.
-  _asymmetricObject('AsymmetricObject', 2);
+  asymmetricObject('AsymmetricObject', 2);
 
   const ObjectType([this._className = 'Unknown', this._flags = -1]);
 

--- a/common/lib/src/realm_types.dart
+++ b/common/lib/src/realm_types.dart
@@ -139,6 +139,9 @@ abstract class RealmObjectMarker implements RealmObjectBaseMarker {}
 /// @nodoc
 abstract class EmbeddedObjectMarker implements RealmObjectBaseMarker {}
 
+/// @nodoc
+abstract class AsymmetricObjectMarker implements RealmObjectBaseMarker {}
+
 /// A type that can represent any valid realm data type, except collections and embedded objects.
 ///
 /// You can use [RealmValue] to declare fields on realm models, in which case it must be non-nullable,

--- a/generator/lib/src/class_element_ex.dart
+++ b/generator/lib/src/class_element_ex.dart
@@ -196,7 +196,7 @@ extension ClassElementEx on ClassElement {
         for (final field in mappedFields) {
           final fieldElement = field.fieldElement;
           final classElement = fieldElement.type.basicType.element as ClassElement;
-          if (field.type.isRealmModel && !classElement.thisType.isRealmModelOfType(ObjectType.embeddedObject)) {
+          if (field.type.basicType.isRealmModel && !classElement.thisType.isRealmModelOfType(ObjectType.embeddedObject)) {
             throw RealmInvalidGenerationSourceError('Asymmetric objects cannot link to non-embedded objects', todo: '', element: fieldElement);
           }
           if (field.isPrimaryKey) {

--- a/generator/lib/src/dart_type_ex.dart
+++ b/generator/lib/src/dart_type_ex.dart
@@ -34,7 +34,18 @@ extension DartTypeEx on DartType {
   bool get isRealmValue => const TypeChecker.fromRuntime(RealmValue).isAssignableFromType(this);
   bool get isRealmCollection => realmCollectionType != RealmCollectionType.none;
   bool get isRealmSet => realmCollectionType == RealmCollectionType.set;
-  bool get isRealmModel => element2 != null ? realmModelChecker.annotationsOfExact(element2!).isNotEmpty : false;
+
+  ObjectType? get realmObjectType {
+    if (element == null) return null;
+    final realmModelAnnotation = realmModelChecker.firstAnnotationOfExact(element!);
+    if (realmModelAnnotation == null) return null; // not a RealmModel
+    final index = realmModelAnnotation.getField('type')!.getField('index')!.toIntValue()!;
+    return ObjectType.values[index];
+  }
+
+  bool get isRealmModel => realmObjectType != null;
+  bool isRealmModelOfType(ObjectType type) => realmObjectType == type;
+
   bool get isUint8List => isExactly<Uint8List>();
 
   bool get isNullable => session.typeSystem.isNullable(this);
@@ -50,7 +61,7 @@ extension DartTypeEx on DartType {
     return RealmCollectionType.none;
   }
 
-  DartType? get nullIfDynamic => isDynamic ? null : this;
+  DartType? get nullIfDynamic => this is DynamicType ? null : this;
 
   DartType get basicType {
     final self = this;

--- a/generator/lib/src/field_element_ex.dart
+++ b/generator/lib/src/field_element_ex.dart
@@ -39,6 +39,8 @@ import 'type_checkers.dart';
 extension FieldElementEx on FieldElement {
   static const realmSetUnsupportedRealmTypes = [RealmPropertyType.linkingObjects];
 
+  ClassElement get enclosingClassElement => enclosingElement as ClassElement;
+
   FieldDeclaration get declarationAstNode => getDeclarationFromElement(this)!.node.parent!.parent as FieldDeclaration;
 
   AnnotationValue? get ignoredInfo => annotationInfoOfExact(ignoredChecker);

--- a/generator/test/error_test_data/asymmetric_external_link.dart
+++ b/generator/test/error_test_data/asymmetric_external_link.dart
@@ -1,0 +1,13 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel(ObjectType.asymmetricObject)
+class _Asymmetric {
+  @PrimaryKey()
+  @MapTo('_id')
+  late ObjectId id;
+}
+
+@RealmModel()
+class _Bad {
+  _Asymmetric? asymmetric;
+}

--- a/generator/test/error_test_data/asymmetric_external_link.expected
+++ b/generator/test/error_test_data/asymmetric_external_link.expected
@@ -1,0 +1,12 @@
+Linking to asymmetric objects is not allowed
+
+in: asset:pkg/test/error_test_data/asymmetric_external_link.dart:12:16
+   ╷
+10 │ @RealmModel()
+11 │ class _Bad {
+   │       ━━━━ in realm model for 'Bad'
+12 │   _Asymmetric? asymmetric;
+   │                ^^^^^^^^^^ !
+   ╵
+Remove the field
+

--- a/generator/test/error_test_data/asymmetric_link_to_non_embedded.dart
+++ b/generator/test/error_test_data/asymmetric_link_to_non_embedded.dart
@@ -1,0 +1,13 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel()
+class _Symmetric {}
+
+@RealmModel(ObjectType.asymmetricObject)
+class _Asymmetric {
+  @PrimaryKey()
+  @MapTo('_id')
+  late ObjectId id;
+
+  _Symmetric? illegal;
+}

--- a/generator/test/error_test_data/asymmetric_link_to_non_embedded.expected
+++ b/generator/test/error_test_data/asymmetric_link_to_non_embedded.expected
@@ -1,0 +1,11 @@
+Asymmetric objects cannot link to non-embedded objects
+
+in: asset:pkg/test/error_test_data/asymmetric_link_to_non_embedded.dart:12:15
+    ╷
+6   │ @RealmModel(ObjectType.asymmetricObject)
+7   │ class _Asymmetric {
+    │       ━━━━━━━━━━━ in realm model for 'Asymmetric'
+... │
+12  │   _Symmetric? illegal;
+    │               ^^^^^^^ !
+    ╵

--- a/generator/test/error_test_data/asymmetric_link_to_non_embedded_list.dart
+++ b/generator/test/error_test_data/asymmetric_link_to_non_embedded_list.dart
@@ -1,0 +1,13 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel()
+class _Symmetric {}
+
+@RealmModel(ObjectType.asymmetricObject)
+class _Asymmetric {
+  @PrimaryKey()
+  @MapTo('_id')
+  late ObjectId id;
+
+  late List<_Symmetric> illegal;
+}

--- a/generator/test/error_test_data/asymmetric_link_to_non_embedded_list.expected
+++ b/generator/test/error_test_data/asymmetric_link_to_non_embedded_list.expected
@@ -1,0 +1,11 @@
+Asymmetric objects cannot link to non-embedded objects
+
+in: asset:pkg/test/error_test_data/asymmetric_link_to_non_embedded_list.dart:12:25
+    ╷
+6   │ @RealmModel(ObjectType.asymmetricObject)
+7   │ class _Asymmetric {
+    │       ━━━━━━━━━━━ in realm model for 'Asymmetric'
+... │
+12  │   late List<_Symmetric> illegal;
+    │                         ^^^^^^^ !
+    ╵

--- a/generator/test/error_test_data/asymmetric_missing_pk.dart
+++ b/generator/test/error_test_data/asymmetric_missing_pk.dart
@@ -1,0 +1,8 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel(ObjectType.asymmetricObject)
+class _BadAsymmetric {
+  // missing @PrimaryKey()
+  @MapTo('_id')
+  late ObjectId id;
+}

--- a/generator/test/error_test_data/asymmetric_missing_pk.expected
+++ b/generator/test/error_test_data/asymmetric_missing_pk.expected
@@ -1,0 +1,10 @@
+Asymmetric objects must have a primary key named _id
+
+in: asset:pkg/test/error_test_data/asymmetric_missing_pk.dart:4:7
+  ╷
+3 │ @RealmModel(ObjectType.asymmetricObject)
+4 │ class _BadAsymmetric {
+  │       ^^^^^^^^^^^^^^
+  ╵
+Add a primary key named _id
+

--- a/generator/test/error_test_data/asymmetric_wrong_pk.dart
+++ b/generator/test/error_test_data/asymmetric_wrong_pk.dart
@@ -1,0 +1,7 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel(ObjectType.asymmetricObject)
+class _BadAsymmetric {
+  @PrimaryKey()
+  late ObjectId wrongName;
+}

--- a/generator/test/error_test_data/asymmetric_wrong_pk.expected
+++ b/generator/test/error_test_data/asymmetric_wrong_pk.expected
@@ -1,0 +1,13 @@
+Asymmetric objects must have a primary key named _id
+
+in: asset:pkg/test/error_test_data/asymmetric_wrong_pk.dart:6:17
+  ╷
+3 │ @RealmModel(ObjectType.asymmetricObject)
+4 │ class _BadAsymmetric {
+  │       ━━━━━━━━━━━━━━ in realm model for 'BadAsymmetric'
+5 │   @PrimaryKey()
+6 │   late ObjectId wrongName;
+  │                 ^^^^^^^^^ !
+  ╵
+Add @MapTo("_id") to the @PrimaryKey field
+

--- a/generator/test/good_test_data/asymmetric_object.dart
+++ b/generator/test/good_test_data/asymmetric_object.dart
@@ -1,0 +1,18 @@
+import 'package:realm_common/realm_common.dart';
+
+@RealmModel()
+class _Asymmetric {
+  @PrimaryKey()
+  @MapTo('_id')
+  late ObjectId id;
+
+  late List<_Embedded> children;
+  late _Embedded? farther;
+  late _Embedded? mother;
+}
+
+@RealmModel(ObjectType.embeddedObject)
+class _Embedded {
+  late String name;
+  late int age;
+}

--- a/generator/test/good_test_data/asymmetric_object.dart
+++ b/generator/test/good_test_data/asymmetric_object.dart
@@ -7,7 +7,7 @@ class _Asymmetric {
   late ObjectId id;
 
   late List<_Embedded> children;
-  late _Embedded? farther;
+  late _Embedded? father;
   late _Embedded? mother;
 }
 

--- a/generator/test/good_test_data/asymmetric_object.expected
+++ b/generator/test/good_test_data/asymmetric_object.expected
@@ -6,12 +6,12 @@ class Asymmetric extends _Asymmetric
     with RealmEntity, RealmObjectBase, RealmObject {
   Asymmetric(
     ObjectId id, {
-    Embedded? farther,
+    Embedded? father,
     Embedded? mother,
     Iterable<Embedded> children = const [],
   }) {
     RealmObjectBase.set(this, '_id', id);
-    RealmObjectBase.set(this, 'farther', farther);
+    RealmObjectBase.set(this, 'father', father);
     RealmObjectBase.set(this, 'mother', mother);
     RealmObjectBase.set<RealmList<Embedded>>(
         this, 'children', RealmList<Embedded>(children));
@@ -32,11 +32,11 @@ class Asymmetric extends _Asymmetric
       throw RealmUnsupportedSetError();
 
   @override
-  Embedded? get farther =>
-      RealmObjectBase.get<Embedded>(this, 'farther') as Embedded?;
+  Embedded? get father =>
+      RealmObjectBase.get<Embedded>(this, 'father') as Embedded?;
   @override
-  set farther(covariant Embedded? value) =>
-      RealmObjectBase.set(this, 'farther', value);
+  set father(covariant Embedded? value) =>
+      RealmObjectBase.set(this, 'father', value);
 
   @override
   Embedded? get mother =>
@@ -62,7 +62,7 @@ class Asymmetric extends _Asymmetric
           mapTo: '_id', primaryKey: true),
       SchemaProperty('children', RealmPropertyType.object,
           linkTarget: 'Embedded', collectionType: RealmCollectionType.list),
-      SchemaProperty('farther', RealmPropertyType.object,
+      SchemaProperty('father', RealmPropertyType.object,
           optional: true, linkTarget: 'Embedded'),
       SchemaProperty('mother', RealmPropertyType.object,
           optional: true, linkTarget: 'Embedded'),

--- a/generator/test/good_test_data/asymmetric_object.expected
+++ b/generator/test/good_test_data/asymmetric_object.expected
@@ -1,0 +1,112 @@
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class Asymmetric extends _Asymmetric
+    with RealmEntity, RealmObjectBase, RealmObject {
+  Asymmetric(
+    ObjectId id, {
+    Embedded? farther,
+    Embedded? mother,
+    Iterable<Embedded> children = const [],
+  }) {
+    RealmObjectBase.set(this, '_id', id);
+    RealmObjectBase.set(this, 'farther', farther);
+    RealmObjectBase.set(this, 'mother', mother);
+    RealmObjectBase.set<RealmList<Embedded>>(
+        this, 'children', RealmList<Embedded>(children));
+  }
+
+  Asymmetric._();
+
+  @override
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
+  @override
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
+
+  @override
+  RealmList<Embedded> get children =>
+      RealmObjectBase.get<Embedded>(this, 'children') as RealmList<Embedded>;
+  @override
+  set children(covariant RealmList<Embedded> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Embedded? get farther =>
+      RealmObjectBase.get<Embedded>(this, 'farther') as Embedded?;
+  @override
+  set farther(covariant Embedded? value) =>
+      RealmObjectBase.set(this, 'farther', value);
+
+  @override
+  Embedded? get mother =>
+      RealmObjectBase.get<Embedded>(this, 'mother') as Embedded?;
+  @override
+  set mother(covariant Embedded? value) =>
+      RealmObjectBase.set(this, 'mother', value);
+
+  @override
+  Stream<RealmObjectChanges<Asymmetric>> get changes =>
+      RealmObjectBase.getChanges<Asymmetric>(this);
+
+  @override
+  Asymmetric freeze() => RealmObjectBase.freezeObject<Asymmetric>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Asymmetric._);
+    return const SchemaObject(
+        ObjectType.realmObject, Asymmetric, 'Asymmetric', [
+      SchemaProperty('id', RealmPropertyType.objectid,
+          mapTo: '_id', primaryKey: true),
+      SchemaProperty('children', RealmPropertyType.object,
+          linkTarget: 'Embedded', collectionType: RealmCollectionType.list),
+      SchemaProperty('farther', RealmPropertyType.object,
+          optional: true, linkTarget: 'Embedded'),
+      SchemaProperty('mother', RealmPropertyType.object,
+          optional: true, linkTarget: 'Embedded'),
+    ]);
+  }
+}
+
+class Embedded extends _Embedded
+    with RealmEntity, RealmObjectBase, EmbeddedObject {
+  Embedded(
+    String name,
+    int age,
+  ) {
+    RealmObjectBase.set(this, 'name', name);
+    RealmObjectBase.set(this, 'age', age);
+  }
+
+  Embedded._();
+
+  @override
+  String get name => RealmObjectBase.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => RealmObjectBase.set(this, 'name', value);
+
+  @override
+  int get age => RealmObjectBase.get<int>(this, 'age') as int;
+  @override
+  set age(int value) => RealmObjectBase.set(this, 'age', value);
+
+  @override
+  Stream<RealmObjectChanges<Embedded>> get changes =>
+      RealmObjectBase.getChanges<Embedded>(this);
+
+  @override
+  Embedded freeze() => RealmObjectBase.freezeObject<Embedded>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Embedded._);
+    return const SchemaObject(ObjectType.embeddedObject, Embedded, 'Embedded', [
+      SchemaProperty('name', RealmPropertyType.string),
+      SchemaProperty('age', RealmPropertyType.int),
+    ]);
+  }
+}
+

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -769,6 +769,9 @@ class _RealmCore {
       case ObjectType.embeddedObject:
         type = EmbeddedObject;
         break;
+      case ObjectType.asymmetricObject:
+        type = AsymmetricObject;
+        break;
       default:
         throw RealmError('$baseType is not supported yet');
     }

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -279,7 +279,10 @@ class Realm implements Finalizable {
     return object;
   }
 
-  /// TODO
+  /// Ingest an [AsymmetricObject] to the [Realm].
+  ///
+  /// Ingesting is a write only operation. The ingested object will be dead immediately
+  /// after commit, but still transferred to the backend when possible.
   void ingest<T extends AsymmetricObject>(T object) {
     final metadata = _metadata.getByType(object.runtimeType);
     final handle = _createObject(object, metadata, false);

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -96,6 +96,7 @@ export 'set.dart' show RealmSet, RealmSetChanges, RealmSetOfObject;
 export 'migration.dart' show Migration;
 export 'realm_object.dart'
     show
+        AsymmetricObject,
         DynamicRealmObject,
         EmbeddedObject,
         EmbeddedObjectExtension,
@@ -276,6 +277,15 @@ class Realm implements Finalizable {
     object.manage(this, handle, accessor, update);
 
     return object;
+  }
+
+  /// TODO
+  void ingest<T extends AsymmetricObject>(T object) {
+    final metadata = _metadata.getByType(object.runtimeType);
+    final handle = _createObject(object, metadata, false);
+
+    final accessor = RealmCoreAccessor(metadata, _isInMigration);
+    object.manage(this, handle, accessor, false);
   }
 
   RealmObjectHandle _createObject(RealmObjectBase object, RealmObjectMetadata metadata, bool update) {

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -281,8 +281,9 @@ class Realm implements Finalizable {
 
   /// Ingest an [AsymmetricObject] to the [Realm].
   ///
-  /// Ingesting is a write only operation. The ingested object will be dead immediately
-  /// after commit, but still transferred to the backend when possible.
+  /// Ingesting is a write only operation. The ingested objects synchronizes to
+  /// the App Services backend and are deleted from the device. An [AsymmetricObject]
+  /// can never be read from the Realm.
   void ingest<T extends AsymmetricObject>(T object) {
     final metadata = _metadata.getByType(object.runtimeType);
     final handle = _createObject(object, metadata, false);

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -169,6 +169,8 @@ class RealmCoreAccessor implements RealmAccessor {
               return object.realm.createList<RealmObject>(handle, listMetadata);
             case ObjectType.embeddedObject:
               return object.realm.createList<EmbeddedObject>(handle, listMetadata);
+            case ObjectType.asymmetricObject:
+              return object.realm.createList<AsymmetricObject>(handle, listMetadata);
             default:
               throw RealmError('List of ${listMetadata.schema.baseType} is not supported yet');
           }
@@ -310,6 +312,7 @@ mixin RealmObjectBase on RealmEntity implements RealmObjectBaseMarker, Finalizab
     _typeOf<RealmObject?>(): () => _ConcreteRealmObject(),
     EmbeddedObject: () => _ConcreteEmbeddedObject(),
     _typeOf<EmbeddedObject?>(): () => _ConcreteEmbeddedObject(),
+    // We can never read asymmetric objects from a realm, so we don't need a factory for them.
   };
 
   /// @nodoc
@@ -455,6 +458,9 @@ mixin RealmObject on RealmObjectBase implements RealmObjectMarker {}
 
 /// @nodoc
 mixin EmbeddedObject on RealmObjectBase implements EmbeddedObjectMarker {}
+
+/// @nodoc
+mixin AsymmetricObject on RealmObjectBase implements AsymmetricObjectMarker {}
 
 extension EmbeddedObjectExtension on EmbeddedObject {
   /// Retrieve the [parent] object of this embedded object.
@@ -684,6 +690,8 @@ class DynamicRealmObject {
     _typeOf<RealmObject?>(): RealmPropertyType.object,
     EmbeddedObject: RealmPropertyType.object,
     _typeOf<EmbeddedObject?>(): RealmPropertyType.object,
+    AsymmetricObject: RealmPropertyType.object,
+    _typeOf<AsymmetricObject?>(): RealmPropertyType.object,
   };
 
   RealmPropertyType? _getPropertyType<T extends Object?>() => _propertyTypeMap[T];

--- a/lib/src/realm_object.dart
+++ b/lib/src/realm_object.dart
@@ -459,7 +459,15 @@ mixin RealmObject on RealmObjectBase implements RealmObjectMarker {}
 /// @nodoc
 mixin EmbeddedObject on RealmObjectBase implements EmbeddedObjectMarker {}
 
-/// @nodoc
+/// Base for any object that can be persisted in a [Realm], but cannot be retrieved,
+/// hence cannot be modified.
+///
+/// The benefit of using [AsymmetricObject] is that synchronization is one-way, and
+/// thus performs much better. However, they cannot be queried, or retrieved
+/// locally, which limits their use-cases greatly.
+///
+/// Use [AsymmetricObject] when you have a write-/only use case. You use it by
+/// parsing [ObjectType.asymmetricObject] to the [RealmModel] annotation.
 mixin AsymmetricObject on RealmObjectBase implements AsymmetricObjectMarker {}
 
 extension EmbeddedObjectExtension on EmbeddedObject {

--- a/lib/src/realm_property.dart
+++ b/lib/src/realm_property.dart
@@ -18,7 +18,7 @@
 
 import 'realm_class.dart';
 
-/// Describes a property on [RealmObject]/[EmbeddedObject] with its name, type and other attributes in the [RealmSchema]
+/// Describes a property on [RealmObjectBase] with its name, type and other attributes in the [RealmSchema]
 ///{@category Configuration}
 class SchemaProperty {
   /// The name of the property as persisted in the `Realm`

--- a/test/asymmetric_test.dart
+++ b/test/asymmetric_test.dart
@@ -111,6 +111,11 @@ Future<void> main([List<String>? args]) async {
     await realm.syncSession.waitForUpload();
   });
 
+  test("Asymmetric don't work local realms", () {
+    expect(() => Realm(Configuration.local([Asymmetric.schema, Embedded.schema, Symmetric.schema])),
+        throws<RealmException>("Asymmetric table 'Asymmetric' not allowed in a local Realm"));
+  });
+
   // TODO
   // Test that asymmetric objects are actually transferred to backend, once we have
   // a mongoClient to query the backend with.

--- a/test/asymmetric_test.dart
+++ b/test/asymmetric_test.dart
@@ -1,0 +1,117 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import 'package:test/expect.dart' hide throws;
+
+import '../lib/realm.dart';
+import 'test.dart';
+
+part 'asymmetric_test.g.dart';
+
+@RealmModel(ObjectType.asymmetricObject)
+class _Asymmetric {
+  @PrimaryKey()
+  @MapTo('_id')
+  late ObjectId id;
+
+  late List<_Embedded> embeddedObjects;
+}
+
+@RealmModel(ObjectType.embeddedObject)
+class _Embedded {
+  late int value;
+  late RealmValue any;
+  _Symmetric? symmetric;
+}
+
+@RealmModel()
+class _Symmetric {
+  @PrimaryKey()
+  @MapTo('_id')
+  late ObjectId id;
+}
+
+Future<void> main([List<String>? args]) async {
+  await setupTests(args);
+
+  Future<Realm> getSyncRealm(AppConfiguration config) async {
+    return await (AppConfiguration config, List<SchemaObject> schemas) async {
+      final app = App(config);
+      final user = await getAnonymousUser(app);
+      final realmConfig = Configuration.flexibleSync(user, schemas);
+      return getRealm(realmConfig);
+    }(config, [Asymmetric.schema, Embedded.schema, Symmetric.schema]);
+  }
+
+  baasTest('Asymmetric objects die even before upload', (config) async {
+    final realm = await getSyncRealm(config);
+    realm.syncSession.pause();
+
+    final oid = ObjectId();
+    realm.write(() {
+      realm.ingest(Asymmetric(oid, embeddedObjects: [1, 2, 3].map(Embedded.new)));
+    });
+
+    // Find & query on an Asymmetric object is compile time error, but you can cheat with dynamic
+    expect(realm.dynamic.find('Asymmetric', oid), null); // should this throw instead?
+    expect(() => realm.dynamic.all('Asymmetric'), throws<RealmException>('Query on ephemeral objects not allowed'));
+
+    realm.syncSession.resume();
+    await realm.syncSession.waitForUpload();
+  });
+
+  baasTest('Asymmetric re-add same PK', (config) async {
+    final realm = await getSyncRealm(config);
+
+    final oid = ObjectId();
+    realm.write(() {
+      realm.ingest(Asymmetric(oid, embeddedObjects: [1, 2, 3].map(Embedded.new)));
+      expect(() => realm.ingest(Asymmetric(oid, embeddedObjects: [1, 2, 3, 4].map(Embedded.new))),
+          throws<RealmException>("Attempting to create an object of type 'Asymmetric' with an existing primary key value"));
+    });
+
+    realm.write(() {
+      // okay to ingest again in another transaction, because object already dead to us
+      realm.ingest(Asymmetric(oid, embeddedObjects: [1, 2, 3, 5].map(Embedded.new)));
+    });
+
+    await realm.syncSession.waitForUpload();
+  });
+
+  baasTest('Asymmetric tricks to add non-embedded links', (config) async {
+    final realm = await getSyncRealm(config);
+
+    realm.subscriptions.update((mutableSubscriptions) {
+      mutableSubscriptions.add(realm.all<Symmetric>());
+    });
+
+    realm.write(() {
+      final s = realm.add(Symmetric(ObjectId()));
+      // Since this shenanigan is allowed, I have opened a feature request to allow
+      // direct links on a symmetric objects. See https://github.com/realm/realm-core/issues/6976.
+      realm.ingest(Asymmetric(ObjectId(), embeddedObjects: [Embedded(1, symmetric: s)]));
+      realm.ingest(Asymmetric(ObjectId(), embeddedObjects: [Embedded(1, any: RealmValue.from(s))]));
+    });
+
+    await realm.syncSession.waitForUpload();
+  });
+
+  // TODO
+  // Test that asymmetric objects are actually transferred to backend, once we have
+  // a mongoClient to query the backend with.
+}

--- a/test/asymmetric_test.dart
+++ b/test/asymmetric_test.dart
@@ -68,7 +68,7 @@ Future<void> main([List<String>? args]) async {
     });
 
     // Find & query on an Asymmetric object is compile time error, but you can cheat with dynamic
-    expect(realm.dynamic.find('Asymmetric', oid), null); // should this throw instead?
+    expect(realm.dynamic.find('Asymmetric', oid), null);
     expect(() => realm.dynamic.all('Asymmetric'), throws<RealmException>('Query on ephemeral objects not allowed'));
 
     realm.syncSession.resume();

--- a/test/asymmetric_test.dart
+++ b/test/asymmetric_test.dart
@@ -50,12 +50,10 @@ Future<void> main([List<String>? args]) async {
   await setupTests(args);
 
   Future<Realm> getSyncRealm(AppConfiguration config) async {
-    return await (AppConfiguration config, List<SchemaObject> schemas) async {
-      final app = App(config);
-      final user = await getAnonymousUser(app);
-      final realmConfig = Configuration.flexibleSync(user, schemas);
-      return getRealm(realmConfig);
-    }(config, [Asymmetric.schema, Embedded.schema, Symmetric.schema]);
+    final app = App(config);
+    final user = await getAnonymousUser(app);
+    final realmConfig = Configuration.flexibleSync(user, [Asymmetric.schema, Embedded.schema, Symmetric.schema]);
+    return getRealm(realmConfig);
   }
 
   baasTest('Asymmetric objects die even before upload', (config) async {
@@ -114,6 +112,11 @@ Future<void> main([List<String>? args]) async {
   test("Asymmetric don't work local realms", () {
     expect(() => Realm(Configuration.local([Asymmetric.schema, Embedded.schema, Symmetric.schema])),
         throws<RealmException>("Asymmetric table 'Asymmetric' not allowed in a local Realm"));
+  });
+
+  test("Asymmetric don't work with disconnectedSync", () {
+    final config = Configuration.disconnectedSync([Asymmetric.schema, Embedded.schema, Symmetric.schema], path: 'asymmetric_disconnected.realm');
+    expect(() => Realm(config), throws<RealmException>());
   });
 
   // TODO

--- a/test/asymmetric_test.g.dart
+++ b/test/asymmetric_test.g.dart
@@ -1,0 +1,139 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'asymmetric_test.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class Asymmetric extends _Asymmetric
+    with RealmEntity, RealmObjectBase, AsymmetricObject {
+  Asymmetric(
+    ObjectId id, {
+    Iterable<Embedded> embeddedObjects = const [],
+  }) {
+    RealmObjectBase.set(this, '_id', id);
+    RealmObjectBase.set<RealmList<Embedded>>(
+        this, 'embeddedObjects', RealmList<Embedded>(embeddedObjects));
+  }
+
+  Asymmetric._();
+
+  @override
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
+  @override
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
+
+  @override
+  RealmList<Embedded> get embeddedObjects =>
+      RealmObjectBase.get<Embedded>(this, 'embeddedObjects')
+          as RealmList<Embedded>;
+  @override
+  set embeddedObjects(covariant RealmList<Embedded> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<Asymmetric>> get changes =>
+      RealmObjectBase.getChanges<Asymmetric>(this);
+
+  @override
+  Asymmetric freeze() => RealmObjectBase.freezeObject<Asymmetric>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Asymmetric._);
+    return const SchemaObject(
+        ObjectType.asymmetricObject, Asymmetric, 'Asymmetric', [
+      SchemaProperty('id', RealmPropertyType.objectid,
+          mapTo: '_id', primaryKey: true),
+      SchemaProperty('embeddedObjects', RealmPropertyType.object,
+          linkTarget: 'Embedded', collectionType: RealmCollectionType.list),
+    ]);
+  }
+}
+
+class Embedded extends _Embedded
+    with RealmEntity, RealmObjectBase, EmbeddedObject {
+  Embedded(
+    int value, {
+    RealmValue any = const RealmValue.nullValue(),
+    Symmetric? symmetric,
+  }) {
+    RealmObjectBase.set(this, 'value', value);
+    RealmObjectBase.set(this, 'any', any);
+    RealmObjectBase.set(this, 'symmetric', symmetric);
+  }
+
+  Embedded._();
+
+  @override
+  int get value => RealmObjectBase.get<int>(this, 'value') as int;
+  @override
+  set value(int value) => RealmObjectBase.set(this, 'value', value);
+
+  @override
+  RealmValue get any =>
+      RealmObjectBase.get<RealmValue>(this, 'any') as RealmValue;
+  @override
+  set any(RealmValue value) => RealmObjectBase.set(this, 'any', value);
+
+  @override
+  Symmetric? get symmetric =>
+      RealmObjectBase.get<Symmetric>(this, 'symmetric') as Symmetric?;
+  @override
+  set symmetric(covariant Symmetric? value) =>
+      RealmObjectBase.set(this, 'symmetric', value);
+
+  @override
+  Stream<RealmObjectChanges<Embedded>> get changes =>
+      RealmObjectBase.getChanges<Embedded>(this);
+
+  @override
+  Embedded freeze() => RealmObjectBase.freezeObject<Embedded>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Embedded._);
+    return const SchemaObject(ObjectType.embeddedObject, Embedded, 'Embedded', [
+      SchemaProperty('value', RealmPropertyType.int),
+      SchemaProperty('any', RealmPropertyType.mixed, optional: true),
+      SchemaProperty('symmetric', RealmPropertyType.object,
+          optional: true, linkTarget: 'Symmetric'),
+    ]);
+  }
+}
+
+class Symmetric extends _Symmetric
+    with RealmEntity, RealmObjectBase, RealmObject {
+  Symmetric(
+    ObjectId id,
+  ) {
+    RealmObjectBase.set(this, '_id', id);
+  }
+
+  Symmetric._();
+
+  @override
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
+  @override
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
+
+  @override
+  Stream<RealmObjectChanges<Symmetric>> get changes =>
+      RealmObjectBase.getChanges<Symmetric>(this);
+
+  @override
+  Symmetric freeze() => RealmObjectBase.freezeObject<Symmetric>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Symmetric._);
+    return const SchemaObject(ObjectType.realmObject, Symmetric, 'Symmetric', [
+      SchemaProperty('id', RealmPropertyType.objectid,
+          mapTo: '_id', primaryKey: true),
+    ]);
+  }
+}


### PR DESCRIPTION
Support asymmetric objects
```dart
@RealmModel(ObjectType.asymmetricObject)
class _Asymmetric {
  @PrimaryKey()
  @MapTo('_id')
  late ObjectId id;

  late List<_Embedded> embeddedObjects;
}
// ...    
realm.write(() {
  realm.ingest(Asymmetric(oid));
});
```

Fixes: #917 