### PR TITLE
Use default context rather than creating a new one

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -65,7 +65,7 @@ Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 -----END CERTIFICATE-----''';
 
   try {
-    final context = SecurityContext(withTrustedRoots: true);
+    final context = SecurityContext.defaultContext;
     context.setTrustedCertificatesBytes(const AsciiEncoder().convert(isrgRootX1CertPEM));
     return HttpClient(context: context);
   } on TlsException catch (e) {


### PR DESCRIPTION
This appears to have caused issues on Android where we would get certificate validation errors.