### PR TITLE
RPM-568: Add a workflow that verifies PR title

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,22 @@
+# NOTE: This is a common file that is overwritten by realm/ci-actions sync service
+# and should only be modified in that repository.
+
+name: "Check PR Title"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled, converted_to_draft, edited]
+
+jobs:
+  check-pr-title:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Enforce PR title
+        uses: realm/ci-actions/title-checker@main
+        with:
+          regex: R[A-Z]{2,5}-[0-9]{1,6}
+          error-hint: Invalid PR title. Make sure it's prefixed with the JIRA ticket the PR addresses or add the no-jira-ticket label.
+          ignore-labels: 'no-jira-ticket'


### PR DESCRIPTION
Adds a workflow that verifies that PR titles have the form of "R...-123".