### PR TITLE
Don't emit code for empty files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* Fixed warnings being emitted by the realm generator requesting that `xyz.g.dart` be included with `part 'xyz.g.dart';` for `xyz.dart` files that import `realm` but don't have realm models defined. Those should not need generated parts and including the part file would have resulted in an empty file with `// ignore_for_file: type=lint` being generated. (PR [#1443](https://github.com/realm/realm-dart/pull/1443))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/generator/lib/src/realm_object_generator.dart
+++ b/generator/lib/src/realm_object_generator.dart
@@ -56,10 +56,15 @@ class RealmObjectGenerator extends Generator {
     return await measure(
       () async {
         final result = await _getResolvedLibrary(library.element, buildStep.resolver);
+
         return scopeSession(
           result,
           () {
-            return ['// ignore_for_file: type=lint', ...library.classes.realmInfo.expand((m) => m.toCode())].join('\n');
+            final codeLines = library.classes.realmInfo.expand((m) => m.toCode())..toList();
+            if (codeLines.isEmpty) {
+              return '';
+            }
+            return ['// ignore_for_file: type=lint', ...codeLines].join('\n');
           },
           color: stdout.supportsAnsiEscapes,
         );


### PR DESCRIPTION
https://github.com/realm/realm-dart/pull/1438 introduced a regression where we would emit `// ignore_for_file: type=lint` for every file, even those that don't have any realm models, resulting in warnings like:

```
xyz.g.dart must be included as a part directive in the input library with:
part 'xyz.g.dart';
```

for files that don't contain models and should not have needed part files.