### PR TITLE
Rework app isolate API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* Reworked how creating an `App` instance works across isolates:
+  * The `App(AppConfiguration)` constructor should only be used on the main isolate. Ideally, it should be called once as soon as your app launches. If you attempt to use it on a background isolate (as indicated by `Isolate.debugName` being different from `main`), a warning will be logged.
+  * Added a new method - `App.getById` that allows you to obtain an already constructed app on a background isolate.
+  (Issue [#1433](https://github.com/realm/realm-dart/issues/1433))
 
 ### Fixed
 * Fixed warnings being emitted by the realm generator requesting that `xyz.g.dart` be included with `part 'xyz.g.dart';` for `xyz.dart` files that import `realm` but don't have realm models defined. Those should not need generated parts and including the part file would have resulted in an empty file with `// ignore_for_file: type=lint` being generated. (PR [#1443](https://github.com/realm/realm-dart/pull/1443))

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -404,6 +404,28 @@ class RealmLibrary {
       ffi.Pointer<realm_app_t> Function(ffi.Pointer<realm_app_config_t>,
           ffi.Pointer<realm_sync_client_config_t>)>();
 
+  /// Create cached realm_app_t* instance given a valid realm configuration and sync client configuration.
+  ///
+  /// @return A non-null pointer if no error occurred.
+  ffi.Pointer<realm_app_t> realm_app_create_cached(
+    ffi.Pointer<realm_app_config_t> arg0,
+    ffi.Pointer<realm_sync_client_config_t> arg1,
+  ) {
+    return _realm_app_create_cached(
+      arg0,
+      arg1,
+    );
+  }
+
+  late final _realm_app_create_cachedPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<realm_app_t> Function(ffi.Pointer<realm_app_config_t>,
+                  ffi.Pointer<realm_sync_client_config_t>)>>(
+      'realm_app_create_cached');
+  late final _realm_app_create_cached = _realm_app_create_cachedPtr.asFunction<
+      ffi.Pointer<realm_app_t> Function(ffi.Pointer<realm_app_config_t>,
+          ffi.Pointer<realm_sync_client_config_t>)>();
+
   ffi.Pointer<realm_app_credentials_t> realm_app_credentials_new_anonymous(
     bool reuse_credentials,
   ) {
@@ -991,6 +1013,27 @@ class RealmLibrary {
               ffi.Pointer<realm_app_t>)>>('realm_app_get_app_id');
   late final _realm_app_get_app_id = _realm_app_get_app_idPtr
       .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<realm_app_t>)>();
+
+  /// Get a cached realm_app_t* instance given an app id.
+  ///
+  /// @return A non-null pointer if no error occurred.
+  ffi.Pointer<realm_app_t> realm_app_get_cached(
+    ffi.Pointer<ffi.Char> app_id,
+    ffi.Pointer<ffi.Char> base_url,
+  ) {
+    return _realm_app_get_cached(
+      app_id,
+      base_url,
+    );
+  }
+
+  late final _realm_app_get_cachedPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<realm_app_t> Function(ffi.Pointer<ffi.Char>,
+              ffi.Pointer<ffi.Char>)>>('realm_app_get_cached');
+  late final _realm_app_get_cached = _realm_app_get_cachedPtr.asFunction<
+      ffi.Pointer<realm_app_t> Function(
+          ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Char>)>();
 
   ffi.Pointer<realm_user_t> realm_app_get_current_user(
     ffi.Pointer<realm_app_t> arg0,

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -1874,8 +1874,15 @@ class _RealmCore {
     final httpTransportHandle = _createHttpTransport(configuration.httpClient);
     final appConfigHandle = _createAppConfig(configuration, httpTransportHandle);
     final syncClientConfigHandle = _createSyncClientConfig(configuration);
-    final realmAppPtr = _realmLib.invokeGetPointer(() => _realmLib.realm_app_create(appConfigHandle._pointer, syncClientConfigHandle._pointer));
+    final realmAppPtr = _realmLib.invokeGetPointer(() => _realmLib.realm_app_create_cached(appConfigHandle._pointer, syncClientConfigHandle._pointer));
     return AppHandle._(realmAppPtr);
+  }
+
+  AppHandle? getApp(String id, String? baseUrl) {
+    return using((arena) {
+      final ptr = _realmLib.realm_app_get_cached(id.toCharPtr(arena), baseUrl == null ? nullptr : baseUrl.toCharPtr(arena));
+      return ptr == nullptr ? null : AppHandle._(ptr);
+    });
   }
 
   String appGetId(App app) {

--- a/test/test.dart
+++ b/test/test.dart
@@ -651,6 +651,8 @@ Future<void> _waitForInitialSync() async {
     } catch (e) {
       print(e);
       await _waitForInitialSync();
+    } finally {
+      clearCachedApps();
     }
   }
 }


### PR DESCRIPTION
* Adds `App.getById` to be used on background isolates.
* Pulls in https://github.com/realm/realm-core/pull/7182 to start constructing cached apps.
* Logs a warning when `App(AppConfiguration)` is used outside of the main isolate.