### PR TITLE
Remember '?'

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -190,7 +190,7 @@ class App implements Finalizable {
   /// on the main isolate. If an App hasn't been already constructed with the same id, will return null. This method is safe to call
   /// on a background isolate.
   static App? getById(String id, {Uri? baseUrl}) {
-    final handle = realmCore.getApp(id, baseUrl.toString());
+    final handle = realmCore.getApp(id, baseUrl?.toString());
     return handle == null ? null : App._(handle);
   }
 


### PR DESCRIPTION
This little bug causes cached apps to be retrieved with an baseUrl of `"null"` instead of `null`, when no explicit url is given.