### PR TITLE
RDART-962: Use xcode 15.4

### DIFF
--- a/.github/workflows/binary-combine-android.yml
+++ b/.github/workflows/binary-combine-android.yml
@@ -14,11 +14,13 @@ jobs:
         with:
           name: librealm-android-x86_64
           path: packages/realm_dart/binary/android
+
       - name: Fetch armeabi-v7a build
         uses: actions/download-artifact@v4
         with:
           name: librealm-android-armeabi-v7a
           path: packages/realm_dart/binary/android
+
       - name: Fetch arm64-v8a build
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
       - name: Select XCode for MacOS
-        if: startsWith(inputs.runner, 'macos')
+        if: runner.os == 'macOS'
         run: |
           xcodes installed
           sudo xcodes select 15.4

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -51,9 +51,11 @@ jobs:
         if: startsWith(matrix.build, 'android')
         run: echo "ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
-      - name: Downgrade XCode for MacOS
-        if: matrix.build == 'macos'
-        run: sudo xcodes select 14.3.1
+      - name: Select XCode for MacOS
+        if: startsWith(inputs.runner, 'macos')
+        run: |
+          xcodes installed
+          sudo xcodes select 15.4
 
       - name: Build
         if: steps.check-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
     secrets: inherit
     with:
       runner: macos-14
-      architecture: arm
+      arch: arm64
       differentiator: dma${{ github.run_id }}${{ github.run_attempt }}
 
   cleanup-cluster-dart-macos-arm:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     name: Build Windows
     uses: ./.github/workflows/build-native.yml
     with:
-     runner: windows-latest
-     binary: windows
-     build: '["windows"]'
+      runner: windows-latest
+      binary: windows
+      build: '["windows"]'
 
   build-macos:
     name: Build MacOS
@@ -35,23 +35,23 @@ jobs:
     name: Build Linux
     uses: ./.github/workflows/build-native.yml
     with:
-     runner: ubuntu-20.04 # Building on the lowest possible Linux (Ubuntu) version for compatibility
-     binary: linux
-     build: '["linux"]'
+      runner: ubuntu-20.04 # Building on the lowest possible Linux (Ubuntu) version for compatibility
+      binary: linux
+      build: '["linux"]'
 
   build-android:
     name: Build Android
     uses: ./.github/workflows/build-native.yml
     with:
-     runner: ubuntu-20.04
-     binary: android
-     build: '["android-x86_64", "android-armeabi-v7a", "android-arm64-v8a"]'
+      runner: ubuntu-20.04
+      binary: android
+      build: '["android-x86_64", "android-armeabi-v7a", "android-arm64-v8a"]'
 
   build-ios:
     name: Build IOS
     uses: ./.github/workflows/build-native.yml
     with:
-      runner: macos-12
+      runner: macos-14
       binary: ios
       build: '["ios-device", "ios-simulator"]'
 
@@ -65,7 +65,7 @@ jobs:
     needs: build-ios
     uses: ./.github/workflows/binary-combine-ios.yml
 
-# Dart jobs
+  # Dart jobs
 
   deploy-cluster-dart-windows:
     name: Deploy Cluster for Dart Windows
@@ -82,7 +82,6 @@ jobs:
       - deploy-cluster-dart-windows
     secrets: inherit
     with:
-      os: windows
       runner: windows-latest
       differentiator: dw${{ github.run_id }}${{ github.run_attempt }}
 
@@ -111,8 +110,7 @@ jobs:
       - deploy-cluster-dart-macos
     secrets: inherit
     with:
-      os: macos
-      runner: macos-latest
+      runner: macos-13
       differentiator: dm${{ github.run_id }}${{ github.run_attempt }}
 
   cleanup-cluster-dart-macos:
@@ -140,7 +138,6 @@ jobs:
       - deploy-cluster-dart-macos-arm
     secrets: inherit
     with:
-      os: macos
       runner: macos-14
       architecture: arm
       differentiator: dma${{ github.run_id }}${{ github.run_attempt }}
@@ -170,7 +167,6 @@ jobs:
       - deploy-cluster-dart-linux
     secrets: inherit
     with:
-      os: linux
       runner: ubuntu-latest
       differentiator: dl${{ github.run_id }}${{ github.run_attempt }}
 
@@ -184,7 +180,7 @@ jobs:
     with:
       differentiator: dl${{ github.run_id }}${{ github.run_attempt }}
 
-# Flutter jobs
+  # Flutter jobs
   deploy-cluster-flutter-windows:
     name: Deploy Cluster for Flutter Windows
     uses: ./.github/workflows/deploy-baas.yml
@@ -200,10 +196,8 @@ jobs:
       - deploy-cluster-flutter-windows
     secrets: inherit
     with:
-      os: windows
       runner: windows-latest
       differentiator: fw${{ github.run_id }}${{ github.run_attempt }}
-
 
   cleanup-cluster-flutter-windows:
     name: Cleanup Cluster for Flutter Windows
@@ -230,8 +224,7 @@ jobs:
       - deploy-cluster-flutter-macos
     secrets: inherit
     with:
-      os: macos
-      runner: macos-latest
+      runner: macos-13
       differentiator: fm${{ github.run_id }}${{ github.run_attempt }}
 
   cleanup-cluster-flutter-macos:
@@ -259,7 +252,6 @@ jobs:
       - deploy-cluster-flutter-linux
     secrets: inherit
     with:
-      os: linux
       runner: ubuntu-latest
       differentiator: fl${{ github.run_id }}${{ github.run_attempt }}
 
@@ -281,7 +273,7 @@ jobs:
       differentiator: fi${{ github.run_id }}${{ github.run_attempt }}
 
   flutter-tests-ios:
-    runs-on: macos-12
+    runs-on: macos-14
     name: Flutter Tests iOS
     timeout-minutes: 45
     needs:
@@ -298,7 +290,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
+
+      - name: Select XCode for MacOS
+        run: |
+          xcodes installed
+          sudo xcodes select 15.3
 
       - name: Enable ccache
         run: echo "PATH=/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
@@ -312,7 +309,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Setup Melos
         run: |
@@ -325,9 +322,9 @@ jobs:
       - name: Launch Simulator
         uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone SE (3rd generation)'
-          os: 'iOS'
-          os_version: '>= 14.0'
+          model: "iPhone SE (3rd generation)"
+          os: "iOS"
+          os_version: ">= 14.0"
 
       - name: Run tests on iOS Simulator
         run: |
@@ -382,7 +379,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Enable KVM
         run: |
@@ -396,7 +393,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 11
 
       - name: Fetch artifacts
@@ -408,7 +405,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Setup Melos
         run: |
@@ -419,7 +416,7 @@ jobs:
         run: dart pub get
 
       # Hack to free up space on the runner to ensure we have enough diskspace to run the emulator
-      - name: Remove unnecessary files (dotnet, etc.) 
+      - name: Remove unnecessary files (dotnet, etc.)
         run: |
           sudo rm -rf /usr/share/dotnet
 
@@ -468,7 +465,6 @@ jobs:
           only-summary: true
           working-directory: packages/realm/tests
 
-
   cleanup-cluster-flutter-android:
     name: Cleanup Cluster for Flutter Android
     uses: ./.github/workflows/terminate-baas.yml
@@ -479,7 +475,7 @@ jobs:
     with:
       differentiator: fa${{ github.run_id }}${{ github.run_attempt }}
 
-# Generator jobs
+  # Generator jobs
 
   generator:
     strategy:
@@ -499,12 +495,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Setup Melos
         run: |
@@ -580,7 +576,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && github.ref == 'refs/heads/main'
     steps:
-        # Run this action to set env.WORKFLOW_CONCLUSION
+      # Run this action to set env.WORKFLOW_CONCLUSION
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5
 
       - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f
@@ -589,7 +585,7 @@ jobs:
         with:
           status: ${{ env.WORKFLOW_CONCLUSION }}
           webhook-url: ${{ secrets.SLACK_DART_WEBHOOK }}
-          channel: '#realm-github-dart'
+          channel: "#realm-github-dart"
           message: |
             *<https://github.com/realm/realm-dart/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|_{{workflow}}_ run id: ${{ github.run_id }} has status _{{jobStatus}}_ >*
             <{{refUrl}}|`{{ref}}` - {{description}}>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,11 @@ jobs:
         with:
           submodules: "recursive"
 
+      - name: Bump ulimit
+        run: |
+          ulimit -n
+          ulimit -n 10240
+
       - name: Select XCode for MacOS
         run: |
           xcodes installed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,11 +326,6 @@ jobs:
           ulimit -n
           ulimit -n 10240
 
-      - name: Select XCode for MacOS
-        run: |
-          xcodes installed
-          sudo xcodes select 15.3
-
       - name: Enable ccache
         run: echo "PATH=/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
       differentiator: fi${{ github.run_id }}${{ github.run_attempt }}
 
   flutter-tests-ios:
-    runs-on: macos-14
+    runs-on: macos-12
     name: Flutter Tests iOS
     timeout-minutes: 45
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,35 @@ jobs:
     with:
       differentiator: fm${{ github.run_id }}${{ github.run_attempt }}
 
+  deploy-cluster-flutter-macos-arm:
+    name: Deploy Cluster for Flutter MacOS Arm
+    uses: ./.github/workflows/deploy-baas.yml
+    secrets: inherit
+    with:
+      differentiator: fma${{ github.run_id }}${{ github.run_attempt }}
+
+  flutter-tests-macos-arm:
+    name: Flutter Tests MacOS Arm
+    uses: ./.github/workflows/flutter-desktop-tests.yml
+    needs:
+      - build-macos
+      - deploy-cluster-flutter-macos-arm
+    secrets: inherit
+    with:
+      runner: macos-14
+      arch: arm64
+      differentiator: fma${{ github.run_id }}${{ github.run_attempt }}
+
+  cleanup-cluster-flutter-macos-arm:
+    name: Cleanup Cluster for Flutter macOS Arm
+    uses: ./.github/workflows/terminate-baas.yml
+    if: always()
+    needs:
+      - flutter-tests-macos-arm
+    secrets: inherit
+    with:
+      differentiator: fma${{ github.run_id }}${{ github.run_attempt }}
+
   deploy-cluster-flutter-linux:
     name: Deploy Cluster for Flutter Linux
     uses: ./.github/workflows/deploy-baas.yml

--- a/.github/workflows/dart-desktop-tests.yml
+++ b/.github/workflows/dart-desktop-tests.yml
@@ -38,16 +38,17 @@ jobs:
         run: false # fail if arch is not as expected
         shell: bash
 
-      - name: Set RUNNER_OS
+      - id: runner_os_lowercase
         # there is no such thing as ${{ tolower(runner.os) }}, hence this abomination ¯\_(ツ)_/¯ 
-        run: echo ${{ runner.os }} | awk '{print "RUNNER_OS=" tolower($0)}' >> $GITHUB_ENV
+        # use with steps.runner_os_lowercase.outputs.os
+        run: echo ${{ runner.os }} | awk '{print "os=" tolower($0)}' >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Fetch artifacts
         uses: actions/download-artifact@v4
         with:
-          name: librealm-${{ env.RUNNER_OS }}
-          path: packages/realm_dart/binary/${{ env.RUNNER_OS }}
+          name: librealm-${{ steps.runner_os_lowercase.outputs.os }}
+          path: packages/realm_dart/binary/${{ steps.runner_os_lowercase.outputs.os }}
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@main

--- a/.github/workflows/dart-desktop-tests.yml
+++ b/.github/workflows/dart-desktop-tests.yml
@@ -52,7 +52,9 @@ jobs:
           melos setup
 
       - name: Bump ulimit on macos
-        run: ulimit -n 10240
+        run: |
+          ulimit -n
+          ulimit -n 10240
         if: ${{ contains(runner.os, 'macos') }}
 
       - name: Run tests ${{ runner.name }} ${{ runner.arch }}

--- a/.github/workflows/dart-desktop-tests.yml
+++ b/.github/workflows/dart-desktop-tests.yml
@@ -3,17 +3,9 @@ name: Dart desktop tests
 on:
   workflow_call:
     inputs:
-      os:
-        description: OS to execute on.
-        required: true
-        type: string
       runner:
         description: GitHub runner image to execute on.
         required: true
-        type: string
-      architecture:
-        description: Architecture to execute on.
-        required: false
         type: string
       differentiator:
         description: Differentiator for the BaaS container.
@@ -28,7 +20,7 @@ env:
 jobs:
   dart-tests:
     runs-on: ${{ inputs.runner }}
-    name: Dart tests on ${{inputs.os }} ${{ inputs.architecture }}
+    name: Dart tests on ${{ inputs.runner }}
     timeout-minutes: 45
 
     steps:
@@ -37,17 +29,21 @@ jobs:
         with:
           submodules: false
 
+      - name: Set RUNNER_OS
+        # there is no such thing as ${{ tolower(runner.os) }}, hence this abomination ¯\_(ツ)_/¯ 
+        run: echo ${{ runner.os }} | awk '{print "RUNNER_OS=" tolower($0)}' >> $GITHUB_ENV
+        shell: bash
+
       - name: Fetch artifacts
         uses: actions/download-artifact@v4
         with:
-          name: librealm-${{ inputs.os }}
-          path: packages/realm_dart/binary/${{ inputs.os }}
+          name: librealm-${{ env.RUNNER_OS }}
+          path: packages/realm_dart/binary/${{ env.RUNNER_OS }}
 
-      - name : Setup Dart SDK
+      - name: Setup Dart SDK
         uses: dart-lang/setup-dart@main
         with:
           sdk: stable
-          architecture: ${{ inputs.architecture == 'arm' && 'arm64' || 'x64'}}
 
       - name: Setup Melos
         run: |
@@ -57,17 +53,17 @@ jobs:
 
       - name: Bump ulimit on macos
         run: ulimit -n 10240
-        if: ${{ contains(inputs.os, 'macos') }}
+        if: ${{ contains(runner.os, 'macos') }}
 
-      - name: Run tests
-        run: ${{ inputs.architecture == 'arm' && 'arch -arm64 ' || '' }}melos test:unit
+      - name: Run tests ${{ runner.name }} ${{ runner.arch }}
+        run: melos test:unit
 
       # TODO: Publish all reports
       - name: Publish Test Report
         uses: dorny/test-reporter@v1.8.0
         if: success() || failure()
         with:
-          name: Test Results Dart ${{ inputs.os }} ${{ inputs.architecture }}
+          name: Test Results Dart ${{ runner.name }} ${{ runner.arch }}
           path: test-results.json
           reporter: dart-json
           only-summary: true

--- a/.github/workflows/dart-desktop-tests.yml
+++ b/.github/workflows/dart-desktop-tests.yml
@@ -11,6 +11,10 @@ on:
         description: Differentiator for the BaaS container.
         required: true
         type: string
+      arch:
+        description: Architecture to execute on.
+        default: x64
+        type: string
 
 env:
   REALM_CI: true
@@ -20,7 +24,7 @@ env:
 jobs:
   dart-tests:
     runs-on: ${{ inputs.runner }}
-    name: Dart tests on ${{ inputs.runner }}
+    name: Dart tests on ${{ inputs.runner }}-${{ inputs.arch }}
     timeout-minutes: 45
 
     steps:
@@ -28,6 +32,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+
+      - name: Check runner.arch
+        if: ${{ inputs.arch != runner.arch }}
+        run: false # fail if arch is not as expected
+        shell: bash
 
       - name: Set RUNNER_OS
         # there is no such thing as ${{ tolower(runner.os) }}, hence this abomination ¯\_(ツ)_/¯ 
@@ -57,7 +66,7 @@ jobs:
           ulimit -n 10240
         if: ${{ contains(runner.os, 'macos') }}
 
-      - name: Run tests ${{ runner.name }} ${{ runner.arch }}
+      - name: Run tests ${{ runner }} ${{ runner.arch }}
         run: melos test:unit
 
       # TODO: Publish all reports
@@ -65,7 +74,7 @@ jobs:
         uses: dorny/test-reporter@v1.8.0
         if: success() || failure()
         with:
-          name: Test Results Dart ${{ runner.name }} ${{ runner.arch }}
+          name: Test Results Dart ${{ runner }} ${{ runner.arch }}
           path: test-results.json
           reporter: dart-json
           only-summary: true

--- a/.github/workflows/flutter-desktop-tests.yml
+++ b/.github/workflows/flutter-desktop-tests.yml
@@ -3,21 +3,17 @@ name: Flutter desktop tests
 on:
   workflow_call:
     inputs:
-      os:
-        description: OS to execute on.
-        required: true
-        type: string
       runner:
         description: GitHub runner image to execute on.
         required: true
         type: string
-      architecture:
-        description: Architecture to execute on.
-        required: false
-        type: string
       differentiator:
         description: Differentiator for the BaaS container.
         required: true
+        type: string
+      arch:
+        description: Architecture to execute on.
+        default: x64
         type: string
 
 env:
@@ -26,7 +22,7 @@ env:
 jobs:
   flutter-tests:
     runs-on: ${{ inputs.runner }}
-    name: Flutter tests on ${{inputs.os }}-${{ inputs.architecture }}
+    name: Flutter tests on ${{ inputs.runner }}-${{ inputs.arch }}
     timeout-minutes: 45
     env:
       BAAS_BAASAAS_API_KEY: ${{ secrets.BAASAAS_API_KEY}}
@@ -42,8 +38,18 @@ jobs:
         with:
           submodules: false
 
+      - name: Check runner.arch
+        if: ${{ inputs.arch != runner.arch }}
+        run: false # fail if arch is not as expected
+        shell: bash
+
+      - name: Set RUNNER_OS
+        # there is no such thing as ${{ tolower(runner.os) }}, hence this abomination ¯\_(ツ)_/¯ 
+        run: echo ${{ runner.os }} | awk '{print "RUNNER_OS=" tolower($0)}' >> $GITHUB_ENV
+        shell: bash
+
       - name: Setup GTK & Ninja on Linux
-        if: ${{ inputs.os == 'linux' }}
+        if: ${{ runner.os == 'linux' }}
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libgtk-3-dev xvfb ninja-build
@@ -51,17 +57,14 @@ jobs:
       - name: Fetch artifacts
         uses: actions/download-artifact@v4
         with:
-          name: librealm-${{ inputs.os }}
-          path: packages/realm_dart/binary/${{ inputs.os }}
+          name: librealm-${{ env.RUNNER_OS }}
+          path: packages/realm_dart/binary/${{ env.RUNNER_OS }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          architecture: ${{ inputs.architecture == 'arm' && 'arm64' || 'x64'}}
-
-      - name: Enable Flutter Desktop support
-        run: flutter config --enable-${{ inputs.os }}-desktop
+          architecture: ${{ inputs.arch }}
 
       - name: Setup Melos
         run: |
@@ -72,16 +75,18 @@ jobs:
         run: dart pub get
 
       - name: Bump ulimit
-        run: ulimit -n 10240
-        if: ${{ contains(inputs.os, 'macos') }}
+        run: |
+          ulimit -n
+          ulimit -n 10240
+        if: ${{ contains(runner.os, 'macos') }}
 
       - name: Run tests
         run: |
-          ${{ inputs.os == 'linux' && 'xvfb-run' || '' }} \
+          ${{ runner.os == 'linux' && 'xvfb-run' || '' }} \
           flutter test integration_test/all_tests.dart \
             --dart-define=BAAS_BAASAAS_API_KEY=$BAAS_BAASAAS_API_KEY \
             --dart-define=BAAS_DIFFERENTIATOR=$BAAS_DIFFERENTIATOR \
-            --device-id=${{ inputs.os }} \
+            --device-id=${{ env.RUNNER_OS }} \
             --file-reporter=json:test-results.json \
             --suppress-analytics
         shell: bash
@@ -91,7 +96,7 @@ jobs:
         uses: dorny/test-reporter@v1.8.0
         if: success() || failure()
         with:
-          name: Test Results Flutter ${{ inputs.os }} ${{ inputs.architecture }}
+          name: Test Results Flutter ${{ runner.os }} ${{ runner.arch }}
           path: test-results.json
           reporter: dart-json
           only-summary: true

--- a/.github/workflows/flutter-desktop-tests.yml
+++ b/.github/workflows/flutter-desktop-tests.yml
@@ -43,9 +43,10 @@ jobs:
         run: false # fail if arch is not as expected
         shell: bash
 
-      - name: Set RUNNER_OS
+      - id: runner_os_lowercase
         # there is no such thing as ${{ tolower(runner.os) }}, hence this abomination ¯\_(ツ)_/¯ 
-        run: echo ${{ runner.os }} | awk '{print "RUNNER_OS=" tolower($0)}' >> $GITHUB_ENV
+        # use with steps.runner_os_lowercase.outputs.os
+        run: echo ${{ runner.os }} | awk '{print "os=" tolower($0)}' >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Setup GTK & Ninja on Linux
@@ -57,8 +58,8 @@ jobs:
       - name: Fetch artifacts
         uses: actions/download-artifact@v4
         with:
-          name: librealm-${{ env.RUNNER_OS }}
-          path: packages/realm_dart/binary/${{ env.RUNNER_OS }}
+          name: librealm-${{ steps.runner_os_lowercase.outputs.os }}
+          path: packages/realm_dart/binary/${{ steps.runner_os_lowercase.outputs.os }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -86,7 +87,7 @@ jobs:
           flutter test integration_test/all_tests.dart \
             --dart-define=BAAS_BAASAAS_API_KEY=$BAAS_BAASAAS_API_KEY \
             --dart-define=BAAS_DIFFERENTIATOR=$BAAS_DIFFERENTIATOR \
-            --device-id=${{ env.RUNNER_OS }} \
+            --device-id=${{ steps.runner_os_lowercase.outputs.os }} \
             --file-reporter=json:test-results.json \
             --suppress-analytics
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Using Core 14.7.0.
 * Disabled codesigning of Apple binaries. (Issue [#1679](https://github.com/realm/realm-dart/issues/1679))
 * Drop building xcframework for catalyst. (Issue [#1695](https://github.com/realm/realm-dart/issues/1695))
+* Using xcode 15.4 for native build. (Issue [#1547](https://github.com/realm/realm-dart/issues/1547))
 
 ## 2.3.0 (2024-05-23)
 

--- a/packages/realm_dart/CMakePresets.json
+++ b/packages/realm_dart/CMakePresets.json
@@ -154,7 +154,7 @@
       "configurePreset": "macos",
       "nativeToolOptions": [
         "-destination",
-        "platform=macOS"
+        "generic/platform=macOS"
       ],
       "configuration": "Debug"
     },

--- a/packages/realm_dart/scripts/build-macos.sh
+++ b/packages/realm_dart/scripts/build-macos.sh
@@ -7,4 +7,4 @@ set -o pipefail
 cd "$(dirname "$0")/.."
 
 cmake --preset macos
-cmake --build --preset macos --config MinSizeRel -- -destination "generic/platform=macOS"
+cmake --build --preset macos --config Release -- -destination "generic/platform=macOS"


### PR DESCRIPTION
Fixes: #1547 

- Use macos-14 runner for arm64 and macos-13 runner for x86_64 (see https://github.com/actions/runner-images?tab=readme-ov-file)
- Use xcode 15.4 which changes a bit how to build universal binaries.