### PR TITLE
Calculate core version with 'git describe' and update automatically in changelog as well

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -75,7 +75,7 @@ jobs:
         id: get-core-version
         run: |
           cd src/realm-core
-          pkgVersion=$(grep "\bVERSION=" dependencies.list | cut -d= -f2)
+          pkgVersion=$(git describe --abbrev=5)
           echo "core-version=$pkgVersion" >> $GITHUB_OUTPUT
           echo "Realm Core version: $pkgVersion"
         shell: bash
@@ -94,6 +94,15 @@ jobs:
             echo 'At most one modified file expected, got ${{ steps.update-realmCoreVersion.outputs.modifiedFiles }}'
             exit 1
           fi
+
+      - name: Update realmCoreVersion in changelog
+        id: update-realmCoreVersion-changelog
+        uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d #! 2.0.0
+        with:
+          find: "* Using Core x.y.z."
+          regex: false
+          replace: "* Using Core ${{ steps.get-core-version.outputs.core-version }}."
+          include: 'CHANGELOG.md'
 
       - name: Create Release PR
         uses: peter-evans/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad #! 3.10.1


### PR DESCRIPTION
This PR updates the way we calculate the core version to allow us to use unofficial releases, and still report a unique tag, instead of just tagging with the version number of the lates official release.

It just uses `git describe` instead of parsing the `dependencies.list` file.

`git describe --abbrev=5` do the right thing on pure tagged commits as well, fx.

- a5e87a39c (tag: v13.26.0) core v13.26.0

produces:
```
realm-core (a5e87a3) [$] via △ v3.28.2 via  v14.21.3 via 🐦 v5.8.1
❯ git describe --abbrev=5
v13.26.0
```