### PR TITLE
upgrade AGP to 8.0+, added namespace property

### DIFF
--- a/flutter/realm_flutter/android/build.gradle
+++ b/flutter/realm_flutter/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.1.2'
     }
 }
 
@@ -23,6 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    namespace "io.realm"
 
     defaultConfig {
         minSdkVersion 16

--- a/flutter/realm_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter/realm_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
This PR aims to resolve missing namespace issues when upgrading apps to AGP 8.

Issue: https://github.com/realm/realm-dart/issues/1388

NOTE: I was not able to test the changes as I couldn't build the realm locally. I did follow the contributing guide but the command to generate realm flutter native binaries does not fully work for me.  Some logs are attached below:
https://katb.in/realmscriptlogs

Could anyone have a go at this PR and test it on their machine? or any solution for my logs

Steps to check:
1. Create a fresh vanilla flutter project
2. Upgrade the android gradle plugin to 8.0+ via manual/upgrade assistant
3. Add realm with these PR changes
4. Test