### PR TITLE
Use a guaranteed stable sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* Ctor arguments appear in random order on generated classes, if the realm model contains many properties. (PR [#1531](https://github.com/realm/realm-dart/pull/1531))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.
@@ -16,7 +16,7 @@
 
 ### Enhancements
 * Added `User.changes` stream that allows subscribers to receive notifications when the User changes - for example when the user's custom data changes or when their authentication state changes. (PR [#1500](https://github.com/realm/realm-dart/pull/1500))
-* Allow the query builder to construct >, >=, <, <= queries for string constants. This is a case sensitive lexicographical comparison. Improved performance of RQL queries on a non-linked string property using: >, >=, <, <=, operators and fixed behaviour that a null string should be evaulated as less than everything, previously nulls were not matched. (Core 13.26.0-13-gd12c3)
+* Allow the query builder to construct >, >=, <, <= queries for string constants. This is a case sensitive lexicographical comparison. Improved performance of RQL queries on a non-linked string property using: >, >=, <, <=, operators and fixed behavior that a null string should be evaluated as less than everything, previously nulls were not matched. (Core 13.26.0-13-gd12c3)
 
 ### Fixed
 * Creating an `AppConfiguration` with an empty appId will now throw an exception rather than crashing the app. (Issue [#1487](https://github.com/realm/realm-dart/issues/1487))

--- a/generator/lib/src/class_element_ex.dart
+++ b/generator/lib/src/class_element_ex.dart
@@ -18,6 +18,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import "package:collection/collection.dart";
 import 'package:realm_common/realm_common.dart';
 import 'package:realm_generator/src/dart_type_ex.dart';
 import 'package:source_gen/source_gen.dart';
@@ -153,8 +154,11 @@ extension ClassElementEx on ClassElement {
 
       final objectType = thisType.realmObjectType!;
 
-      // Realm Core requires computed properties at the end so we sort them at generation time versus doing it at runtime every time.
-      final mappedFields = fields.realmInfo.toList()..sort((a, b) => a.isComputed ^ b.isComputed ? (a.isComputed ? 1 : -1) : -1);
+      // Realm Core requires computed properties, such as backlinks, at the end.
+      // So we sort them using a stable sort at generation time, versus doing it
+      // at runtime every time.
+      final mappedFields = fields.realmInfo.toList();
+      mergeSort(mappedFields, compare: (a, b) => a.isComputed ^ b.isComputed ? (a.isComputed ? 1 : -1) : 0);
 
       if (objectType == ObjectType.embeddedObject && mappedFields.any((field) => field.isPrimaryKey)) {
         final pkSpan = fields.firstWhere((field) => field.realmInfo?.isPrimaryKey == true).span;


### PR DESCRIPTION
Fix a bug reported on slack for realm models with many properties, where the order of ctor arguments would appear random.

Turns out `List.sort` is not guaranteed to be stable (but apparently is for small lists).