### PR TITLE
Handle duplicate certificates

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -64,9 +64,18 @@ he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
 Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 -----END CERTIFICATE-----''';
 
-  final context = SecurityContext(withTrustedRoots: true);
-  context.setTrustedCertificatesBytes(const AsciiEncoder().convert(isrgRootX1CertPEM));
-  return HttpClient(context: context);
+  try {
+    final context = SecurityContext(withTrustedRoots: true);
+    context.setTrustedCertificatesBytes(const AsciiEncoder().convert(isrgRootX1CertPEM));
+    return HttpClient(context: context);
+  } on TlsException catch (e) {
+    if (e.osError?.message.contains("CERT_ALREADY_IN_HASH_TABLE") == true) {
+      // certificate is already trusted. Nothing to do here
+      return HttpClient();
+    } else {
+      rethrow;
+    }
+  }
 }();
 
 /// A class exposing configuration options for an [App]


### PR DESCRIPTION
Follow up on https://github.com/realm/realm-dart/pull/1378 to handle the case where the certificate is already present on the machine.