### PR TITLE
kn/run ci with flutter 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.10.0'
           channel: 'stable'
 
       - name: Install dependencies
@@ -373,6 +374,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.10.0'
           channel: 'stable'
 
       - name: Install dependencies
@@ -444,6 +446,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.10.0'
           channel: 'stable'
 
       - name: Delete generated files

--- a/.github/workflows/dart-desktop-tests.yml
+++ b/.github/workflows/dart-desktop-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name : Setup Dart SDK
         uses: dart-lang/setup-dart@main
         with:
-          sdk: stable
+          sdk: 3.0.0
           architecture: ${{ inputs.architecture == 'arm' && 'arm64' || 'x64'}}
 
       - name: Install dependencies

--- a/.github/workflows/flutter-desktop-tests.yml
+++ b/.github/workflows/flutter-desktop-tests.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.10.0'
           channel: 'stable'
           architecture: ${{ inputs.architecture == 'arm' && 'arm64' || 'x64'}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
   The map keys may not contain `.` or start with `$`. (Issue [#685](https://github.com/realm/realm-dart/issues/685))
 * Added a new exception - `MigrationRequiredException` that will be thrown when a local Realm is opened with a schema that differs from the schema on disk and no migration callback is supplied. Additionally, a `helpLink` property has been added to `RealmException` and its subclasses to provide a link to the documentation for the error. (Issue [#1448](https://github.com/realm/realm-dart/issues/1448))
+* Downgrade minimum dependencies to Dart 3.0.0 and Flutter 3.10.0. (PR [#1457](https://github.com/realm/realm-dart/pull/1457))
 
 ### Fixed
 * Fixed warnings being emitted by the realm generator requesting that `xyz.g.dart` be included with `part 'xyz.g.dart';` for `xyz.dart` files that import `realm` but don't have realm models defined. Those should not need generated parts and including the part file would have resulted in an empty file with `// ignore_for_file: type=lint` being generated. (PR [#1443](https://github.com/realm/realm-dart/pull/1443))
@@ -51,6 +52,8 @@
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.
+* Flutter: ^3.10.0
+* Dart: ^3.0.0
 
 ### Internal
 * Using Core v13.26.0.

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -12,7 +12,7 @@ issue_tracker: https://github.com/realm/realm-dart/issues
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.0.0
 
 dependencies:
   objectid: ^3.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: A simple command-line application using Realm Dart SDK.
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.0.0
 
 dependencies:
   realm_dart:

--- a/ffigen/pubspec.yaml
+++ b/ffigen/pubspec.yaml
@@ -8,4 +8,4 @@ environment:
   sdk: ^3.0.0
 
 dev_dependencies:
-  ffigen: ^11.0.0
+  ffigen: ^9.0.0

--- a/ffigen/pubspec.yaml
+++ b/ffigen/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.0.0
 
 dev_dependencies:
   ffigen: ^11.0.0

--- a/flutter/realm_flutter/example/pubspec.yaml
+++ b/flutter/realm_flutter/example/pubspec.yaml
@@ -7,8 +7,8 @@ version: 1.6.1
 publish_to: "none"
 
 environment:
-  sdk: ^3.1.0
-  flutter: ^3.13.0
+  sdk: ^3.0.0
+  flutter: ^3.10.0
 
 dependencies:
   flutter:

--- a/flutter/realm_flutter/pubspec.yaml
+++ b/flutter/realm_flutter/pubspec.yaml
@@ -9,8 +9,8 @@ issue_tracker: https://github.com/realm/realm-dart/issues
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
-  flutter: ^3.13.0
+  sdk: ^3.0.0
+  flutter: ^3.10.0
 
 dependencies:
   flutter:

--- a/flutter/realm_flutter/tests/pubspec.yaml
+++ b/flutter/realm_flutter/tests/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: "none"
 version: 1.6.1
 
 environment:
-  sdk: ^3.1.0
-  flutter: ^3.13.0
+  sdk: ^3.0.0
+  flutter: ^3.10.0
 
 dependencies:
   flutter:

--- a/flutter/realm_flutter/tests/pubspec.yaml
+++ b/flutter/realm_flutter/tests/pubspec.yaml
@@ -7,7 +7,6 @@ version: 1.6.1
 
 environment:
   sdk: ^3.0.0
-  flutter: ^3.10.0
 
 dependencies:
   flutter:
@@ -23,17 +22,17 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  flutter_test:
-    sdk: flutter  
-  flutter_lints: ^3.0.1
-  build_runner: ^2.1.2
+  flutter_lints: ^3.0.0
   test: any
-  timezone: ^0.9.0
+  timezone: any
+
+# Hack to run driver tests with flutter 3.10
+dependency_overrides:
+  realm_common:
+    path: ../../../common 
+  realm_generator: 1.6.0 # unfortunately this is a direct dependency currently, noy a dev dependency
 
 flutter:
   uses-material-design: true
   assets:
     - data/realm_files/old-format.realm
-
-dependency_overrides:
-  test_api: ^0.6.1

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -12,7 +12,7 @@ issue_tracker: https://github.com/realm/realm-dart/issues
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.0.0
 
 dependencies:
   analyzer: ^6.0.0

--- a/lib/src/native/realm_bindings.dart
+++ b/lib/src/native/realm_bindings.dart
@@ -3444,9 +3444,9 @@ class RealmLibrary {
   }
 
   late final _realm_dart_decimal128_from_stringPtr = _lookup<
-          ffi
-          .NativeFunction<realm_decimal128_t Function(ffi.Pointer<ffi.Char>)>>(
-      'realm_dart_decimal128_from_string');
+      ffi.NativeFunction<
+          realm_decimal128_t Function(
+              ffi.Pointer<ffi.Char>)>>('realm_dart_decimal128_from_string');
   late final _realm_dart_decimal128_from_string =
       _realm_dart_decimal128_from_stringPtr
           .asFunction<realm_decimal128_t Function(ffi.Pointer<ffi.Char>)>();
@@ -3748,9 +3748,9 @@ class RealmLibrary {
   }
 
   late final _realm_dart_log_message_for_testingPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Int32, ffi.Pointer<ffi.Char>)>>(
-      'realm_dart_log_message_for_testing');
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int32,
+              ffi.Pointer<ffi.Char>)>>('realm_dart_log_message_for_testing');
   late final _realm_dart_log_message_for_testing =
       _realm_dart_log_message_for_testingPtr
           .asFunction<void Function(int, ffi.Pointer<ffi.Char>)>();
@@ -4231,9 +4231,9 @@ class RealmLibrary {
   }
 
   late final _realm_dictionary_clearPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Bool Function(ffi.Pointer<realm_dictionary_t>)>>(
-      'realm_dictionary_clear');
+      ffi.NativeFunction<
+          ffi.Bool Function(
+              ffi.Pointer<realm_dictionary_t>)>>('realm_dictionary_clear');
   late final _realm_dictionary_clear = _realm_dictionary_clearPtr
       .asFunction<bool Function(ffi.Pointer<realm_dictionary_t>)>();
 
@@ -4636,9 +4636,9 @@ class RealmLibrary {
   }
 
   late final _realm_dictionary_is_validPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Bool Function(ffi.Pointer<realm_dictionary_t>)>>(
-      'realm_dictionary_is_valid');
+      ffi.NativeFunction<
+          ffi.Bool Function(
+              ffi.Pointer<realm_dictionary_t>)>>('realm_dictionary_is_valid');
   late final _realm_dictionary_is_valid = _realm_dictionary_is_validPtr
       .asFunction<bool Function(ffi.Pointer<realm_dictionary_t>)>();
 
@@ -6859,9 +6859,9 @@ class RealmLibrary {
   }
 
   late final _realm_object_as_linkPtr = _lookup<
-          ffi
-          .NativeFunction<realm_link_t Function(ffi.Pointer<realm_object_t>)>>(
-      'realm_object_as_link');
+      ffi.NativeFunction<
+          realm_link_t Function(
+              ffi.Pointer<realm_object_t>)>>('realm_object_as_link');
   late final _realm_object_as_link = _realm_object_as_linkPtr
       .asFunction<realm_link_t Function(ffi.Pointer<realm_object_t>)>();
 
@@ -8315,8 +8315,8 @@ class RealmLibrary {
   }
 
   late final _realm_scheduler_perform_workPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<realm_work_queue_t>)>>(
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<realm_work_queue_t>)>>(
       'realm_scheduler_perform_work');
   late final _realm_scheduler_perform_work = _realm_scheduler_perform_workPtr
       .asFunction<void Function(ffi.Pointer<realm_work_queue_t>)>();
@@ -8500,9 +8500,9 @@ class RealmLibrary {
   }
 
   late final _realm_set_auto_refreshPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<realm_t>, ffi.Bool)>>(
-      'realm_set_auto_refresh');
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Pointer<realm_t>, ffi.Bool)>>('realm_set_auto_refresh');
   late final _realm_set_auto_refresh = _realm_set_auto_refreshPtr
       .asFunction<void Function(ffi.Pointer<realm_t>, bool)>();
 
@@ -8942,9 +8942,9 @@ class RealmLibrary {
   }
 
   late final _realm_sync_client_config_newPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<realm_sync_client_config_t> Function()>>(
-      'realm_sync_client_config_new');
+      ffi.NativeFunction<
+          ffi.Pointer<realm_sync_client_config_t>
+              Function()>>('realm_sync_client_config_new');
   late final _realm_sync_client_config_new = _realm_sync_client_config_newPtr
       .asFunction<ffi.Pointer<realm_sync_client_config_t> Function()>();
 
@@ -11262,8 +11262,8 @@ class _SymbolAddresses {
       get realm_dart_decimal128_from_int64 =>
           _library._realm_dart_decimal128_from_int64Ptr;
   ffi.Pointer<
-          ffi
-          .NativeFunction<realm_decimal128_t Function(ffi.Pointer<ffi.Char>)>>
+          ffi.NativeFunction<
+              realm_decimal128_t Function(ffi.Pointer<ffi.Char>)>>
       get realm_dart_decimal128_from_string =>
           _library._realm_dart_decimal128_from_stringPtr;
   ffi.Pointer<
@@ -11336,8 +11336,8 @@ class _SymbolAddresses {
   ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>
       get realm_dart_library_version => _library._realm_dart_library_versionPtr;
   ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Int32, ffi.Pointer<ffi.Char>)>>
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int32, ffi.Pointer<ffi.Char>)>>
       get realm_dart_log_message_for_testing =>
           _library._realm_dart_log_message_for_testingPtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function(ffi.Handle)>>
@@ -11358,8 +11358,8 @@ class _SymbolAddresses {
       get realm_dart_return_string_callback =>
           _library._realm_dart_return_string_callbackPtr;
   ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Uint64, ffi.Pointer<ffi.Void>)>>
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Uint64, ffi.Pointer<ffi.Void>)>>
       get realm_dart_scheduler_invoke =>
           _library._realm_dart_scheduler_invokePtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int32, Dart_Port)>>
@@ -11395,8 +11395,8 @@ class _SymbolAddresses {
       get realm_dart_sync_error_handler_callback =>
           _library._realm_dart_sync_error_handler_callbackPtr;
   ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>>
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>>
       get realm_dart_sync_on_subscription_state_changed_callback =>
           _library._realm_dart_sync_on_subscription_state_changed_callbackPtr;
   ffi.Pointer<
@@ -11440,7 +11440,6 @@ class _SymbolAddresses {
 
 /// A port is used to send or receive inter-isolate messages
 typedef Dart_Port = ffi.Int64;
-typedef DartDart_Port = int;
 
 final class UnnamedUnion1 extends ffi.Union {
   @ffi.Int64()
@@ -11524,38 +11523,26 @@ typedef realm_app_user_apikey_t = realm_app_user_apikey;
 /// The pointer is alive only for the duration of the callback,
 /// if you wish to use it further make a copy with realm_clone().
 /// @param error Pointer to an error object if the operation failed, otherwise null if it completed successfully.
-typedef realm_app_user_completion_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_app_user_completion_func_tFunction>>;
-typedef realm_app_user_completion_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_user_t> user,
-    ffi.Pointer<realm_app_error_t> error);
-typedef Dartrealm_app_user_completion_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_user_t> user,
-    ffi.Pointer<realm_app_error_t> error);
+typedef realm_app_user_completion_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_user_t> user,
+            ffi.Pointer<realm_app_error_t> error)>>;
 
 /// Generic completion callback for asynchronous Realm App operations.
 ///
 /// @param error Pointer to an error object if the operation failed, otherwise null if it completed successfully.
-typedef realm_app_void_completion_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_app_void_completion_func_tFunction>>;
-typedef realm_app_void_completion_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_app_error_t> error);
-typedef Dartrealm_app_void_completion_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_app_error_t> error);
-typedef realm_async_begin_write_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_async_begin_write_func_tFunction>>;
-typedef realm_async_begin_write_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef Dartrealm_async_begin_write_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef realm_async_commit_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_async_commit_func_tFunction>>;
-typedef realm_async_commit_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Bool error, ffi.Pointer<ffi.Char> desc);
-typedef Dartrealm_async_commit_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, bool error, ffi.Pointer<ffi.Char> desc);
+typedef realm_app_void_completion_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_app_error_t> error)>>;
+typedef realm_async_begin_write_func_t = ffi.Pointer<
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void> userdata)>>;
+typedef realm_async_commit_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata, ffi.Bool error,
+            ffi.Pointer<ffi.Char> desc)>>;
 
 final class realm_async_error extends ffi.Opaque {}
 
@@ -11574,21 +11561,15 @@ final class realm_async_open_task extends ffi.Opaque {}
 /// the object and must release it when used.
 /// @param error Null, if the operation complete successfully.
 typedef realm_async_open_task_completion_func_t = ffi.Pointer<
-    ffi.NativeFunction<realm_async_open_task_completion_func_tFunction>>;
-typedef realm_async_open_task_completion_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_thread_safe_reference_t> realm,
-    ffi.Pointer<realm_async_error_t> error);
-typedef Dartrealm_async_open_task_completion_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_thread_safe_reference_t> realm,
-    ffi.Pointer<realm_async_error_t> error);
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_thread_safe_reference_t> realm,
+            ffi.Pointer<realm_async_error_t> error)>>;
 typedef realm_async_open_task_init_subscription_func_t = ffi.Pointer<
-    ffi.NativeFunction<realm_async_open_task_init_subscription_func_tFunction>>;
-typedef realm_async_open_task_init_subscription_func_tFunction = ffi.Void
-    Function(ffi.Pointer<realm_t> realm, ffi.Pointer<ffi.Void> userdata);
-typedef Dartrealm_async_open_task_init_subscription_func_tFunction = void
-    Function(ffi.Pointer<realm_t> realm, ffi.Pointer<ffi.Void> userdata);
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<realm_t> realm, ffi.Pointer<ffi.Void> userdata)>>;
 
 final class realm_async_open_task_progress_notification_token
     extends ffi.Opaque {}
@@ -11649,7 +11630,6 @@ final class realm_class_info extends ffi.Struct {
 
 typedef realm_class_info_t = realm_class_info;
 typedef realm_class_key_t = ffi.Uint32;
-typedef Dartrealm_class_key_t = int;
 
 final class realm_collection_changes extends ffi.Opaque {}
 
@@ -11691,12 +11671,10 @@ typedef realm_config_t = realm_config;
 final class realm_dart_userdata_async extends ffi.Opaque {}
 
 typedef realm_dart_userdata_async_t = ffi.Pointer<realm_dart_userdata_async>;
-typedef realm_data_initialization_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_data_initialization_func_tFunction>>;
-typedef realm_data_initialization_func_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_t> realm);
-typedef Dartrealm_data_initialization_func_tFunction = bool Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_t> realm);
+typedef realm_data_initialization_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Bool Function(
+            ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_t> realm)>>;
 
 final class realm_decimal128 extends ffi.Struct {
   @ffi.Array.multi([2])
@@ -11895,7 +11873,6 @@ final class realm_error extends ffi.Struct {
 }
 
 typedef realm_error_categories = ffi.UnsignedInt;
-typedef Dartrealm_error_categories = int;
 typedef realm_error_t = realm_error;
 
 final class realm_flx_sync_mutable_subscription_set extends ffi.Opaque {}
@@ -11921,12 +11898,8 @@ abstract class realm_flx_sync_subscription_set_state {
 
 typedef realm_flx_sync_subscription_set_t = realm_flx_sync_subscription_set;
 typedef realm_flx_sync_subscription_t = realm_flx_sync_subscription;
-typedef realm_free_userdata_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_free_userdata_func_tFunction>>;
-typedef realm_free_userdata_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef Dartrealm_free_userdata_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata);
+typedef realm_free_userdata_func_t = ffi.Pointer<
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void> userdata)>>;
 
 final class realm_http_header extends ffi.Struct {
   external ffi.Pointer<ffi.Char> name;
@@ -11964,16 +11937,12 @@ final class realm_http_request extends ffi.Struct {
 ///
 /// @param request The request to send.
 /// @param request_context Internal state pointer of Core, needed by realm_http_transport_complete_request().
-typedef realm_http_request_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_http_request_func_tFunction>>;
-typedef realm_http_request_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    realm_http_request_t request,
-    ffi.Pointer<ffi.Void> request_context);
-typedef Dartrealm_http_request_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    realm_http_request_t request,
-    ffi.Pointer<ffi.Void> request_context);
+typedef realm_http_request_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void> userdata,
+            realm_http_request_t request,
+            ffi.Pointer<ffi.Void> request_context)>>;
 
 abstract class realm_http_request_method {
   static const int RLM_HTTP_REQUEST_METHOD_GET = 0;
@@ -12036,14 +12005,10 @@ typedef realm_link_t = realm_link;
 final class realm_list extends ffi.Opaque {}
 
 typedef realm_list_t = realm_list;
-typedef realm_log_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_log_func_tFunction>>;
-typedef realm_log_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Int32 level,
-    ffi.Pointer<ffi.Char> message);
-typedef Dartrealm_log_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, int level, ffi.Pointer<ffi.Char> message);
+typedef realm_log_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata, ffi.Int32 level,
+            ffi.Pointer<ffi.Char> message)>>;
 
 abstract class realm_log_level {
   static const int RLM_LOG_LEVEL_ALL = 0;
@@ -12057,28 +12022,17 @@ abstract class realm_log_level {
   static const int RLM_LOG_LEVEL_OFF = 8;
 }
 
-typedef realm_migration_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_migration_func_tFunction>>;
-typedef realm_migration_func_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_t> old_realm,
-    ffi.Pointer<realm_t> new_realm,
-    ffi.Pointer<realm_schema_t> schema);
-typedef Dartrealm_migration_func_tFunction = bool Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_t> old_realm,
-    ffi.Pointer<realm_t> new_realm,
-    ffi.Pointer<realm_schema_t> schema);
-typedef realm_mongodb_callback_t
-    = ffi.Pointer<ffi.NativeFunction<realm_mongodb_callback_tFunction>>;
-typedef realm_mongodb_callback_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    realm_string_t bson,
-    ffi.Pointer<realm_app_error_t> app_error);
-typedef Dartrealm_mongodb_callback_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    realm_string_t bson,
-    ffi.Pointer<realm_app_error_t> app_error);
+typedef realm_migration_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Bool Function(
+            ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_t> old_realm,
+            ffi.Pointer<realm_t> new_realm,
+            ffi.Pointer<realm_schema_t> schema)>>;
+typedef realm_mongodb_callback_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata, realm_string_t bson,
+            ffi.Pointer<realm_app_error_t> app_error)>>;
 
 final class realm_mongodb_collection extends ffi.Opaque {}
 
@@ -12127,61 +12081,37 @@ final class realm_object_id extends ffi.Struct {
 
 typedef realm_object_id_t = realm_object_id;
 typedef realm_object_key_t = ffi.Int64;
-typedef Dartrealm_object_key_t = int;
 typedef realm_object_t = realm_object;
-typedef realm_on_collection_change_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_on_collection_change_func_tFunction>>;
-typedef realm_on_collection_change_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void>, ffi.Pointer<realm_collection_changes_t>);
-typedef Dartrealm_on_collection_change_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void>, ffi.Pointer<realm_collection_changes_t>);
-typedef realm_on_dictionary_change_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_on_dictionary_change_func_tFunction>>;
-typedef realm_on_dictionary_change_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void>, ffi.Pointer<realm_dictionary_changes_t>);
-typedef Dartrealm_on_dictionary_change_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void>, ffi.Pointer<realm_dictionary_changes_t>);
-typedef realm_on_object_change_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_on_object_change_func_tFunction>>;
-typedef realm_on_object_change_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void>, ffi.Pointer<realm_object_changes_t>);
-typedef Dartrealm_on_object_change_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void>, ffi.Pointer<realm_object_changes_t>);
+typedef realm_on_collection_change_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void>, ffi.Pointer<realm_collection_changes_t>)>>;
+typedef realm_on_dictionary_change_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void>, ffi.Pointer<realm_dictionary_changes_t>)>>;
+typedef realm_on_object_change_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void>, ffi.Pointer<realm_object_changes_t>)>>;
 typedef realm_on_object_store_error_callback_t = ffi.Pointer<
-    ffi.NativeFunction<realm_on_object_store_error_callback_tFunction>>;
-typedef realm_on_object_store_error_callback_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>);
-typedef Dartrealm_on_object_store_error_callback_tFunction = bool Function(
-    ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>);
+    ffi.NativeFunction<
+        ffi.Bool Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>>;
 typedef realm_on_object_store_thread_callback_t = ffi.Pointer<
-    ffi.NativeFunction<realm_on_object_store_thread_callback_tFunction>>;
-typedef realm_on_object_store_thread_callback_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef Dartrealm_on_object_store_thread_callback_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef realm_on_realm_change_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_on_realm_change_func_tFunction>>;
-typedef realm_on_realm_change_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef Dartrealm_on_realm_change_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef realm_on_realm_refresh_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_on_realm_refresh_func_tFunction>>;
-typedef realm_on_realm_refresh_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef Dartrealm_on_realm_refresh_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata);
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void> userdata)>>;
+typedef realm_on_realm_change_func_t = ffi.Pointer<
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void> userdata)>>;
+typedef realm_on_realm_refresh_func_t = ffi.Pointer<
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void> userdata)>>;
 
 /// Callback for realm schema changed notifications.
 ///
 /// @param new_schema The new schema. This object is released after the callback returns.
 /// Preserve it with realm_clone() if you wish to keep it around for longer.
-typedef realm_on_schema_change_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_on_schema_change_func_tFunction>>;
-typedef realm_on_schema_change_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_schema_t> new_schema);
-typedef Dartrealm_on_schema_change_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_schema_t> new_schema);
+typedef realm_on_schema_change_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_schema_t> new_schema)>>;
 
 abstract class realm_property_flags {
   static const int RLM_PROPERTY_NORMAL = 0;
@@ -12215,7 +12145,6 @@ final class realm_property_info extends ffi.Struct {
 
 typedef realm_property_info_t = realm_property_info;
 typedef realm_property_key_t = ffi.Int64;
-typedef Dartrealm_property_key_t = int;
 
 abstract class realm_property_type {
   static const int RLM_PROPERTY_TYPE_INT = 0;
@@ -12255,72 +12184,42 @@ typedef realm_refresh_callback_token_t = realm_refresh_callback_token;
 final class realm_results extends ffi.Opaque {}
 
 typedef realm_results_t = realm_results;
-typedef realm_return_apikey_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_return_apikey_func_tFunction>>;
-typedef realm_return_apikey_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<realm_app_user_apikey_t>,
-    ffi.Pointer<realm_app_error_t>);
-typedef Dartrealm_return_apikey_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<realm_app_user_apikey_t>,
-    ffi.Pointer<realm_app_error_t>);
-typedef realm_return_apikey_list_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_return_apikey_list_func_tFunction>>;
-typedef realm_return_apikey_list_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<realm_app_user_apikey_t>,
-    ffi.Size,
-    ffi.Pointer<realm_app_error_t>);
-typedef Dartrealm_return_apikey_list_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<realm_app_user_apikey_t>,
-    int,
-    ffi.Pointer<realm_app_error_t>);
-typedef realm_return_string_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_return_string_func_tFunction>>;
-typedef realm_return_string_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<realm_app_error_t>);
-typedef Dartrealm_return_string_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<realm_app_error_t>);
+typedef realm_return_apikey_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<realm_app_user_apikey_t>,
+            ffi.Pointer<realm_app_error_t>)>>;
+typedef realm_return_apikey_list_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<realm_app_user_apikey_t>,
+            ffi.Size,
+            ffi.Pointer<realm_app_error_t>)>>;
+typedef realm_return_string_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>,
+            ffi.Pointer<realm_app_error_t>)>>;
 
 final class realm_scheduler extends ffi.Opaque {}
 
 typedef realm_scheduler_can_deliver_notifications_func_t = ffi.Pointer<
-    ffi
-    .NativeFunction<realm_scheduler_can_deliver_notifications_func_tFunction>>;
-typedef realm_scheduler_can_deliver_notifications_func_tFunction = ffi.Bool
-    Function(ffi.Pointer<ffi.Void> userdata);
-typedef Dartrealm_scheduler_can_deliver_notifications_func_tFunction = bool
-    Function(ffi.Pointer<ffi.Void> userdata);
+    ffi.NativeFunction<ffi.Bool Function(ffi.Pointer<ffi.Void> userdata)>>;
 typedef realm_scheduler_default_factory_func_t = ffi.Pointer<
-    ffi.NativeFunction<realm_scheduler_default_factory_func_tFunction>>;
-typedef realm_scheduler_default_factory_func_tFunction
-    = ffi.Pointer<realm_scheduler_t> Function(ffi.Pointer<ffi.Void> userdata);
-typedef realm_scheduler_is_on_thread_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_scheduler_is_on_thread_func_tFunction>>;
-typedef realm_scheduler_is_on_thread_func_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef Dartrealm_scheduler_is_on_thread_func_tFunction = bool Function(
-    ffi.Pointer<ffi.Void> userdata);
-typedef realm_scheduler_is_same_as_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_scheduler_is_same_as_func_tFunction>>;
-typedef realm_scheduler_is_same_as_func_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void> scheduler_userdata_1,
-    ffi.Pointer<ffi.Void> scheduler_userdata_2);
-typedef Dartrealm_scheduler_is_same_as_func_tFunction = bool Function(
-    ffi.Pointer<ffi.Void> scheduler_userdata_1,
-    ffi.Pointer<ffi.Void> scheduler_userdata_2);
-typedef realm_scheduler_notify_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_scheduler_notify_func_tFunction>>;
-typedef realm_scheduler_notify_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_work_queue_t> work_queue);
-typedef Dartrealm_scheduler_notify_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_work_queue_t> work_queue);
+    ffi.NativeFunction<
+        ffi.Pointer<realm_scheduler_t> Function(
+            ffi.Pointer<ffi.Void> userdata)>>;
+typedef realm_scheduler_is_on_thread_func_t = ffi.Pointer<
+    ffi.NativeFunction<ffi.Bool Function(ffi.Pointer<ffi.Void> userdata)>>;
+typedef realm_scheduler_is_same_as_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Bool Function(ffi.Pointer<ffi.Void> scheduler_userdata_1,
+            ffi.Pointer<ffi.Void> scheduler_userdata_2)>>;
+typedef realm_scheduler_notify_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_work_queue_t> work_queue)>>;
 typedef realm_scheduler_t = realm_scheduler;
 
 final class realm_schema extends ffi.Opaque {}
@@ -12355,14 +12254,10 @@ abstract class realm_schema_validation_mode {
 final class realm_set extends ffi.Opaque {}
 
 typedef realm_set_t = realm_set;
-typedef realm_should_compact_on_launch_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_should_compact_on_launch_func_tFunction>>;
-typedef realm_should_compact_on_launch_func_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Uint64 total_bytes,
-    ffi.Uint64 used_bytes);
-typedef Dartrealm_should_compact_on_launch_func_tFunction = bool Function(
-    ffi.Pointer<ffi.Void> userdata, int total_bytes, int used_bytes);
+typedef realm_should_compact_on_launch_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Bool Function(ffi.Pointer<ffi.Void> userdata,
+            ffi.Uint64 total_bytes, ffi.Uint64 used_bytes)>>;
 
 /// Represents a view over a UTF-8 string buffer. The buffer is unowned by this struct.
 ///
@@ -12392,24 +12287,17 @@ final class realm_string extends ffi.Struct {
 /// - non-empty
 /// When the data member is non-NULL, and the size member is greater than 0.
 typedef realm_string_t = realm_string;
-typedef realm_sync_after_client_reset_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_sync_after_client_reset_func_tFunction>>;
-typedef realm_sync_after_client_reset_func_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_t> before_realm,
-    ffi.Pointer<realm_thread_safe_reference_t> after_realm,
-    ffi.Bool did_recover);
-typedef Dartrealm_sync_after_client_reset_func_tFunction = bool Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_t> before_realm,
-    ffi.Pointer<realm_thread_safe_reference_t> after_realm,
-    bool did_recover);
-typedef realm_sync_before_client_reset_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_sync_before_client_reset_func_tFunction>>;
-typedef realm_sync_before_client_reset_func_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_t> before_realm);
-typedef Dartrealm_sync_before_client_reset_func_tFunction = bool Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_t> before_realm);
+typedef realm_sync_after_client_reset_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Bool Function(
+            ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_t> before_realm,
+            ffi.Pointer<realm_thread_safe_reference_t> after_realm,
+            ffi.Bool did_recover)>>;
+typedef realm_sync_before_client_reset_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Bool Function(ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_t> before_realm)>>;
 
 final class realm_sync_client_config extends ffi.Opaque {}
 
@@ -12437,11 +12325,9 @@ abstract class realm_sync_connection_state {
 }
 
 typedef realm_sync_connection_state_changed_func_t = ffi.Pointer<
-    ffi.NativeFunction<realm_sync_connection_state_changed_func_tFunction>>;
-typedef realm_sync_connection_state_changed_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Int32 old_state, ffi.Int32 new_state);
-typedef Dartrealm_sync_connection_state_changed_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, int old_state, int new_state);
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata, ffi.Int32 old_state,
+            ffi.Int32 new_state)>>;
 
 final class realm_sync_error extends ffi.Struct {
   external realm_error_t status;
@@ -12499,16 +12385,10 @@ final class realm_sync_error_compensating_write_info extends ffi.Struct {
 
 typedef realm_sync_error_compensating_write_info_t
     = realm_sync_error_compensating_write_info;
-typedef realm_sync_error_handler_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_sync_error_handler_func_tFunction>>;
-typedef realm_sync_error_handler_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<realm_sync_session_t>,
-    realm_sync_error_t);
-typedef Dartrealm_sync_error_handler_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<realm_sync_session_t>,
-    realm_sync_error_t);
+typedef realm_sync_error_handler_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void>,
+            ffi.Pointer<realm_sync_session_t>, realm_sync_error_t)>>;
 typedef realm_sync_error_t = realm_sync_error;
 
 final class realm_sync_error_user_info extends ffi.Struct {
@@ -12519,25 +12399,18 @@ final class realm_sync_error_user_info extends ffi.Struct {
 
 typedef realm_sync_error_user_info_t = realm_sync_error_user_info;
 typedef realm_sync_on_subscription_state_changed_t = ffi.Pointer<
-    ffi.NativeFunction<realm_sync_on_subscription_state_changed_tFunction>>;
-typedef realm_sync_on_subscription_state_changed_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Int32 state);
-typedef Dartrealm_sync_on_subscription_state_changed_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, int state);
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata, ffi.Int32 state)>>;
 
 abstract class realm_sync_progress_direction {
   static const int RLM_SYNC_PROGRESS_DIRECTION_UPLOAD = 0;
   static const int RLM_SYNC_PROGRESS_DIRECTION_DOWNLOAD = 1;
 }
 
-typedef realm_sync_progress_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_sync_progress_func_tFunction>>;
-typedef realm_sync_progress_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Uint64 transferred_bytes,
-    ffi.Uint64 total_bytes);
-typedef Dartrealm_sync_progress_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, int transferred_bytes, int total_bytes);
+typedef realm_sync_progress_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata,
+            ffi.Uint64 transferred_bytes, ffi.Uint64 total_bytes)>>;
 
 final class realm_sync_session extends ffi.Opaque {}
 
@@ -12585,91 +12458,58 @@ abstract class realm_sync_socket_callback_result {
   static const int RLM_ERR_SYNC_SOCKET_INVALID_ARGUMENT = 3000;
 }
 
-typedef realm_sync_socket_connect_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_sync_socket_connect_func_tFunction>>;
-typedef realm_sync_socket_connect_func_tFunction
-    = realm_sync_socket_websocket_t Function(
-        ffi.Pointer<ffi.Void> userdata,
-        realm_websocket_endpoint_t endpoint,
-        ffi.Pointer<realm_websocket_observer_t> websocket_observer);
-typedef realm_sync_socket_create_timer_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_sync_socket_create_timer_func_tFunction>>;
-typedef realm_sync_socket_create_timer_func_tFunction
-    = realm_sync_socket_timer_t Function(
-        ffi.Pointer<ffi.Void> userdata,
-        ffi.Uint64 delay_ms,
-        ffi.Pointer<realm_sync_socket_timer_callback_t> timer_callback);
-typedef Dartrealm_sync_socket_create_timer_func_tFunction
-    = realm_sync_socket_timer_t Function(
-        ffi.Pointer<ffi.Void> userdata,
-        int delay_ms,
-        ffi.Pointer<realm_sync_socket_timer_callback_t> timer_callback);
+typedef realm_sync_socket_connect_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        realm_sync_socket_websocket_t Function(
+            ffi.Pointer<ffi.Void> userdata,
+            realm_websocket_endpoint_t endpoint,
+            ffi.Pointer<realm_websocket_observer_t> websocket_observer)>>;
+typedef realm_sync_socket_create_timer_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        realm_sync_socket_timer_t Function(
+            ffi.Pointer<ffi.Void> userdata,
+            ffi.Uint64 delay_ms,
+            ffi.Pointer<realm_sync_socket_timer_callback_t> timer_callback)>>;
 typedef realm_sync_socket_post_callback_t = realm_sync_socket_callback;
-typedef realm_sync_socket_post_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_sync_socket_post_func_tFunction>>;
-typedef realm_sync_socket_post_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_sync_socket_post_callback_t> post_callback);
-typedef Dartrealm_sync_socket_post_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<realm_sync_socket_post_callback_t> post_callback);
+typedef realm_sync_socket_post_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<realm_sync_socket_post_callback_t> post_callback)>>;
 typedef realm_sync_socket_t = realm_sync_socket;
 typedef realm_sync_socket_timer_callback_t = realm_sync_socket_callback;
 typedef realm_sync_socket_timer_canceled_func_t = ffi.Pointer<
-    ffi.NativeFunction<realm_sync_socket_timer_canceled_func_tFunction>>;
-typedef realm_sync_socket_timer_canceled_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, realm_sync_socket_timer_t timer_userdata);
-typedef Dartrealm_sync_socket_timer_canceled_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, realm_sync_socket_timer_t timer_userdata);
-typedef realm_sync_socket_timer_free_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_sync_socket_timer_free_func_tFunction>>;
-typedef realm_sync_socket_timer_free_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, realm_sync_socket_timer_t timer_userdata);
-typedef Dartrealm_sync_socket_timer_free_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, realm_sync_socket_timer_t timer_userdata);
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata,
+            realm_sync_socket_timer_t timer_userdata)>>;
+typedef realm_sync_socket_timer_free_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata,
+            realm_sync_socket_timer_t timer_userdata)>>;
 typedef realm_sync_socket_timer_t = ffi.Pointer<ffi.Void>;
 typedef realm_sync_socket_websocket_async_write_func_t = ffi.Pointer<
-    ffi.NativeFunction<realm_sync_socket_websocket_async_write_func_tFunction>>;
-typedef realm_sync_socket_websocket_async_write_func_tFunction
-    = ffi.Void Function(
-        ffi.Pointer<ffi.Void> userdata,
-        realm_sync_socket_websocket_t websocket,
-        ffi.Pointer<ffi.Char> data,
-        ffi.Size size,
-        ffi.Pointer<realm_sync_socket_write_callback_t> write_callback);
-typedef Dartrealm_sync_socket_websocket_async_write_func_tFunction
-    = void Function(
-        ffi.Pointer<ffi.Void> userdata,
-        realm_sync_socket_websocket_t websocket,
-        ffi.Pointer<ffi.Char> data,
-        int size,
-        ffi.Pointer<realm_sync_socket_write_callback_t> write_callback);
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void> userdata,
+            realm_sync_socket_websocket_t websocket,
+            ffi.Pointer<ffi.Char> data,
+            ffi.Size size,
+            ffi.Pointer<realm_sync_socket_write_callback_t> write_callback)>>;
 typedef realm_sync_socket_websocket_free_func_t = ffi.Pointer<
-    ffi.NativeFunction<realm_sync_socket_websocket_free_func_tFunction>>;
-typedef realm_sync_socket_websocket_free_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, realm_sync_socket_websocket_t websocket);
-typedef Dartrealm_sync_socket_websocket_free_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, realm_sync_socket_websocket_t websocket);
+    ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> userdata,
+            realm_sync_socket_websocket_t websocket)>>;
 typedef realm_sync_socket_websocket_t = ffi.Pointer<ffi.Void>;
 typedef realm_sync_socket_write_callback_t = realm_sync_socket_callback;
-typedef realm_sync_ssl_verify_func_t
-    = ffi.Pointer<ffi.NativeFunction<realm_sync_ssl_verify_func_tFunction>>;
-typedef realm_sync_ssl_verify_func_tFunction = ffi.Bool Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<ffi.Char> server_address,
-    ffi.Short server_port,
-    ffi.Pointer<ffi.Char> pem_data,
-    ffi.Size pem_size,
-    ffi.Int preverify_ok,
-    ffi.Int depth);
-typedef Dartrealm_sync_ssl_verify_func_tFunction = bool Function(
-    ffi.Pointer<ffi.Void> userdata,
-    ffi.Pointer<ffi.Char> server_address,
-    int server_port,
-    ffi.Pointer<ffi.Char> pem_data,
-    int pem_size,
-    int preverify_ok,
-    int depth);
+typedef realm_sync_ssl_verify_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Bool Function(
+            ffi.Pointer<ffi.Void> userdata,
+            ffi.Pointer<ffi.Char> server_address,
+            ffi.Short server_port,
+            ffi.Pointer<ffi.Char> pem_data,
+            ffi.Size pem_size,
+            ffi.Int preverify_ok,
+            ffi.Int depth)>>;
 
 /// Callback function invoked by the sync session once it has uploaded or download
 /// all available changesets. See @a realm_sync_session_wait_for_upload and
@@ -12678,12 +12518,10 @@ typedef Dartrealm_sync_ssl_verify_func_tFunction = bool Function(
 /// This callback is invoked on the sync client's worker thread.
 ///
 /// @param error Null, if the operation completed successfully.
-typedef realm_sync_wait_for_completion_func_t = ffi
-    .Pointer<ffi.NativeFunction<realm_sync_wait_for_completion_func_tFunction>>;
-typedef realm_sync_wait_for_completion_func_tFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_error_t> error);
-typedef Dartrealm_sync_wait_for_completion_func_tFunction = void Function(
-    ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_error_t> error);
+typedef realm_sync_wait_for_completion_func_t = ffi.Pointer<
+    ffi.NativeFunction<
+        ffi.Void Function(
+            ffi.Pointer<ffi.Void> userdata, ffi.Pointer<realm_error_t> error)>>;
 typedef realm_t = shared_realm;
 
 final class realm_thread_safe_reference extends ffi.Opaque {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/realm/realm-dart/issues
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.0.0
 
 dependencies:
   args: ^2.3.0


### PR DESCRIPTION
- Run ffigen after downgrade
- Use flutter 3.10.0 on CI (temporary test)
- Hack to run driver tests with Flutter 3.10 (Dart 3.0)

This PR should not be merged. It exists to test realm with Flutter 3.10 (Dart 3.0), instead of latest stable.

NOTE: We should rework CI to run the full suite on multiple Flutter / Dart versions.