### PR TITLE
Conditional for compatibility with AGP <4.2.

### DIFF
--- a/packages/realm/android/build.gradle
+++ b/packages/realm/android/build.gradle
@@ -22,6 +22,12 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.realm'
+    }
+
     compileSdkVersion 28
 
     defaultConfig {


### PR DESCRIPTION
Compatibility Fix

### Issue 
```shell
Launching lib/main.dart on sdk gphone64 arm64 in debug mode...
Running Gradle task 'assembleDebug'...

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':realm'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

````


### flutter doctor -v

```zshrc
Doctor summary (to see all details, run flutter doctor -v):

[✓] Flutter (Channel stable, 3.19.0, on macOS 14.2.1 23C71 darwin-arm64, locale en-IN)
[✓] Android toolchain - develop for Android devices (Android SDK version 34.0.0)
[✓] Xcode - develop for iOS and macOS (Xcode 15.2)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2023.1)
[✓] VS Code (version 1.86.2)
[✓] Connected device (3 available)
    ! Error: Browsing on the local area network for Candy's iPhone. Ensure the device is unlocked and attached with a cable or associated
      with the same local area network as this Mac.
      The device must be opted into Developer Mode to connect wirelessly. (code -27)
[✓] Network resources

• No issues found!

````