### PR TITLE
Fix use of http transport from background isolate

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,12 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Attach",
+            "type": "lldb",
+            "request": "attach",
+            "pid": "${command:pickProcess}",
+        },
+        {
             "name": "Flutter: Attach to Device",
             "type": "dart",
             "request": "attach"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -153,6 +153,13 @@
     "__mutex_base": "cpp",
     "coroutine": "cpp",
     "ranges": "cpp",
-    "span": "cpp"
+    "span": "cpp",
+    "__bit_reference": "cpp",
+    "__bits": "cpp",
+    "__config": "cpp",
+    "__debug": "cpp",
+    "__split_buffer": "cpp",
+    "__tuple": "cpp",
+    "__verbose_abort": "cpp"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
   },
   "dart.lineLength": 160,
   "cSpell.words": [
+    "apikey",
     "apikeys",
     "backlinks",
     "BEGINSWITH",

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3192,6 +3192,36 @@ class RealmLibrary {
               ffi.Pointer<realm_app_user_apikey_t>,
               ffi.Pointer<realm_app_error_t>)>();
 
+  void realm_dart_apikey_list_callback(
+    ffi.Pointer<ffi.Void> userdata,
+    ffi.Pointer<realm_app_user_apikey_t> apikey_list,
+    int count,
+    ffi.Pointer<realm_app_error_t> error,
+  ) {
+    return _realm_dart_apikey_list_callback(
+      userdata,
+      apikey_list,
+      count,
+      error,
+    );
+  }
+
+  late final _realm_dart_apikey_list_callbackPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<ffi.Void>,
+                  ffi.Pointer<realm_app_user_apikey_t>,
+                  ffi.Size,
+                  ffi.Pointer<realm_app_error_t>)>>(
+      'realm_dart_apikey_list_callback');
+  late final _realm_dart_apikey_list_callback =
+      _realm_dart_apikey_list_callbackPtr.asFunction<
+          void Function(
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<realm_app_user_apikey_t>,
+              int,
+              ffi.Pointer<realm_app_error_t>)>();
+
   void realm_dart_async_open_task_callback(
     ffi.Pointer<ffi.Void> userdata,
     ffi.Pointer<realm_thread_safe_reference_t> realm,
@@ -11092,6 +11122,15 @@ class _SymbolAddresses {
                   ffi.Pointer<realm_app_user_apikey_t>,
                   ffi.Pointer<realm_app_error_t>)>>
       get realm_dart_apikey_callback => _library._realm_dart_apikey_callbackPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<ffi.Void>,
+                  ffi.Pointer<realm_app_user_apikey_t>,
+                  ffi.Size,
+                  ffi.Pointer<realm_app_error_t>)>>
+      get realm_dart_apikey_list_callback =>
+          _library._realm_dart_apikey_list_callbackPtr;
   ffi.Pointer<
           ffi.NativeFunction<
               ffi.Void Function(

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3746,6 +3746,28 @@ class RealmLibrary {
   late final _realm_dart_release_logger =
       _realm_dart_release_loggerPtr.asFunction<void Function(int)>();
 
+  void realm_dart_return_string_callback(
+    ffi.Pointer<ffi.Void> userdata,
+    ffi.Pointer<ffi.Char> serialized_ejson_response,
+    ffi.Pointer<realm_app_error_t> arg2,
+  ) {
+    return _realm_dart_return_string_callback(
+      userdata,
+      serialized_ejson_response,
+      arg2,
+    );
+  }
+
+  late final _realm_dart_return_string_callbackPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>,
+                  ffi.Pointer<realm_app_error_t>)>>(
+      'realm_dart_return_string_callback');
+  late final _realm_dart_return_string_callback =
+      _realm_dart_return_string_callbackPtr.asFunction<
+          void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>,
+              ffi.Pointer<realm_app_error_t>)>();
+
   void realm_dart_scheduler_invoke(
     int isolateId,
     ffi.Pointer<ffi.Void> userData,
@@ -11261,6 +11283,12 @@ class _SymbolAddresses {
           _library._realm_dart_persistent_handle_to_objectPtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(Dart_Port)>>
       get realm_dart_release_logger => _library._realm_dart_release_loggerPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>,
+                  ffi.Pointer<realm_app_error_t>)>>
+      get realm_dart_return_string_callback =>
+          _library._realm_dart_return_string_callbackPtr;
   ffi.Pointer<
           ffi
           .NativeFunction<ffi.Void Function(ffi.Uint64, ffi.Pointer<ffi.Void>)>>

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3889,6 +3889,28 @@ class RealmLibrary {
       _realm_dart_sync_wait_for_completion_callbackPtr.asFunction<
           void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<realm_error_t>)>();
 
+  void realm_dart_user_completion_callback(
+    ffi.Pointer<ffi.Void> userdata,
+    ffi.Pointer<realm_user_t> user,
+    ffi.Pointer<realm_app_error_t> error,
+  ) {
+    return _realm_dart_user_completion_callback(
+      userdata,
+      user,
+      error,
+    );
+  }
+
+  late final _realm_dart_user_completion_callbackPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<ffi.Void>,
+                  ffi.Pointer<realm_user_t>, ffi.Pointer<realm_app_error_t>)>>(
+      'realm_dart_user_completion_callback');
+  late final _realm_dart_user_completion_callback =
+      _realm_dart_user_completion_callbackPtr.asFunction<
+          void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<realm_user_t>,
+              ffi.Pointer<realm_app_error_t>)>();
+
   void realm_dart_userdata_async_free(
     ffi.Pointer<ffi.Void> userdata,
   ) {
@@ -11201,6 +11223,12 @@ class _SymbolAddresses {
                   ffi.Pointer<ffi.Void>, ffi.Pointer<realm_error_t>)>>
       get realm_dart_sync_wait_for_completion_callback =>
           _library._realm_dart_sync_wait_for_completion_callbackPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<ffi.Void>,
+                  ffi.Pointer<realm_user_t>, ffi.Pointer<realm_app_error_t>)>>
+      get realm_dart_user_completion_callback =>
+          _library._realm_dart_user_completion_callbackPtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
       get realm_dart_userdata_async_free =>
           _library._realm_dart_userdata_async_freePtr;

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3948,6 +3948,26 @@ class RealmLibrary {
           realm_dart_userdata_async_t Function(
               Object, ffi.Pointer<ffi.Void>, ffi.Pointer<realm_scheduler_t>)>();
 
+  void realm_dart_void_completion_callback(
+    ffi.Pointer<ffi.Void> userdata,
+    ffi.Pointer<realm_app_error_t> error,
+  ) {
+    return _realm_dart_void_completion_callback(
+      userdata,
+      error,
+    );
+  }
+
+  late final _realm_dart_void_completion_callbackPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<ffi.Void>, ffi.Pointer<realm_app_error_t>)>>(
+      'realm_dart_void_completion_callback');
+  late final _realm_dart_void_completion_callback =
+      _realm_dart_void_completion_callbackPtr.asFunction<
+          void Function(
+              ffi.Pointer<ffi.Void>, ffi.Pointer<realm_app_error_t>)>();
+
   Object realm_dart_weak_handle_to_object(
     ffi.Pointer<ffi.Void> handle,
   ) {
@@ -11238,6 +11258,12 @@ class _SymbolAddresses {
                   ffi.Pointer<ffi.Void>, ffi.Pointer<realm_scheduler_t>)>>
       get realm_dart_userdata_async_new =>
           _library._realm_dart_userdata_async_newPtr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<ffi.Void>, ffi.Pointer<realm_app_error_t>)>>
+      get realm_dart_void_completion_callback =>
+          _library._realm_dart_void_completion_callbackPtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Handle Function(ffi.Pointer<ffi.Void>)>>
       get realm_dart_weak_handle_to_object =>
           _library._realm_dart_weak_handle_to_objectPtr;

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3749,12 +3749,12 @@ class RealmLibrary {
   void realm_dart_return_string_callback(
     ffi.Pointer<ffi.Void> userdata,
     ffi.Pointer<ffi.Char> serialized_ejson_response,
-    ffi.Pointer<realm_app_error_t> arg2,
+    ffi.Pointer<realm_app_error_t> error,
   ) {
     return _realm_dart_return_string_callback(
       userdata,
       serialized_ejson_response,
-      arg2,
+      error,
     );
   }
 

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3167,6 +3167,31 @@ class RealmLibrary {
           ffi.Pointer<realm_thread_safe_reference_t> Function(
               ffi.Pointer<ffi.Void>)>();
 
+  void realm_dart_apikey_callback(
+    ffi.Pointer<ffi.Void> userdata,
+    ffi.Pointer<realm_app_user_apikey_t> apikey,
+    ffi.Pointer<realm_app_error_t> error,
+  ) {
+    return _realm_dart_apikey_callback(
+      userdata,
+      apikey,
+      error,
+    );
+  }
+
+  late final _realm_dart_apikey_callbackPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<realm_app_user_apikey_t>,
+              ffi.Pointer<realm_app_error_t>)>>('realm_dart_apikey_callback');
+  late final _realm_dart_apikey_callback =
+      _realm_dart_apikey_callbackPtr.asFunction<
+          void Function(
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<realm_app_user_apikey_t>,
+              ffi.Pointer<realm_app_error_t>)>();
+
   void realm_dart_async_open_task_callback(
     ffi.Pointer<ffi.Void> userdata,
     ffi.Pointer<realm_thread_safe_reference_t> realm,
@@ -11060,6 +11085,13 @@ class RealmLibrary {
 class _SymbolAddresses {
   final RealmLibrary _library;
   _SymbolAddresses(this._library);
+  ffi.Pointer<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<ffi.Void>,
+                  ffi.Pointer<realm_app_user_apikey_t>,
+                  ffi.Pointer<realm_app_error_t>)>>
+      get realm_dart_apikey_callback => _library._realm_dart_apikey_callbackPtr;
   ffi.Pointer<
           ffi.NativeFunction<
               ffi.Void Function(

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -524,10 +524,7 @@ class _RealmCore {
   static bool initial_data_callback(Pointer<Void> userdata, Pointer<shared_realm> realmPtr) {
     final realmHandle = RealmHandle._unowned(realmPtr);
     try {
-      final LocalConfiguration? config = userdata.toObject();
-      if (config == null) {
-        return false;
-      }
+      final LocalConfiguration config = userdata.toObject();
       final realm = RealmInternal.getUnowned(config, realmHandle);
       config.initialDataCallback!(realm);
       return true;
@@ -541,7 +538,7 @@ class _RealmCore {
   }
 
   static bool should_compact_callback(Pointer<Void> userdata, int totalSize, int usedSize) {
-    Object? config = userdata.toObject();
+    final config = userdata.toObject();
 
     if (config is LocalConfiguration) {
       return config.shouldCompactCallback!(totalSize, usedSize);
@@ -557,10 +554,7 @@ class _RealmCore {
     final oldHandle = RealmHandle._unowned(oldRealmHandle);
     final newHandle = RealmHandle._unowned(newRealmHandle);
     try {
-      final LocalConfiguration? config = userdata.toObject();
-      if (config == null) {
-        return false;
-      }
+      final LocalConfiguration config = userdata.toObject();
 
       final oldSchemaVersion = _realmLib.realm_get_schema_version(oldRealmHandle);
       final oldConfig = Configuration.local([], path: config.path, isReadOnly: true, schemaVersion: oldSchemaVersion);
@@ -899,20 +893,12 @@ class _RealmCore {
   }
 
   static void _completeAsyncBeginWrite(Pointer<Void> userdata) {
-    Completer<void>? completer = userdata.toObject(isPersistent: true);
-    if (completer == null) {
-      return;
-    }
-
+    final Completer<void> completer = userdata.toObject(isPersistent: true);
     completer.complete();
   }
 
   static void _completeAsyncCommit(Pointer<Void> userdata, bool error, Pointer<Char> description) {
-    Completer<void>? completer = userdata.toObject(isPersistent: true);
-    if (completer == null) {
-      return;
-    }
-
+    final Completer<void> completer = userdata.toObject(isPersistent: true);
     if (error) {
       completer.completeError(RealmException(description.cast<Utf8>().toDartString()));
     } else {
@@ -1679,10 +1665,7 @@ class _RealmCore {
   }
 
   static void collection_change_callback(Pointer<Void> userdata, Pointer<realm_collection_changes> data) {
-    NotificationsController? controller = userdata.toObject();
-    if (controller == null) {
-      return;
-    }
+    final NotificationsController controller = userdata.toObject();
 
     if (data == nullptr) {
       controller.onError(RealmError("Invalid notifications data received"));
@@ -1704,10 +1687,7 @@ class _RealmCore {
   }
 
   static void object_change_callback(Pointer<Void> userdata, Pointer<realm_object_changes> data) {
-    NotificationsController? controller = userdata.toObject();
-    if (controller == null) {
-      return;
-    }
+    final NotificationsController controller = userdata.toObject();
 
     if (data == nullptr) {
       controller.onError(RealmError("Invalid notifications data received"));
@@ -1729,10 +1709,7 @@ class _RealmCore {
   }
 
   static void map_change_callback(Pointer<Void> userdata, Pointer<realm_dictionary_changes> data) {
-    NotificationsController? controller = userdata.toObject();
-    if (controller == null) {
-      return;
-    }
+    final NotificationsController controller = userdata.toObject();
 
     if (data == nullptr) {
       controller.onError(RealmError("Invalid notifications data received"));
@@ -1908,8 +1885,6 @@ class _RealmCore {
   }
 
   RealmHttpTransportHandle _createHttpTransport(HttpClient httpClient) {
-    print('_createHttpTransport ${isolate.asDebugString}');
-
     final requestCallback = Pointer.fromFunction<Void Function(Handle, realm_http_request, Pointer<Void>)>(_request_callback);
     final requestCallbackUserdata = _realmLib.realm_dart_userdata_async_new(httpClient, requestCallback.cast(), scheduler.handle._pointer);
     return RealmHttpTransportHandle._(_realmLib.realm_http_transport_new(
@@ -1920,8 +1895,6 @@ class _RealmCore {
   }
 
   static void _request_callback(Object userData, realm_http_request request, Pointer<Void> request_context) {
-    print('_request_callback ${isolate.asDebugString}');
-
     //
     // The request struct only survives until end-of-call, even though
     // we explicitly call realm_http_transport_complete_request to
@@ -1959,8 +1932,6 @@ class _RealmCore {
     Map<String, String> headers,
     Pointer<Void> request_context,
   ) async {
-    print('_request_callback_async ${isolate.asDebugString}');
-
     await using((arena) async {
       final response_pointer = arena<realm_http_response>();
       final responseRef = response_pointer.ref;
@@ -2116,8 +2087,6 @@ class _RealmCore {
   }
 
   Future<UserHandle> logIn(App app, Credentials credentials) {
-    print(isolate.asDebugString);
-
     final completer = Completer<UserHandle>();
     final userCompletionCallback = Pointer.fromFunction<
         Void Function(
@@ -2148,11 +2117,7 @@ class _RealmCore {
   }
 
   static void void_completion_callback(Pointer<Void> userdata, Pointer<realm_app_error> error) {
-    print(isolate.asDebugString);
-    final Completer<void>? completer = userdata.toObject(isPersistent: true);
-    if (completer == null) {
-      return;
-    }
+    final Completer<void> completer = userdata.toObject(isPersistent: true);
 
     if (error != nullptr) {
       completer.completeWithAppError(error);
@@ -2275,10 +2240,7 @@ class _RealmCore {
   }
 
   static void _logOutCallback(Pointer<Void> userdata, Pointer<realm_app_error> error) {
-    final Completer<void>? completer = userdata.toObject(isPersistent: true);
-    if (completer == null) {
-      return;
-    }
+    final Completer<void> completer = userdata.toObject(isPersistent: true);
 
     if (error != nullptr) {
       completer.completeWithAppError(error);
@@ -2758,10 +2720,7 @@ class _RealmCore {
   }
 
   static void _app_api_key_completion_callback(Pointer<Void> userdata, Pointer<realm_app_user_apikey> apiKey, Pointer<realm_app_error> error) {
-    final Completer<ApiKey>? completer = userdata.toObject(isPersistent: true);
-    if (completer == null) {
-      return;
-    }
+    final Completer<ApiKey> completer = userdata.toObject(isPersistent: true);
 
     if (error != nullptr) {
       completer.completeWithAppError(error);
@@ -2777,10 +2736,7 @@ class _RealmCore {
   }
 
   static void _app_api_key_array_completion_callback(Pointer<Void> userdata, Pointer<realm_app_user_apikey> apiKey, int size, Pointer<realm_app_error> error) {
-    final Completer<List<ApiKey>>? completer = userdata.toObject(isPersistent: true);
-    if (completer == null) {
-      return;
-    }
+    final Completer<List<ApiKey>> completer = userdata.toObject(isPersistent: true);
 
     if (error != nullptr) {
       completer.completeWithAppError(error);
@@ -2876,10 +2832,8 @@ class _RealmCore {
   }
 
   static void _call_app_function_callback(Pointer<Void> userdata, Pointer<Char> response, Pointer<realm_app_error> error) {
-    final Completer<String>? completer = userdata.toObject(isPersistent: true);
-    if (completer == null) {
-      return;
-    }
+    final Completer<String> completer = userdata.toObject(isPersistent: true);
+
     if (error != nullptr) {
       completer.completeWithAppError(error);
       return;
@@ -3721,10 +3675,4 @@ extension on realm_error {
     final message = this.message.cast<Utf8>().toRealmDartString();
     return LastError(error, message, user_code_error.toUserCodeError());
   }
-}
-
-final isolate = Isolate.current;
-
-extension on Isolate {
-  String get asDebugString => 'isolate: $debugName, hashCode: $hashCode';
 }

--- a/lib/src/native/realm_core.dart
+++ b/lib/src/native/realm_core.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
@@ -2041,11 +2042,17 @@ class _RealmCore {
     });
   }
 
+  // TODO:
+  // We need a pure Dart equivalent of:
+  // `ServiceBinding.rootIsolateToken != null`
+  // to get rid of this hack.
+  final bool _isRootIsolate = Isolate.current.debugName == 'main';
+
   static bool _firstTime = true;
   AppHandle createApp(AppConfiguration configuration) {
     // to avoid caching apps across hot restarts we clear the cache on the first
     // call to createApp in the root isolate.
-    if (_firstTime /* TODO: Pure Dart equivalent of: '&& ServiceBinding.rootIolateToken != null' */) {
+    if (_firstTime && _isRootIsolate) {
       _firstTime = false;
       _realmLib.realm_clear_cached_apps();
     }

--- a/lib/src/realm_class.dart
+++ b/lib/src/realm_class.dart
@@ -558,10 +558,10 @@ class Realm implements Finalizable {
     }
 
     _logger.clearListeners();
-    realmCore.realmLoggerLevelChangedSubscipiton.cancel();
+    realmCore.realmLoggerLevelChangedSubscription.cancel();
     _logger = value;
     realmCore.loggerSetLogLevel(_logger.level, scheduler.nativePort);
-    realmCore.realmLoggerLevelChangedSubscipiton =
+    realmCore.realmLoggerLevelChangedSubscription =
         _logger.onLevelChanged.listen((logLevel) => realmCore.loggerSetLogLevel(logLevel ?? RealmLogLevel.off, scheduler.nativePort));
   }
 

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -277,7 +277,7 @@ class ApiKeyClient {
 /// A class representing an API key for a [User]. It can be used to represent the user when logging in
 /// instead of their regular credentials. These keys are created or fetched through [User.apiKeys].
 class ApiKey {
-  /// The unique idenitifer for this [ApiKey].
+  /// The unique identifier for this [ApiKey].
   final ObjectId id;
 
   /// The name of this [ApiKey].

--- a/src/dart-dl/dart_api.h
+++ b/src/dart-dl/dart_api.h
@@ -28,7 +28,7 @@
 #ifdef __cplusplus
 #define DART_EXTERN_C extern "C"
 #else
-#define DART_EXTERN_C
+#define DART_EXTERN_C extern
 #endif
 
 #if defined(__CYGWIN__)
@@ -381,9 +381,9 @@ DART_EXPORT Dart_Handle Dart_NewUnhandledExceptionError(Dart_Handle exception);
  * See the additional discussion under "Propagating Errors" at the
  * beginning of this file.
  *
- * \param An error handle (See Dart_IsError)
+ * \param handle An error handle (See Dart_IsError)
  *
- * \return On success, this function does not return.  On failure, the
+ * On success, this function does not return.  On failure, the
  * process is terminated.
  */
 DART_EXPORT void Dart_PropagateError(Dart_Handle handle);
@@ -443,9 +443,6 @@ DART_EXPORT Dart_PersistentHandle Dart_NewPersistentHandle(Dart_Handle object);
  *
  * \param obj1 A persistent handle whose value needs to be set.
  * \param obj2 An object whose value needs to be set to the persistent handle.
- *
- * \return Success if the persistent handle was set
- *   Otherwise, returns an error.
  */
 DART_EXPORT void Dart_SetPersistentHandle(Dart_PersistentHandle obj1,
                                           Dart_Handle obj2);
@@ -586,7 +583,7 @@ DART_EXPORT void Dart_UpdateFinalizableExternalSize(
  *
  * \return The version string for the embedded Dart VM.
  */
-DART_EXPORT const char* Dart_VersionString();
+DART_EXPORT const char* Dart_VersionString(void);
 
 /**
  * Isolate specific flags are set when creating a new isolate using the
@@ -608,6 +605,8 @@ typedef struct {
   bool copy_parent_code;
   bool null_safety;
   bool is_system_isolate;
+  bool snapshot_is_dontneed_safe;
+  bool branch_coverage;
 } Dart_IsolateFlags;
 
 /**
@@ -707,13 +706,6 @@ typedef bool (*Dart_InitializeIsolateCallback)(void** child_isolate_data,
                                                char** error);
 
 /**
- * An isolate unhandled exception callback function.
- *
- * This callback has been DEPRECATED.
- */
-typedef void (*Dart_IsolateUnhandledExceptionCallback)(Dart_Handle error);
-
-/**
  * An isolate shutdown callback function.
  *
  * This callback, provided by the embedder, is called before the vm
@@ -765,51 +757,78 @@ typedef void (*Dart_IsolateCleanupCallback)(void* isolate_group_data,
 typedef void (*Dart_IsolateGroupCleanupCallback)(void* isolate_group_data);
 
 /**
+ * A thread start callback function.
+ * This callback, provided by the embedder, is called after a thread in the
+ * vm thread pool starts.
+ * This function could be used to adjust thread priority or attach native
+ * resources to the thread.
+ */
+typedef void (*Dart_ThreadStartCallback)(void);
+
+/**
  * A thread death callback function.
  * This callback, provided by the embedder, is called before a thread in the
  * vm thread pool exits.
  * This function could be used to dispose of native resources that
  * are associated and attached to the thread, in order to avoid leaks.
  */
-typedef void (*Dart_ThreadExitCallback)();
+typedef void (*Dart_ThreadExitCallback)(void);
 
 /**
- * Callbacks provided by the embedder for file operations. If the
- * embedder does not allow file operations these callbacks can be
+ * Opens a file for reading or writing.
+ *
+ * Callback provided by the embedder for file operations. If the
+ * embedder does not allow file operations this callback can be
  * NULL.
  *
- * Dart_FileOpenCallback - opens a file for reading or writing.
  * \param name The name of the file to open.
  * \param write A boolean variable which indicates if the file is to
  *   opened for writing. If there is an existing file it needs to truncated.
+ */
+typedef void* (*Dart_FileOpenCallback)(const char* name, bool write);
+
+/**
+ * Read contents of file.
  *
- * Dart_FileReadCallback - Read contents of file.
+ * Callback provided by the embedder for file operations. If the
+ * embedder does not allow file operations this callback can be
+ * NULL.
+ *
  * \param data Buffer allocated in the callback into which the contents
  *   of the file are read into. It is the responsibility of the caller to
  *   free this buffer.
  * \param file_length A variable into which the length of the file is returned.
  *   In the case of an error this value would be -1.
  * \param stream Handle to the opened file.
- *
- * Dart_FileWriteCallback - Write data into file.
- * \param data Buffer which needs to be written into the file.
- * \param length Length of the buffer.
- * \param stream Handle to the opened file.
- *
- * Dart_FileCloseCallback - Closes the opened file.
- * \param stream Handle to the opened file.
- *
  */
-typedef void* (*Dart_FileOpenCallback)(const char* name, bool write);
-
 typedef void (*Dart_FileReadCallback)(uint8_t** data,
                                       intptr_t* file_length,
                                       void* stream);
 
+/**
+ * Write data into file.
+ *
+ * Callback provided by the embedder for file operations. If the
+ * embedder does not allow file operations this callback can be
+ * NULL.
+ *
+ * \param data Buffer which needs to be written into the file.
+ * \param length Length of the buffer.
+ * \param stream Handle to the opened file.
+ */
 typedef void (*Dart_FileWriteCallback)(const void* data,
                                        intptr_t length,
                                        void* stream);
 
+/**
+ * Closes the opened file.
+ *
+ * Callback provided by the embedder for file operations. If the
+ * embedder does not allow file operations this callback can be
+ * NULL.
+ *
+ * \param stream Handle to the opened file.
+ */
 typedef void (*Dart_FileCloseCallback)(void* stream);
 
 typedef bool (*Dart_EntropySource)(uint8_t* buffer, intptr_t length);
@@ -824,13 +843,13 @@ typedef bool (*Dart_EntropySource)(uint8_t* buffer, intptr_t length);
  * \return The embedder must return a handle to a Uint8List containing an
  *   uncompressed tar archive or null.
  */
-typedef Dart_Handle (*Dart_GetVMServiceAssetsArchive)();
+typedef Dart_Handle (*Dart_GetVMServiceAssetsArchive)(void);
 
 /**
  * The current version of the Dart_InitializeFlags. Should be incremented every
  * time Dart_InitializeFlags changes in a binary incompatible way.
  */
-#define DART_INITIALIZE_PARAMS_CURRENT_VERSION (0x00000004)
+#define DART_INITIALIZE_PARAMS_CURRENT_VERSION (0x00000007)
 
 /** Forward declaration */
 struct Dart_CodeObserver;
@@ -857,51 +876,122 @@ typedef struct Dart_CodeObserver {
 } Dart_CodeObserver;
 
 /**
- * Describes how to initialize the VM. Used with Dart_Initialize.
+ * Optional callback provided by the embedder that is used by the VM to
+ * implement registration of kernel blobs for the subsequent Isolate.spawnUri
+ * If no callback is provided, the registration of kernel blobs will throw
+ * an error.
+ * 
+ * \param kernel_buffer A buffer which contains a kernel program. Callback
+ *                      should copy the contents of `kernel_buffer` as
+ *                      it may be freed immediately after registration.
+ * \param kernel_buffer_size The size of `kernel_buffer`.
  *
- * \param version Identifies the version of the struct used by the client.
- *   should be initialized to DART_INITIALIZE_PARAMS_CURRENT_VERSION.
- * \param vm_isolate_snapshot A buffer containing a snapshot of the VM isolate
- *   or NULL if no snapshot is provided. If provided, the buffer must remain
- *   valid until Dart_Cleanup returns.
- * \param instructions_snapshot A buffer containing a snapshot of precompiled
- *   instructions, or NULL if no snapshot is provided. If provided, the buffer
- *   must remain valid until Dart_Cleanup returns.
- * \param initialize_isolate A function to be called during isolate
- *   initialization inside an existing isolate group.
- *   See Dart_InitializeIsolateCallback.
- * \param create_group A function to be called during isolate group creation.
- *   See Dart_IsolateGroupCreateCallback.
- * \param shutdown A function to be called right before an isolate is shutdown.
- *   See Dart_IsolateShutdownCallback.
- * \param cleanup A function to be called after an isolate was shutdown.
- *   See Dart_IsolateCleanupCallback.
- * \param cleanup_group A function to be called after an isolate group is shutdown.
- *   See Dart_IsolateGroupCleanupCallback.
- * \param get_service_assets A function to be called by the service isolate when
- *    it requires the vmservice assets archive.
- *    See Dart_GetVMServiceAssetsArchive.
- * \param code_observer An external code observer callback function.
- *    The observer can be invoked as early as during the Dart_Initialize() call.
+ * \return A C string representing URI which can be later used
+ *         to spawn a new isolate. This C String should be scope allocated
+ *         or owned by the embedder.
+ *         Returns NULL if embedder runs out of memory.
+ */
+typedef const char* (*Dart_RegisterKernelBlobCallback)(
+    const uint8_t* kernel_buffer,
+    intptr_t kernel_buffer_size);
+
+/**
+ * Optional callback provided by the embedder that is used by the VM to
+ * unregister kernel blobs.
+ * If no callback is provided, the unregistration of kernel blobs will throw
+ * an error.
+ * 
+ * \param kernel_blob_uri URI of the kernel blob to unregister.
+ */
+typedef void (*Dart_UnregisterKernelBlobCallback)(const char* kernel_blob_uri);
+
+/**
+ * Describes how to initialize the VM. Used with Dart_Initialize.
  */
 typedef struct {
+  /**
+   * Identifies the version of the struct used by the client.
+   * should be initialized to DART_INITIALIZE_PARAMS_CURRENT_VERSION.
+   */
   int32_t version;
+
+  /**
+   * A buffer containing snapshot data, or NULL if no snapshot is provided.
+   *
+   * If provided, the buffer must remain valid until Dart_Cleanup returns.
+   */
   const uint8_t* vm_snapshot_data;
+
+  /**
+   * A buffer containing a snapshot of precompiled instructions, or NULL if
+   * no snapshot is provided.
+   *
+   * If provided, the buffer must remain valid until Dart_Cleanup returns.
+   */
   const uint8_t* vm_snapshot_instructions;
+
+  /**
+   * A function to be called during isolate group creation.
+   * See Dart_IsolateGroupCreateCallback.
+   */
   Dart_IsolateGroupCreateCallback create_group;
+
+  /**
+   * A function to be called during isolate
+   * initialization inside an existing isolate group.
+   * See Dart_InitializeIsolateCallback.
+   */
   Dart_InitializeIsolateCallback initialize_isolate;
+
+  /**
+   * A function to be called right before an isolate is shutdown.
+   * See Dart_IsolateShutdownCallback.
+   */
   Dart_IsolateShutdownCallback shutdown_isolate;
+
+  /**
+   * A function to be called after an isolate was shutdown.
+   * See Dart_IsolateCleanupCallback.
+   */
   Dart_IsolateCleanupCallback cleanup_isolate;
+
+  /**
+   * A function to be called after an isolate group is
+   * shutdown. See Dart_IsolateGroupCleanupCallback.
+   */
   Dart_IsolateGroupCleanupCallback cleanup_group;
+
+  Dart_ThreadStartCallback thread_start;
   Dart_ThreadExitCallback thread_exit;
   Dart_FileOpenCallback file_open;
   Dart_FileReadCallback file_read;
   Dart_FileWriteCallback file_write;
   Dart_FileCloseCallback file_close;
   Dart_EntropySource entropy_source;
+
+  /**
+   * A function to be called by the service isolate when it requires the
+   * vmservice assets archive. See Dart_GetVMServiceAssetsArchive.
+   */
   Dart_GetVMServiceAssetsArchive get_service_assets;
+
   bool start_kernel_isolate;
+
+  /**
+   * An external code observer callback function. The observer can be invoked
+   * as early as during the Dart_Initialize() call.
+   */
   Dart_CodeObserver* code_observer;
+
+  /**
+   * Kernel blob registration callback function. See Dart_RegisterKernelBlobCallback.
+   */
+  Dart_RegisterKernelBlobCallback register_kernel_blob;
+
+  /**
+   * Kernel blob unregistration callback function. See Dart_UnregisterKernelBlobCallback.
+   */
+  Dart_UnregisterKernelBlobCallback unregister_kernel_blob;
 } Dart_InitializeParams;
 
 /**
@@ -925,7 +1015,7 @@ DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Initialize(
  * NOTE: This function must not be called on a thread that was created by the VM
  * itself.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Cleanup();
+DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Cleanup(void);
 
 /**
  * Sets command line flags. Should be called before Dart_Initialize.
@@ -968,15 +1058,17 @@ DART_EXPORT bool Dart_IsVMFlagSet(const char* flag_name);
  * Requires there to be no current isolate.
  *
  * \param script_uri The main source file or snapshot this isolate will load.
- *   The VM will provide this URI to the Dart_IsolateGroupCreateCallback when a child
- *   isolate is created by Isolate.spawn. The embedder should use a URI that
- *   allows it to load the same program into such a child isolate.
+ *   The VM will provide this URI to the Dart_IsolateGroupCreateCallback when a
+ *   child isolate is created by Isolate.spawn. The embedder should use a URI
+ *   that allows it to load the same program into such a child isolate.
  * \param name A short name for the isolate to improve debugging messages.
  *   Typically of the format 'foo.dart:main()'.
- * \param isolate_snapshot_data
- * \param isolate_snapshot_instructions Buffers containing a snapshot of the
- *   isolate or NULL if no snapshot is provided. If provided, the buffers must
+ * \param isolate_snapshot_data Buffer containing the snapshot data of the
+ *   isolate or NULL if no snapshot is provided. If provided, the buffer must
  *   remain valid until the isolate shuts down.
+ * \param isolate_snapshot_instructions Buffer containing the snapshot
+ *   instructions of the isolate or NULL if no snapshot is provided. If
+ *   provided, the buffer must remain valid until the isolate shuts down.
  * \param flags Pointer to VM specific flags or NULL for default flags.
  * \param isolate_group_data Embedder group data. This data can be obtained
  *   by calling Dart_IsolateGroupData and will be passed to the
@@ -1013,7 +1105,7 @@ Dart_CreateIsolateGroup(const char* script_uri,
  *   shutdown (may be NULL).
  * \param cleanup_callback A callback to be called when the isolate is being
  *   cleaned up (may be NULL).
- * \param isolate_data The embedder-specific data associated with this isolate.
+ * \param child_isolate_data The embedder-specific data associated with this isolate.
  * \param error Set to NULL if creation is successful, set to an error
  *   message otherwise. The caller is responsible for calling free() on the
  *   error message.
@@ -1041,14 +1133,14 @@ Dart_CreateIsolateInGroup(Dart_Isolate group_member,
  * Requires there to be no current isolate.
  *
  * \param script_uri The main source file or snapshot this isolate will load.
- *   The VM will provide this URI to the Dart_IsolateGroupCreateCallback when a child
- *   isolate is created by Isolate.spawn. The embedder should use a URI that
+ *   The VM will provide this URI to the Dart_IsolateGroupCreateCallback when a
+ * child isolate is created by Isolate.spawn. The embedder should use a URI that
  *   allows it to load the same program into such a child isolate.
  * \param name A short name for the isolate to improve debugging messages.
  *   Typically of the format 'foo.dart:main()'.
- * \param kernel_buffer
- * \param kernel_buffer_size A buffer which contains a kernel/DIL program. Must
+ * \param kernel_buffer A buffer which contains a kernel/DIL program. Must
  *   remain valid until isolate shutdown.
+ * \param kernel_buffer_size The size of `kernel_buffer`.
  * \param flags Pointer to VM specific flags or NULL for default flags.
  * \param isolate_group_data Embedder group data. This data can be obtained
  *   by calling Dart_IsolateGroupData and will be passed to the
@@ -1079,20 +1171,20 @@ Dart_CreateIsolateGroupFromKernel(const char* script_uri,
  *
  * Requires there to be a current isolate.
  */
-DART_EXPORT void Dart_ShutdownIsolate();
+DART_EXPORT void Dart_ShutdownIsolate(void);
 /* TODO(turnidge): Document behavior when there is no current isolate. */
 
 /**
  * Returns the current isolate. Will return NULL if there is no
  * current isolate.
  */
-DART_EXPORT Dart_Isolate Dart_CurrentIsolate();
+DART_EXPORT Dart_Isolate Dart_CurrentIsolate(void);
 
 /**
  * Returns the callback data associated with the current isolate. This
  * data was set when the isolate got created or initialized.
  */
-DART_EXPORT void* Dart_CurrentIsolateData();
+DART_EXPORT void* Dart_CurrentIsolateData(void);
 
 /**
  * Returns the callback data associated with the given isolate. This
@@ -1104,13 +1196,21 @@ DART_EXPORT void* Dart_IsolateData(Dart_Isolate isolate);
  * Returns the current isolate group. Will return NULL if there is no
  * current isolate group.
  */
-DART_EXPORT Dart_IsolateGroup Dart_CurrentIsolateGroup();
+DART_EXPORT Dart_IsolateGroup Dart_CurrentIsolateGroup(void);
 
 /**
  * Returns the callback data associated with the current isolate group. This
  * data was passed to the isolate group when it was created.
  */
-DART_EXPORT void* Dart_CurrentIsolateGroupData();
+DART_EXPORT void* Dart_CurrentIsolateGroupData(void);
+
+/**
+ * Gets an id that uniquely identifies current isolate group.
+ *
+ * It is the responsibility of the caller to free the returned ID.
+ */
+typedef int64_t Dart_IsolateGroupId;
+DART_EXPORT Dart_IsolateGroupId Dart_CurrentIsolateGroupId();
 
 /**
  * Returns the callback data associated with the specified isolate group. This
@@ -1126,7 +1226,18 @@ DART_EXPORT void* Dart_IsolateGroupData(Dart_Isolate isolate);
  * This name is unique to each isolate and should only be used to make
  * debugging messages more comprehensible.
  */
-DART_EXPORT Dart_Handle Dart_DebugName();
+DART_EXPORT Dart_Handle Dart_DebugName(void);
+
+/**
+ * Returns the debugging name for the current isolate.
+ *
+ * This name is unique to each isolate and should only be used to make
+ * debugging messages more comprehensible.
+ *
+ * The returned string is scope allocated and is only valid until the next call
+ * to Dart_ExitScope.
+ */
+DART_EXPORT const char* Dart_DebugNameToCString(void);
 
 /**
  * Returns the ID for an isolate which is used to query the service protocol.
@@ -1159,18 +1270,6 @@ DART_EXPORT void Dart_EnterIsolate(Dart_Isolate isolate);
 DART_EXPORT void Dart_KillIsolate(Dart_Isolate isolate);
 
 /**
- * Notifies the VM that the embedder expects |size| bytes of memory have become
- * unreachable. The VM may use this hint to adjust the garbage collector's
- * growth policy.
- *
- * Multiple calls are interpreted as increasing, not replacing, the estimate of
- * unreachable memory.
- *
- * Requires there to be a current isolate.
- */
-DART_EXPORT void Dart_HintFreed(intptr_t size);
-
-/**
  * Notifies the VM that the embedder expects to be idle until |deadline|. The VM
  * may use this time to perform garbage collection or other tasks to avoid
  * delays during execution of Dart code in the future.
@@ -1182,26 +1281,138 @@ DART_EXPORT void Dart_HintFreed(intptr_t size);
  */
 DART_EXPORT void Dart_NotifyIdle(int64_t deadline);
 
+typedef void (*Dart_HeapSamplingReportCallback)(void* context,
+                                                intptr_t heap_size,
+                                                const char* cls_name,
+                                                void* data);
+
+typedef void* (*Dart_HeapSamplingCreateCallback)(
+    Dart_Isolate isolate,
+    Dart_IsolateGroup isolate_group);
+typedef void (*Dart_HeapSamplingDeleteCallback)(void* data);
+
+/**
+ * Starts the heap sampling profiler for each thread in the VM.
+ */
+DART_EXPORT void Dart_EnableHeapSampling();
+
+/*
+ * Stops the heap sampling profiler for each thread in the VM.
+ */
+DART_EXPORT void Dart_DisableHeapSampling();
+
+/* Registers callbacks are invoked once per sampled allocation upon object
+ * allocation and garbage collection.
+ *
+ * |create_callback| can be used to associate additional data with the sampled
+ * allocation, such as a stack trace. This data pointer will be passed to
+ * |delete_callback| to allow for proper disposal when the object associated
+ * with the allocation sample is collected.
+ *
+ * The provided callbacks must not call into the VM and should do as little
+ * work as possible to avoid performance penalities during object allocation and
+ * garbage collection.
+ *
+ * NOTE: It is a fatal error to set either callback to null once they have been
+ * initialized.
+ */
+DART_EXPORT void Dart_RegisterHeapSamplingCallback(
+    Dart_HeapSamplingCreateCallback create_callback,
+    Dart_HeapSamplingDeleteCallback delete_callback);
+
+/*
+ * Reports the surviving allocation samples for all live isolate groups in the
+ * VM.
+ *
+ * When the callback is invoked:
+ *  - |context| will be the context object provided when invoking
+ *    |Dart_ReportSurvivingAllocations|. This can be safely set to null if not
+ *    required.
+ *  - |heap_size| will be equal to the size of the allocated object associated
+ *    with the sample.
+ *  - |cls_name| will be a C String representing
+ *    the class name of the allocated object. This string is valid for the
+ *    duration of the call to Dart_ReportSurvivingAllocations and can be
+ *    freed by the VM at any point after the method returns.
+ *  - |data| will be set to the data associated with the sample by
+ *    |Dart_HeapSamplingCreateCallback|.
+ */
+DART_EXPORT void Dart_ReportSurvivingAllocations(
+    Dart_HeapSamplingReportCallback callback,
+    void* context);
+
+/*
+ * Sets the average heap sampling rate based on a number of |bytes| for each
+ * thread.
+ *
+ * In other words, approximately every |bytes| allocated will create a sample.
+ * Defaults to 512 KiB.
+ */
+DART_EXPORT void Dart_SetHeapSamplingPeriod(intptr_t bytes);
+
+/**
+ * Notifies the VM that the embedder expects the application's working set has
+ * recently shrunk significantly and is not expected to rise in the near future.
+ * The VM may spend O(heap-size) time performing clean up work.
+ *
+ * Requires there to be a current isolate.
+ */
+DART_EXPORT void Dart_NotifyDestroyed(void);
+
 /**
  * Notifies the VM that the system is running low on memory.
  *
  * Does not require a current isolate. Only valid after calling Dart_Initialize.
  */
-DART_EXPORT void Dart_NotifyLowMemory();
+DART_EXPORT void Dart_NotifyLowMemory(void);
+
+typedef enum {
+  /**
+   * Balanced
+   */
+  Dart_PerformanceMode_Default,
+  /**
+   * Optimize for low latency, at the expense of throughput and memory overhead
+   * by performing work in smaller batches (requiring more overhead) or by
+   * delaying work (requiring more memory). An embedder should not remain in
+   * this mode indefinitely.
+   */
+  Dart_PerformanceMode_Latency,
+  /**
+   * Optimize for high throughput, at the expense of latency and memory overhead
+   * by performing work in larger batches with more intervening growth.
+   */
+  Dart_PerformanceMode_Throughput,
+  /**
+   * Optimize for low memory, at the expensive of throughput and latency by more
+   * frequently performing work.
+   */
+  Dart_PerformanceMode_Memory,
+} Dart_PerformanceMode;
+
+/**
+ * Set the desired performance trade-off.
+ *
+ * Requires a current isolate.
+ *
+ * Returns the previous performance mode.
+ */
+DART_EXPORT Dart_PerformanceMode
+Dart_SetPerformanceMode(Dart_PerformanceMode mode);
 
 /**
  * Starts the CPU sampling profiler.
  */
-DART_EXPORT void Dart_StartProfiling();
+DART_EXPORT void Dart_StartProfiling(void);
 
 /**
  * Stops the CPU sampling profiler.
  *
- * Note that some profile samples might still be taken after this fucntion
+ * Note that some profile samples might still be taken after this function
  * returns due to the asynchronous nature of the implementation on some
  * platforms.
  */
-DART_EXPORT void Dart_StopProfiling();
+DART_EXPORT void Dart_StopProfiling(void);
 
 /**
  * Notifies the VM that the current thread should not be profiled until a
@@ -1212,7 +1423,7 @@ DART_EXPORT void Dart_StopProfiling();
  * to make a blocking call and wants to avoid unnecessary interrupts by
  * the profiler.
  */
-DART_EXPORT void Dart_ThreadDisableProfiling();
+DART_EXPORT void Dart_ThreadDisableProfiling(void);
 
 /**
  * Notifies the VM that the current thread should be profiled.
@@ -1222,7 +1433,7 @@ DART_EXPORT void Dart_ThreadDisableProfiling();
  *
  * NOTE: By default, if a thread has entered an isolate it will be profiled.
  */
-DART_EXPORT void Dart_ThreadEnableProfiling();
+DART_EXPORT void Dart_ThreadEnableProfiling(void);
 
 /**
  * Register symbol information for the Dart VM's profiler and crash dumps.
@@ -1240,7 +1451,7 @@ DART_EXPORT void Dart_AddSymbols(const char* dso_name,
  *
  * Requires there to be a current isolate.
  */
-DART_EXPORT void Dart_ExitIsolate();
+DART_EXPORT void Dart_ExitIsolate(void);
 /* TODO(turnidge): We don't want users of the api to be able to exit a
  * "pure" dart isolate. Implement and document. */
 
@@ -1255,12 +1466,17 @@ DART_EXPORT void Dart_ExitIsolate();
  * Requires there to be a current isolate. Not available in the precompiled
  * runtime (check Dart_IsPrecompiledRuntime).
  *
- * \param buffer Returns a pointer to a buffer containing the
- *   snapshot. This buffer is scope allocated and is only valid
+ * \param vm_snapshot_data_buffer Returns a pointer to a buffer containing the
+ *   vm snapshot. This buffer is scope allocated and is only valid
  *   until the next call to Dart_ExitScope.
- * \param size Returns the size of the buffer.
+ * \param vm_snapshot_data_size Returns the size of vm_snapshot_data_buffer.
+ * \param isolate_snapshot_data_buffer Returns a pointer to a buffer containing
+ *   the isolate snapshot. This buffer is scope allocated and is only valid
+ *   until the next call to Dart_ExitScope.
+ * \param isolate_snapshot_data_size Returns the size of
+ *   isolate_snapshot_data_buffer.
  * \param is_core Create a snapshot containing core libraries.
- *                Such snapshot should be agnostic to null safety mode.
+ *   Such snapshot should be agnostic to null safety mode.
  *
  * \return A valid handle if no error occurs during the operation.
  */
@@ -1317,17 +1533,22 @@ typedef int64_t Dart_Port;
 /**
  * A message notification callback.
  *
- * This callback allows the embedder to provide an alternate wakeup
- * mechanism for the delivery of inter-isolate messages.  It is the
- * responsibility of the embedder to call Dart_HandleMessage to
- * process the message.
+ * This callback allows the embedder to provide a custom wakeup mechanism for
+ * the delivery of inter-isolate messages. This function is called once per
+ * message on an arbitrary thread. It is the responsibility of the embedder to
+ * eventually call Dart_HandleMessage once per callback received with the
+ * destination isolate set as the current isolate to process the message.
  */
-typedef void (*Dart_MessageNotifyCallback)(Dart_Isolate dest_isolate);
+typedef void (*Dart_MessageNotifyCallback)(Dart_Isolate destination_isolate);
 
 /**
- * Allows embedders to provide an alternative wakeup mechanism for the
- * delivery of inter-isolate messages. This setting only applies to
- * the current isolate.
+ * Allows embedders to provide a custom wakeup mechanism for the delivery of
+ * inter-isolate messages. This setting only applies to the current isolate.
+ *
+ * This mechanism is optional: if not provided, the isolate will be scheduled on
+ * a VM-managed thread pool. An embedder should provide this callback if it
+ * wants to run an isolate on a specific thread or to interleave handling of
+ * inter-isolate messages with other event sources.
  *
  * Most embedders will only call this function once, before isolate
  * execution begins. If this function is called after isolate
@@ -1343,7 +1564,7 @@ DART_EXPORT void Dart_SetMessageNotifyCallback(
  *
  * \return The current message notify callback for the isolate.
  */
-DART_EXPORT Dart_MessageNotifyCallback Dart_GetMessageNotifyCallback();
+DART_EXPORT Dart_MessageNotifyCallback Dart_GetMessageNotifyCallback(void);
 
 /**
  * The VM's default message handler supports pausing an isolate before it
@@ -1369,7 +1590,7 @@ DART_EXPORT Dart_MessageNotifyCallback Dart_GetMessageNotifyCallback();
  *
  * \return A boolean value indicating if pause on start was requested.
  */
-DART_EXPORT bool Dart_ShouldPauseOnStart();
+DART_EXPORT bool Dart_ShouldPauseOnStart(void);
 
 /**
  * Override the VM flag `--pause-isolates-on-start` for the current isolate.
@@ -1385,7 +1606,7 @@ DART_EXPORT void Dart_SetShouldPauseOnStart(bool should_pause);
  *
  * \return A boolean value indicating if the isolate is paused on start.
  */
-DART_EXPORT bool Dart_IsPausedOnStart();
+DART_EXPORT bool Dart_IsPausedOnStart(void);
 
 /**
  * Called when the embedder has paused the current isolate on start and when
@@ -1400,7 +1621,7 @@ DART_EXPORT void Dart_SetPausedOnStart(bool paused);
  *
  * \return A boolean value indicating if pause on exit was requested.
  */
-DART_EXPORT bool Dart_ShouldPauseOnExit();
+DART_EXPORT bool Dart_ShouldPauseOnExit(void);
 
 /**
  * Override the VM flag `--pause-isolates-on-exit` for the current isolate.
@@ -1415,7 +1636,7 @@ DART_EXPORT void Dart_SetShouldPauseOnExit(bool should_pause);
  *
  * \return A boolean value indicating if the isolate is paused on exit.
  */
-DART_EXPORT bool Dart_IsPausedOnExit();
+DART_EXPORT bool Dart_IsPausedOnExit(void);
 
 /**
  * Called when the embedder has paused the current isolate on exit and when
@@ -1439,14 +1660,14 @@ DART_EXPORT void Dart_SetStickyError(Dart_Handle error);
 /**
  * Does the current isolate have a sticky error?
  */
-DART_EXPORT bool Dart_HasStickyError();
+DART_EXPORT bool Dart_HasStickyError(void);
 
 /**
  * Gets the sticky error for the current isolate.
  *
  * \return A handle to the sticky error object or null.
  */
-DART_EXPORT Dart_Handle Dart_GetStickyError();
+DART_EXPORT Dart_Handle Dart_GetStickyError(void);
 
 /**
  * Handles the next pending message for the current isolate.
@@ -1455,11 +1676,11 @@ DART_EXPORT Dart_Handle Dart_GetStickyError();
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_HandleMessage();
+DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_HandleMessage(void);
 
 /**
  * Drains the microtask queue, then blocks the calling thread until the current
- * isolate recieves a message, then handles all messages.
+ * isolate receives a message, then handles all messages.
  *
  * \param timeout_millis When non-zero, the call returns after the indicated
           number of milliseconds even if no message was received.
@@ -1481,14 +1702,14 @@ Dart_WaitForEvent(int64_t timeout_millis);
  * \return true if the vm service requests the program resume
  * execution, false otherwise
  */
-DART_EXPORT bool Dart_HandleServiceMessages();
+DART_EXPORT bool Dart_HandleServiceMessages(void);
 
 /**
  * Does the current isolate have pending service messages?
  *
  * \return true if the isolate has pending service messages, false otherwise.
  */
-DART_EXPORT bool Dart_HasServiceMessages();
+DART_EXPORT bool Dart_HasServiceMessages(void);
 
 /**
  * Processes any incoming messages for the current isolate.
@@ -1506,7 +1727,7 @@ DART_EXPORT bool Dart_HasServiceMessages();
  *   exception or other error occurs while processing messages, an
  *   error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop();
+DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop(void);
 
 /**
  * Lets the VM run message processing for the isolate.
@@ -1522,8 +1743,8 @@ DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop();
  * \param error A non-NULL pointer which will hold an error message if the call
  *   fails. The error has to be free()ed by the caller.
  *
- * \return If successfull the VM takes owernship of the isolate and takes care
- *   of its message loop. If not successful the caller retains owernship of the
+ * \return If successful the VM takes ownership of the isolate and takes care
+ *   of its message loop. If not successful the caller retains ownership of the
  *   isolate.
  */
 DART_EXPORT DART_WARN_UNUSED_RESULT bool Dart_RunLoopAsync(
@@ -1537,14 +1758,14 @@ DART_EXPORT DART_WARN_UNUSED_RESULT bool Dart_RunLoopAsync(
 /**
  * Gets the main port id for the current isolate.
  */
-DART_EXPORT Dart_Port Dart_GetMainPortId();
+DART_EXPORT Dart_Port Dart_GetMainPortId(void);
 
 /**
  * Does the current isolate have live ReceivePorts?
  *
  * A ReceivePort is live when it has not been closed.
  */
-DART_EXPORT bool Dart_HasLivePorts();
+DART_EXPORT bool Dart_HasLivePorts(void);
 
 /**
  * Posts a message for some isolate. The message is a serialized
@@ -1552,7 +1773,9 @@ DART_EXPORT bool Dart_HasLivePorts();
  *
  * Requires there to be a current isolate.
  *
- * \param port The destination port.
+ * For posting messages outside of an isolate see \ref Dart_PostCObject.
+ *
+ * \param port_id The destination port.
  * \param object An object from the current isolate.
  *
  * \return True if the message was posted.
@@ -1594,7 +1817,7 @@ DART_EXPORT Dart_Handle Dart_SendPortGetId(Dart_Handle port,
  *
  * Requires there to be a current isolate.
  */
-DART_EXPORT void Dart_EnterScope();
+DART_EXPORT void Dart_EnterScope(void);
 
 /**
  * Exits a scope.
@@ -1603,7 +1826,7 @@ DART_EXPORT void Dart_EnterScope();
  *
  * Requires there to be a current isolate.
  */
-DART_EXPORT void Dart_ExitScope();
+DART_EXPORT void Dart_ExitScope(void);
 
 /**
  * The Dart VM uses "zone allocation" for temporary structures. Zones
@@ -1640,7 +1863,7 @@ DART_EXPORT uint8_t* Dart_ScopeAllocate(intptr_t size);
  *
  * \return A handle to the null object.
  */
-DART_EXPORT Dart_Handle Dart_Null();
+DART_EXPORT Dart_Handle Dart_Null(void);
 
 /**
  * Is this object null?
@@ -1652,7 +1875,7 @@ DART_EXPORT bool Dart_IsNull(Dart_Handle object);
  *
  * \return A handle to the empty string object.
  */
-DART_EXPORT Dart_Handle Dart_EmptyString();
+DART_EXPORT Dart_Handle Dart_EmptyString(void);
 
 /**
  * Returns types that are not classes, and which therefore cannot be looked up
@@ -1660,9 +1883,9 @@ DART_EXPORT Dart_Handle Dart_EmptyString();
  *
  * \return A handle to the dynamic, void or Never type.
  */
-DART_EXPORT Dart_Handle Dart_TypeDynamic();
-DART_EXPORT Dart_Handle Dart_TypeVoid();
-DART_EXPORT Dart_Handle Dart_TypeNever();
+DART_EXPORT Dart_Handle Dart_TypeDynamic(void);
+DART_EXPORT Dart_Handle Dart_TypeVoid(void);
+DART_EXPORT Dart_Handle Dart_TypeNever(void);
 
 /**
  * Checks if the two objects are equal.
@@ -1781,7 +2004,7 @@ DART_EXPORT Dart_Handle Dart_FunctionName(Dart_Handle function);
 DART_EXPORT Dart_Handle Dart_FunctionOwner(Dart_Handle function);
 
 /**
- * Determines whether a function handle referes to a static function
+ * Determines whether a function handle refers to a static function
  * of method.
  *
  * For the purposes of the embedding API, a top-level function is
@@ -1971,7 +2194,7 @@ DART_EXPORT Dart_Handle Dart_GetStaticMethodClosure(Dart_Handle library,
  *
  * \return A handle to the True object.
  */
-DART_EXPORT Dart_Handle Dart_True();
+DART_EXPORT Dart_Handle Dart_True(void);
 
 /**
  * Returns the False object.
@@ -1980,7 +2203,7 @@ DART_EXPORT Dart_Handle Dart_True();
  *
  * \return A handle to the False object.
  */
-DART_EXPORT Dart_Handle Dart_False();
+DART_EXPORT Dart_Handle Dart_False(void);
 
 /**
  * Returns a Boolean with the provided value.
@@ -2024,7 +2247,7 @@ DART_EXPORT Dart_Handle Dart_StringLength(Dart_Handle str, intptr_t* length);
  *  UTF-8 encoded characters and '\0' is considered as a termination
  *  character).
  *
- * \param value A C String
+ * \param str A C String
  *
  * \return The String object if no error occurs. Otherwise returns
  *   an error handle.
@@ -2181,7 +2404,7 @@ DART_EXPORT Dart_Handle Dart_StringToUTF16(Dart_Handle str,
  * Gets the storage size in bytes of a String.
  *
  * \param str A String.
- * \param length Returns the storage size in bytes of the String.
+ * \param size Returns the storage size in bytes of the String.
  *  This is the size in bytes needed to store the String.
  *
  * \return A valid handle if no error occurs during the operation.
@@ -2328,7 +2551,7 @@ DART_EXPORT Dart_Handle Dart_ListGetRange(Dart_Handle list,
  *
  * May generate an unhandled exception error.
  *
- * \param array A List.
+ * \param list A List.
  * \param index A valid index into the List.
  * \param value The Object to put in the List.
  *
@@ -2489,11 +2712,18 @@ Dart_NewExternalTypedDataWithFinalizer(Dart_TypedData_Type type,
                                        void* peer,
                                        intptr_t external_allocation_size,
                                        Dart_HandleFinalizer callback);
+DART_EXPORT Dart_Handle Dart_NewUnmodifiableExternalTypedDataWithFinalizer(
+    Dart_TypedData_Type type,
+    const void* data,
+    intptr_t length,
+    void* peer,
+    intptr_t external_allocation_size,
+    Dart_HandleFinalizer callback);
 
 /**
  * Returns a ByteBuffer object for the typed data.
  *
- * \param type_data The TypedData object.
+ * \param typed_data The TypedData object.
  *
  * \return The ByteBuffer object if no error occurs. Otherwise returns
  *   an error handle.
@@ -2652,13 +2882,13 @@ Dart_InvokeClosure(Dart_Handle closure,
  * Invokes a Generative Constructor on an object that was previously
  * allocated using Dart_Allocate/Dart_AllocateWithNativeFields.
  *
- * The 'target' parameter must be an object.
+ * The 'object' parameter must be an object.
  *
  * This function ignores visibility (leading underscores in names).
  *
  * May generate an unhandled exception error.
  *
- * \param target An object.
+ * \param object An object.
  * \param name The name of the constructor to invoke.
  *   Use Dart_Null() or Dart_EmptyString() to invoke the unnamed constructor.
  * \param number_of_arguments Size of the arguments array.
@@ -2936,7 +3166,7 @@ DART_EXPORT Dart_Handle Dart_GetNativeStringArgument(Dart_NativeArguments args,
 /**
  * Gets an integer native argument at some index.
  * \param args Native arguments structure.
- * \param arg_index Index of the desired argument in the structure above.
+ * \param index Index of the desired argument in the structure above.
  * \param value Returns the integer value if the argument is an Integer.
  * \return Success if no error occurs. Otherwise returns an error handle.
  */
@@ -2947,7 +3177,7 @@ DART_EXPORT Dart_Handle Dart_GetNativeIntegerArgument(Dart_NativeArguments args,
 /**
  * Gets a boolean native argument at some index.
  * \param args Native arguments structure.
- * \param arg_index Index of the desired argument in the structure above.
+ * \param index Index of the desired argument in the structure above.
  * \param value Returns the boolean value if the argument is a Boolean.
  * \return Success if no error occurs. Otherwise returns an error handle.
  */
@@ -2958,7 +3188,7 @@ DART_EXPORT Dart_Handle Dart_GetNativeBooleanArgument(Dart_NativeArguments args,
 /**
  * Gets a double native argument at some index.
  * \param args Native arguments structure.
- * \param arg_index Index of the desired argument in the structure above.
+ * \param index Index of the desired argument in the structure above.
  * \param value Returns the double value if the argument is a double.
  * \return Success if no error occurs. Otherwise returns an error handle.
  */
@@ -3046,7 +3276,7 @@ typedef const uint8_t* (*Dart_NativeEntrySymbol)(Dart_NativeFunction nf);
  *
  * See Dart_SetFfiNativeResolver.
  */
-typedef void* (*Dart_FfiNativeResolver)(const char* name);
+typedef void* (*Dart_FfiNativeResolver)(const char* name, uintptr_t args_n);
 
 /*
  * ===========
@@ -3136,7 +3366,6 @@ typedef enum {
   Dart_kCanonicalizeUrl = 0,
   Dart_kImportTag,
   Dart_kKernelTag,
-  Dart_kImportExtensionTag,
 } Dart_LibraryTag;
 
 /**
@@ -3171,10 +3400,6 @@ typedef enum {
  * script tags. The return value should be an error or a TypedData containing
  * the kernel bytes.
  *
- * Dart_kImportExtensionTag
- *
- * This tag is used to load an external import (shared object file). The
- * extension path must have the scheme 'dart-ext:'.
  */
 typedef Dart_Handle (*Dart_LibraryTagHandler)(
     Dart_LibraryTag tag,
@@ -3205,9 +3430,9 @@ Dart_SetLibraryTagHandler(Dart_LibraryTagHandler handler);
  * call Dart_DeferredLoadComplete or Dart_DeferredLoadCompleteError before the
  * handler returns.
  *
- * If an error is returned, it will be propogated through
+ * If an error is returned, it will be propagated through
  * `prefix.loadLibrary()`. This is useful for synchronous
- * implementations, which must propogate any unwind errors from
+ * implementations, which must propagate any unwind errors from
  * Dart_DeferredLoadComplete or Dart_DeferredLoadComplete. Otherwise the handler
  * should return a non-error such as `Dart_Null()`.
  */
@@ -3275,9 +3500,9 @@ DART_EXPORT Dart_Handle Dart_DefaultCanonicalizeUrl(Dart_Handle base_url,
  *
  * Requires there to be no current root library.
  *
- * \param buffer A buffer which contains a kernel binary (see
+ * \param kernel_buffer A buffer which contains a kernel binary (see
  *     pkg/kernel/binary.md). Must remain valid until isolate group shutdown.
- * \param buffer_size Length of the passed in buffer.
+ * \param kernel_size Length of the passed in buffer.
  *
  * \return A handle to the root library, or an error.
  */
@@ -3293,7 +3518,7 @@ Dart_LoadScriptFromKernel(const uint8_t* kernel_buffer, intptr_t kernel_size);
  *
  * \return Returns the root Library for the current isolate or Dart_Null().
  */
-DART_EXPORT Dart_Handle Dart_RootLibrary();
+DART_EXPORT Dart_Handle Dart_RootLibrary(void);
 
 /**
  * Sets the root library for the current isolate.
@@ -3311,7 +3536,7 @@ DART_EXPORT Dart_Handle Dart_SetRootLibrary(Dart_Handle library);
  * \param number_of_type_arguments Number of type arguments.
  *   For non parametric types the number of type arguments would be 0.
  * \param type_arguments Pointer to an array of type arguments.
- *   For non parameteric types a NULL would be passed in for this argument.
+ *   For non parametric types a NULL would be passed in for this argument.
  *
  * \return If no error occurs, the type is returned.
  *   Otherwise an error handle is returned.
@@ -3330,7 +3555,7 @@ DART_EXPORT Dart_Handle Dart_GetType(Dart_Handle library,
  * \param number_of_type_arguments Number of type arguments.
  *   For non parametric types the number of type arguments would be 0.
  * \param type_arguments Pointer to an array of type arguments.
- *   For non parameteric types a NULL would be passed in for this argument.
+ *   For non parametric types a NULL would be passed in for this argument.
  *
  * \return If no error occurs, the type is returned.
  *   Otherwise an error handle is returned.
@@ -3349,7 +3574,7 @@ DART_EXPORT Dart_Handle Dart_GetNullableType(Dart_Handle library,
  * \param number_of_type_arguments Number of type arguments.
  *   For non parametric types the number of type arguments would be 0.
  * \param type_arguments Pointer to an array of type arguments.
- *   For non parameteric types a NULL would be passed in for this argument.
+ *   For non parametric types a NULL would be passed in for this argument.
  *
  * \return If no error occurs, the type is returned.
  *   Otherwise an error handle is returned.
@@ -3421,7 +3646,7 @@ DART_EXPORT Dart_Handle Dart_LibraryResolvedUrl(Dart_Handle library);
 /**
  * \return An array of libraries.
  */
-DART_EXPORT Dart_Handle Dart_GetLoadedLibraries();
+DART_EXPORT Dart_Handle Dart_GetLoadedLibraries(void);
 
 DART_EXPORT Dart_Handle Dart_LookupLibrary(Dart_Handle url);
 /* TODO(turnidge): Consider returning Dart_Null() when the library is
@@ -3444,26 +3669,17 @@ DART_EXPORT Dart_Handle Dart_LibraryHandleError(Dart_Handle library,
  * Called by the embedder to load a partial program. Does not set the root
  * library.
  *
- * \param buffer A buffer which contains a kernel binary (see
+ * \param kernel_buffer A buffer which contains a kernel binary (see
  *     pkg/kernel/binary.md). Must remain valid until isolate shutdown.
- * \param buffer_size Length of the passed in buffer.
+ * \param kernel_buffer_size Length of the passed in buffer.
  *
  * \return A handle to the main library of the compilation unit, or an error.
  */
 DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
 Dart_LoadLibraryFromKernel(const uint8_t* kernel_buffer,
                            intptr_t kernel_buffer_size);
-
-/**
- * Returns a flattened list of pairs. The first element in each pair is the
- * importing library and and the second element is the imported library for each
- * import in the isolate of a library whose URI's scheme is [scheme].
- *
- * Requires there to be a current isolate.
- *
- * \return A handle to a list of flattened pairs of importer-importee.
- */
-DART_EXPORT Dart_Handle Dart_GetImportsOfScheme(Dart_Handle scheme);
+DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadLibrary(Dart_Handle kernel_buffer);
 
 /**
  * Indicates that all outstanding load requests have been satisfied.
@@ -3538,6 +3754,7 @@ typedef enum {
   Dart_KernelCompilationStatus_Ok = 0,
   Dart_KernelCompilationStatus_Error = 1,
   Dart_KernelCompilationStatus_Crash = 2,
+  Dart_KernelCompilationStatus_MsgFailed = 3,
 } Dart_KernelCompilationStatus;
 
 typedef struct {
@@ -3556,8 +3773,8 @@ typedef enum {
 } Dart_KernelCompilationVerbosityLevel;
 
 DART_EXPORT bool Dart_IsKernelIsolate(Dart_Isolate isolate);
-DART_EXPORT bool Dart_KernelIsolateIsRunning();
-DART_EXPORT Dart_Port Dart_KernelPort();
+DART_EXPORT bool Dart_KernelIsolateIsRunning(void);
+DART_EXPORT Dart_Port Dart_KernelPort(void);
 
 /**
  * Compiles the given `script_uri` to a kernel file.
@@ -3600,7 +3817,7 @@ typedef struct {
   const char* source;
 } Dart_SourceFile;
 
-DART_EXPORT Dart_KernelCompilationResult Dart_KernelListDependencies();
+DART_EXPORT Dart_KernelCompilationResult Dart_KernelListDependencies(void);
 
 /**
  * Sets the kernel buffer which will be used to load Dart SDK sources
@@ -3635,16 +3852,18 @@ DART_EXPORT void Dart_SetDartLibrarySourcesKernel(
  *   process was launched, this is used to correctly resolve the path specified
  *   for package_config.
  *
- * \param snapshot_data
- *
- * \param snapshot_instructions Buffers containing a snapshot of the
+ * \param snapshot_data Buffer containing the snapshot data of the
  *   isolate or NULL if no snapshot is provided. If provided, the buffers must
  *   remain valid until the isolate shuts down.
  *
- * \param kernel_buffer
+ * \param snapshot_instructions Buffer containing the snapshot instructions of
+ *   the isolate or NULL if no snapshot is provided. If provided, the buffers
+ *   must remain valid until the isolate shuts down.
  *
- * \param kernel_buffer_size A buffer which contains a kernel/DIL program. Must
+ * \param kernel_buffer A buffer which contains a kernel/DIL program. Must
  *   remain valid until isolate shutdown.
+ *
+ * \param kernel_buffer_size The size of `kernel_buffer`.
  *
  * \return Returns true if the null safety is opted in by the input being
  *   run `script_uri`, `snapshot_data` or `kernel_buffer`.
@@ -3706,7 +3925,7 @@ DART_EXPORT bool Dart_WriteProfileToTimeline(Dart_Port main_port, char** error);
  * \return An error handle if a compilation error or runtime error running const
  * constructors was encountered.
  */
-DART_EXPORT Dart_Handle Dart_Precompile();
+DART_EXPORT Dart_Handle Dart_Precompile(void);
 
 typedef void (*Dart_CreateLoadingUnitCallback)(
     void* callback_data,
@@ -3844,7 +4063,7 @@ Dart_CreateVMAOTSnapshotAsAssembly(Dart_StreamingWriteCallback callback,
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_SortClasses();
+DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_SortClasses(void);
 
 /**
  *  Creates a snapshot that caches compiled code and type feedback for faster
@@ -3904,7 +4123,7 @@ Dart_GetObfuscationMap(uint8_t** buffer, intptr_t* buffer_length);
  *  not from any other kind of snapshot or from source (that is, the VM was
  *  compiled with DART_PRECOMPILED_RUNTIME).
  */
-DART_EXPORT bool Dart_IsPrecompiledRuntime();
+DART_EXPORT bool Dart_IsPrecompiledRuntime(void);
 
 /**
  *  Print a native stack trace. Used for crash handling.
@@ -3919,6 +4138,31 @@ DART_EXPORT void Dart_DumpNativeStackTrace(void* context);
  *  Indicate that the process is about to abort, and the Dart VM should not
  *  attempt to cleanup resources.
  */
-DART_EXPORT void Dart_PrepareToAbort();
+DART_EXPORT void Dart_PrepareToAbort(void);
+
+/**
+ * Callback provided by the embedder that is used by the VM to
+ * produce footnotes appended to DWARF stack traces.
+ *
+ * Whenever VM formats a stack trace as a string it would call this callback
+ * passing raw program counters for each frame in the stack trace.
+ *
+ * Embedder can then return a string which if not-null will be appended to the
+ * formatted stack trace.
+ *
+ * Returned string is expected to be `malloc()` allocated. VM takes ownership
+ * of the returned string and will `free()` it.
+ *
+ * \param addresses raw program counter addresses for each frame
+ * \param count number of elements in the addresses array
+ */
+typedef char* (*Dart_DwarfStackTraceFootnoteCallback)(void* addresses[],
+                                                      intptr_t count);
+
+/**
+ *  Configure DWARF stack trace footnote callback.
+ */
+DART_EXPORT void Dart_SetDwarfStackTraceFootnoteCallback(
+    Dart_DwarfStackTraceFootnoteCallback callback);
 
 #endif /* INCLUDE_DART_API_H_ */ /* NOLINT */

--- a/src/dart-dl/dart_api_dl.h
+++ b/src/dart-dl/dart_api_dl.h
@@ -22,20 +22,14 @@
  * `Dart_InitializeApiDL` with `NativeApi.initializeApiDLData`.
  */
 
-#ifdef __cplusplus
-#define DART_EXTERN extern "C"
-#else
-#define DART_EXTERN extern
-#endif
-
-DART_EXTERN intptr_t Dart_InitializeApiDL(void* data);
+DART_EXPORT intptr_t Dart_InitializeApiDL(void* data);
 
 // ============================================================================
 // IMPORTANT! Never update these signatures without properly updating
 // DART_API_DL_MAJOR_VERSION and DART_API_DL_MINOR_VERSION.
 //
 // Verbatim copy of `dart_native_api.h` and `dart_api.h` symbol names and types
-// to trigger compile-time errors if the sybols in those files are updated
+// to trigger compile-time errors if the symbols in those files are updated
 // without updating these.
 //
 // Function return and argument types, and typedefs are carbon copied. Structs
@@ -102,8 +96,10 @@ typedef void (*Dart_NativeMessageHandler_DL)(Dart_Port_DL dest_port_id,
   F(Dart_SendPortGetId, Dart_Handle,                                           \
     (Dart_Handle port, Dart_Port_DL * port_id))                                \
   /* Scopes */                                                                 \
-  F(Dart_EnterScope, void, ())                                                 \
-  F(Dart_ExitScope, void, ())
+  F(Dart_EnterScope, void, (void))                                             \
+  F(Dart_ExitScope, void, (void))                                              \
+  /* Objects */                                                                \
+  F(Dart_IsNull, bool, (Dart_Handle))
 
 #define DART_API_ALL_DL_SYMBOLS(F)                                             \
   DART_NATIVE_API_DL_SYMBOLS(F)                                                \
@@ -114,14 +110,43 @@ typedef void (*Dart_NativeMessageHandler_DL)(Dart_Port_DL dest_port_id,
 // End of verbatim copy.
 // ============================================================================
 
+// Copy of definition of DART_EXPORT without 'used' attribute.
+//
+// The 'used' attribute cannot be used with DART_API_ALL_DL_SYMBOLS because
+// they are not function declarations, but variable declarations with a
+// function pointer type.
+//
+// The function pointer variables are initialized with the addresses of the
+// functions in the VM. If we were to use function declarations instead, we
+// would need to forward the call to the VM adding indirection.
+#if defined(__CYGWIN__)
+#error Tool chain and platform not supported.
+#elif defined(_WIN32)
+#if defined(DART_SHARED_LIB)
+#define DART_EXPORT_DL DART_EXTERN_C __declspec(dllexport)
+#else
+#define DART_EXPORT_DL DART_EXTERN_C
+#endif
+#else
+#if __GNUC__ >= 4
+#if defined(DART_SHARED_LIB)
+#define DART_EXPORT_DL DART_EXTERN_C __attribute__((visibility("default")))
+#else
+#define DART_EXPORT_DL DART_EXTERN_C
+#endif
+#else
+#error Tool chain not supported.
+#endif
+#endif
+
 #define DART_API_DL_DECLARATIONS(name, R, A)                                   \
   typedef R(*name##_Type) A;                                                   \
-  DART_EXTERN name##_Type name##_DL;
+  DART_EXPORT_DL name##_Type name##_DL;
 
 DART_API_ALL_DL_SYMBOLS(DART_API_DL_DECLARATIONS)
 
-#undef DART_API_DL_DEFINITIONS
+#undef DART_API_DL_DECLARATIONS
 
-#undef DART_EXTERN
+#undef DART_EXPORT_DL
 
 #endif /* RUNTIME_INCLUDE_DART_API_DL_H_ */ /* NOLINT */

--- a/src/dart-dl/dart_version.h
+++ b/src/dart-dl/dart_version.h
@@ -11,6 +11,6 @@
 // On backwards compatible changes the minor version is increased.
 // The versioning covers the symbols exposed in dart_api_dl.h
 #define DART_API_DL_MAJOR_VERSION 2
-#define DART_API_DL_MINOR_VERSION 0
+#define DART_API_DL_MINOR_VERSION 2
 
 #endif /* RUNTIME_INCLUDE_DART_VERSION_H_ */ /* NOLINT */

--- a/src/realm_dart_sync.cpp
+++ b/src/realm_dart_sync.cpp
@@ -373,3 +373,13 @@ RLM_API void realm_dart_apikey_list_callback(realm_userdata_t userdata, realm_ap
         (reinterpret_cast<realm_return_apikey_list_func_t>(ud->dart_callback))(ud->handle, apikey_list.data(), apikey_list.size(), error.get());
     });
 }
+
+RLM_API void realm_dart_return_string_callback(realm_userdata_t userdata, const char* serialized_ejson_response, const realm_app_error_t* error) {
+    auto error_copy = realm_app_error_copy(error);
+    std::string buf{serialized_ejson_response ? serialized_ejson_response : ""};
+
+    auto ud = reinterpret_cast<realm_dart_userdata_async_t>(userdata);
+    ud->scheduler->invoke([ud, buf = std::move(buf), error = std::move(error_copy)]() mutable {
+        (reinterpret_cast<realm_return_string_func_t>(ud->dart_callback))(ud->handle, buf.data(), error.get());
+    });
+}

--- a/src/realm_dart_sync.cpp
+++ b/src/realm_dart_sync.cpp
@@ -244,7 +244,7 @@ std::unique_ptr<realm_app_error> realm_app_error_copy(const realm_app_error_t* e
     {
         error_buf(const realm_app_error& error_input)
             : message_buffer(error_input.message),
-              link_to_server_logs_buffer(error_input.link_to_server_logs != nullptr ? error_input.link_to_server_logs : "")
+              link_to_server_logs_buffer(error_input.link_to_server_logs ? error_input.link_to_server_logs : "")
         {
             error = error_input.error;
             categories = error_input.categories;
@@ -300,8 +300,8 @@ std::unique_ptr<realm_app_user_apikey> realm_apikey_copy(const realm_app_user_ap
     struct apikey_buf : realm_app_user_apikey
     {
         apikey_buf(const realm_app_user_apikey& apikey_input)
-            : key_buffer(apikey_input.key),
-              name_buffer(apikey_input.name)
+            : key_buffer(apikey_input.key ? apikey_input.key : ""),
+              name_buffer(apikey_input.name ? apikey_input.name : "")
         {
             id = apikey_input.id;
             key = key_buffer.c_str();
@@ -315,7 +315,7 @@ std::unique_ptr<realm_app_user_apikey> realm_apikey_copy(const realm_app_user_ap
 
     std::unique_ptr<realm_app_user_apikey> apikey_copy;
     if (apikey != nullptr) {
-        apikey_copy = std::make_unique<realm_app_user_apikey>(*apikey);
+        apikey_copy = std::make_unique<apikey_buf>(*apikey);
     }
 
     return apikey_copy;

--- a/src/realm_dart_sync.cpp
+++ b/src/realm_dart_sync.cpp
@@ -244,7 +244,7 @@ std::unique_ptr<realm_app_error> realm_app_error_copy(const realm_app_error_t* e
     {
         error_buf(const realm_app_error& error_input)
             : message_buffer(error_input.message),
-              link_to_server_logs_buffer(error_input.link_to_server_logs ? error_input.link_to_server_logs : "")
+            link_to_server_logs_buffer(error_input.link_to_server_logs ? error_input.link_to_server_logs : "")
         {
             error = error_input.error;
             categories = error_input.categories;
@@ -272,13 +272,13 @@ RLM_API void realm_dart_user_completion_callback(realm_userdata_t userdata, real
     auto error_copy = realm_app_error_copy(error);
 
     // take an extra ref to the user, so that it doesn't get deleted before we invoke the callback
-    std::shared_ptr<realm::SyncUser> user_copy; 
+    std::shared_ptr<realm::SyncUser> user_copy;
     if (user != nullptr) {
         user_copy = realm_user(*user);
     }
 
     auto ud = reinterpret_cast<realm_dart_userdata_async_t>(userdata);
-    ud->scheduler->invoke([ud, error = std::move(error_copy), user = realm_user(user_copy)]() mutable { 
+    ud->scheduler->invoke([ud, error = std::move(error_copy), user = realm_user(user_copy)]() mutable {
         (reinterpret_cast<realm_app_user_completion_func_t>(ud->dart_callback))(ud->handle, &user, error.get());
     });
 }
@@ -289,35 +289,33 @@ RLM_API void realm_dart_void_completion_callback(realm_userdata_t userdata, cons
     auto error_copy = realm_app_error_copy(error);
 
     auto ud = reinterpret_cast<realm_dart_userdata_async_t>(userdata);
-    ud->scheduler->invoke([ud, error = std::move(error_copy)]() mutable { 
+    ud->scheduler->invoke([ud, error = std::move(error_copy)]() mutable {
         (reinterpret_cast<realm_app_void_completion_func_t>(ud->dart_callback))(ud->handle, error.get());
     });
 }
 
-std::unique_ptr<realm_app_user_apikey> realm_apikey_copy(const realm_app_user_apikey_t* apikey)
+struct apikey_buf : realm_app_user_apikey
 {
-    // we make a deep copy of error, so it is valid after callback returns
-    struct apikey_buf : realm_app_user_apikey
+    apikey_buf(const realm_app_user_apikey& apikey_input)
+        : key_buffer(apikey_input.key ? apikey_input.key : ""), 
+        name_buffer(apikey_input.name ? apikey_input.name : "")
     {
-        apikey_buf(const realm_app_user_apikey& apikey_input)
-            : key_buffer(apikey_input.key ? apikey_input.key : ""),
-              name_buffer(apikey_input.name ? apikey_input.name : "")
-        {
-            id = apikey_input.id;
-            key = key_buffer.c_str();
-            name = name_buffer.c_str();
-            disabled = apikey_input.disabled;            
-        }
+        id = apikey_input.id;
+        key = key_buffer.c_str();
+        name = name_buffer.c_str();
+        disabled = apikey_input.disabled;
+    }
 
-        const std::string key_buffer;
-        const std::string name_buffer;
-    };
+    const std::string key_buffer;
+    const std::string name_buffer;
+};
 
-    std::unique_ptr<realm_app_user_apikey> apikey_copy;
+std::unique_ptr<apikey_buf> realm_apikey_copy(const realm_app_user_apikey_t* apikey)
+{
+    std::unique_ptr<apikey_buf> apikey_copy;
     if (apikey != nullptr) {
         apikey_copy = std::make_unique<apikey_buf>(*apikey);
     }
-
     return apikey_copy;
 }
 
@@ -327,7 +325,51 @@ RLM_API void realm_dart_apikey_callback(realm_userdata_t userdata, realm_app_use
     auto apikey_copy = realm_apikey_copy(apikey);
 
     auto ud = reinterpret_cast<realm_dart_userdata_async_t>(userdata);
-    ud->scheduler->invoke([ud, apikey = std::move(apikey_copy), error = std::move(error_copy)]() mutable { 
+    ud->scheduler->invoke([ud, apikey = std::move(apikey_copy), error = std::move(error_copy)]() mutable {
         (reinterpret_cast<realm_return_apikey_func_t>(ud->dart_callback))(ud->handle, apikey.get(), error.get());
+    });
+}
+
+std::vector<apikey_buf> realm_apikey_list_copy(const realm_app_user_apikey_t apikey_list[], size_t count)
+{
+    // we make a deep copy of error, so it is valid after callback returns
+    std::vector<apikey_buf> apikey_list_copy;
+    if (apikey_list != nullptr) {
+        apikey_list_copy.reserve(count);
+        std::transform(
+            apikey_list,
+            apikey_list + count,
+            std::back_inserter(apikey_list_copy),
+            [](const realm_app_user_apikey_t& apikey) {
+                return apikey_buf(apikey);
+            }
+        );
+    }
+    return apikey_list_copy;
+}
+
+
+RLM_API void realm_dart_apikey_list_callback(realm_userdata_t userdata, realm_app_user_apikey_t apikey_list[], size_t count, const realm_app_error_t* error) {
+    auto error_copy = realm_app_error_copy(error);
+    auto apikey_list_copy = realm_apikey_list_copy(apikey_list, count);
+
+    auto ud = reinterpret_cast<realm_dart_userdata_async_t>(userdata);
+    ud->scheduler->invoke([ud, apikey_list_buf = std::move(apikey_list_copy), error = std::move(error_copy)]() mutable {
+        std::vector<realm_app_user_apikey> apikey_list;
+        apikey_list.reserve(apikey_list_buf.size());
+        std::transform(
+            apikey_list_buf.begin(),
+            apikey_list_buf.end(),
+            std::back_inserter(apikey_list),
+            [](const apikey_buf& apikey) {
+                return realm_app_user_apikey{
+                    apikey.id,
+                    apikey.key_buffer.c_str(),
+                    apikey.name_buffer.c_str(),
+                    apikey.disabled
+                };
+            }
+        );
+        (reinterpret_cast<realm_return_apikey_list_func_t>(ud->dart_callback))(ud->handle, apikey_list.data(), apikey_list.size(), error.get());
     });
 }

--- a/src/realm_dart_sync.h
+++ b/src/realm_dart_sync.h
@@ -52,3 +52,5 @@ RLM_API void realm_dart_void_completion_callback(realm_userdata_t userdata, cons
 RLM_API void realm_dart_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* apikey, const realm_app_error_t* error);
 
 RLM_API void realm_dart_apikey_list_callback(realm_userdata_t userdata, realm_app_user_apikey_t apikey_list[], size_t count, const realm_app_error_t* error);
+
+RLM_API void realm_dart_return_string_callback(realm_userdata_t userdata, const char* serialized_ejson_response, const realm_app_error_t* error);

--- a/src/realm_dart_sync.h
+++ b/src/realm_dart_sync.h
@@ -47,3 +47,4 @@ RLM_API void realm_dart_async_open_task_callback(realm_userdata_t userdata, real
 
 RLM_API void realm_dart_user_completion_callback(realm_userdata_t userdata, realm_user_t* user, const realm_app_error_t* error);
 
+RLM_API void realm_dart_void_completion_callback(realm_userdata_t userdata, const realm_app_error_t* error);

--- a/src/realm_dart_sync.h
+++ b/src/realm_dart_sync.h
@@ -48,3 +48,6 @@ RLM_API void realm_dart_async_open_task_callback(realm_userdata_t userdata, real
 RLM_API void realm_dart_user_completion_callback(realm_userdata_t userdata, realm_user_t* user, const realm_app_error_t* error);
 
 RLM_API void realm_dart_void_completion_callback(realm_userdata_t userdata, const realm_app_error_t* error);
+
+RLM_API void realm_dart_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* apikey, const realm_app_error_t* error);
+

--- a/src/realm_dart_sync.h
+++ b/src/realm_dart_sync.h
@@ -44,3 +44,6 @@ RLM_API bool realm_dart_sync_before_reset_handler_callback(realm_userdata_t user
 RLM_API bool realm_dart_sync_after_reset_handler_callback(realm_userdata_t userdata, realm_t* before_realm, realm_thread_safe_reference_t* after_realm, bool did_recover);
 
 RLM_API void realm_dart_async_open_task_callback(realm_userdata_t userdata, realm_thread_safe_reference_t* realm, const realm_async_error_t* error);
+
+RLM_API void realm_dart_user_completion_callback(realm_userdata_t userdata, realm_user_t* user, const realm_app_error_t* error);
+

--- a/src/realm_dart_sync.h
+++ b/src/realm_dart_sync.h
@@ -51,3 +51,4 @@ RLM_API void realm_dart_void_completion_callback(realm_userdata_t userdata, cons
 
 RLM_API void realm_dart_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* apikey, const realm_app_error_t* error);
 
+RLM_API void realm_dart_apikey_list_callback(realm_userdata_t userdata, realm_app_user_apikey_t apikey_list[], size_t count, const realm_app_error_t* error);

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -211,6 +211,18 @@ Future<void> main([List<String>? args]) async {
     expect(response, isNotNull);
   });
 
+  baasTest('Call Atlas function on background isolate', (configuration) async {
+    final app = App(configuration);
+    final appId = app.id;
+    expect(Isolate.run(
+      () async {
+        final app = App.getById(appId)!;
+        final user = await app.logIn(Credentials.anonymous());
+        await user.functions.call('userFuncNoArgs');
+      },
+    ), completes);
+  });
+
   baasTest('Call Atlas function with one argument', (configuration) async {
     final app = App(configuration);
     final user = await app.logIn(Credentials.anonymous());

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -309,6 +309,30 @@ Future<void> main([List<String>? args]) async {
     expect(app, null);
   });
 
+  test('app.logIn unsuccessful logIn attempt on background isolate', () {
+    // This test was introduced due to: https://github.com/realm/realm-dart/issues/1467
+    const appId = 'fake-app-id';
+    App(AppConfiguration(appId, baseUrl: Uri.parse('https://this-is-a-fake-url.com')));
+    expect(Isolate.run(
+      () async {
+        final app = App.getById(appId);
+        await app!.logIn(Credentials.anonymous()); // <-- this line used to crash
+      },
+    ), throwsA(isA<AppException>()));
+  });
+
+  baasTest('app.logIn successful logIn on background isolate', (configuration) {
+    // This test was introduced due to: https://github.com/realm/realm-dart/issues/1467
+    final appId = configuration.appId;
+    App(configuration);
+    expect(Isolate.run(
+      () async {
+        final app = App.getById(appId);
+        await app!.logIn(Credentials.anonymous()); // <-- this line used to crash
+      },
+    ), completes);
+  });
+
   baasTest('app.getById with different baseUrl returns null', (appConfig) {
     final app = App(appConfig);
     expect(App.getById(app.id, baseUrl: Uri.parse('https://foo.bar')), null);

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -206,6 +206,18 @@ Future<void> main([List<String>? args]) async {
     expect(apiKeys.length, 0);
   });
 
+  baasTest('User.apiKeys.fetchAll from background isolate', (configuration) async {
+    // This test is to ensure that the API key creation works on a background isolate.
+    // It was introduced due to: https://github.com/realm/realm-dart/issues/1467
+    await getIntegrationUser(App(configuration));
+    final appId = configuration.appId;
+    expect(Isolate.run(() async {
+      final app = App.getById(appId)!;
+      final user = app.currentUser!;
+      user.apiKeys.fetchAll(); // <-- this would crash before the fix
+    }), completes);
+  });
+
   baasTest('User.apiKeys.fetchAll with one key returns it', (configuration) async {
     final app = App(configuration);
     final user = await getIntegrationUser(app);

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 import 'dart:isolate';
+import 'dart:math';
 
 import 'package:test/expect.dart' hide throws;
 
@@ -180,7 +181,7 @@ Future<void> main([List<String>? args]) async {
     expect(key, isNull);
   });
 
-  void expectApiKey(ApiKey? fetched, ApiKey expected) {
+  void expectApiKey(ApiKey? fetched, ApiKey expected, [bool created = false]) {
     expect(fetched, isNotNull);
     expect(fetched!.id, expected.id);
     expect(fetched.isEnabled, expected.isEnabled);
@@ -203,7 +204,7 @@ Future<void> main([List<String>? args]) async {
     final user = await getIntegrationUser(app);
     final apiKeys = await user.apiKeys.fetchAll();
 
-    expect(apiKeys.length, 0);
+    expect(apiKeys, isEmpty);
   });
 
   baasTest('User.apiKeys.fetchAll from background isolate', (configuration) async {
@@ -226,8 +227,8 @@ Future<void> main([List<String>? args]) async {
 
     final apiKeys = await user.apiKeys.fetchAll();
 
-    expect(apiKeys.length, 1);
-    expect(apiKeys.single, original);
+    expect(apiKeys, hasLength(1));
+    expectApiKey(apiKeys.single, original);
   });
 
   baasTest('User.apiKeys.fetchAll with multiple keys returns all', (configuration) async {
@@ -256,7 +257,7 @@ Future<void> main([List<String>? args]) async {
     await user.apiKeys.delete(ObjectId());
 
     final allKeys = await user.apiKeys.fetchAll();
-    expect(allKeys.length, 1);
+    expect(allKeys, hasLength(1));
     expectApiKey(allKeys.single, key);
   });
 
@@ -273,7 +274,7 @@ Future<void> main([List<String>? args]) async {
     expect(fetched, isNull);
 
     final allKeys = await user.apiKeys.fetchAll();
-    expect(allKeys.length, 1);
+    expect(allKeys, hasLength(1));
     expectApiKey(allKeys.single, toRemain);
   });
 


### PR DESCRIPTION
After the introduction of realm app caching hot-restart and background isolates no longer works reliably with realm.

Fixes: #1467 
Fixes: #1466
Fixes: #1451 
Fixes: #1433 (only half fixed by #1445)
