### PR TITLE
RDART-941: Clear collections in mixed when reassigned

### DIFF
--- a/packages/realm_dart/lib/src/native/realm_core.dart
+++ b/packages/realm_dart/lib/src/native/realm_core.dart
@@ -3021,6 +3021,10 @@ class _RealmCore {
           collectionHandle = listHandle;
 
           final list = realm.createList<RealmValue>(listHandle, null);
+
+          // Necessary since Core will not clear the collection if the value was already a collection
+          list.clear();
+
           for (final item in value.value as List<RealmValue>) {
             list.add(item);
           }
@@ -3030,6 +3034,10 @@ class _RealmCore {
           collectionHandle = mapHandle;
 
           final map = realm.createMap<RealmValue>(mapHandle, null);
+
+          // Necessary since Core will not clear the collection if the value was already a collection
+          map.clear();
+
           for (final kvp in (value.value as Map<String, RealmValue>).entries) {
             map[kvp.key] = kvp.value;
           }

--- a/packages/realm_dart/test/realm_value_test.dart
+++ b/packages/realm_dart/test/realm_value_test.dart
@@ -592,6 +592,8 @@ void main() {
 
         final list = obj.oneAny.asList();
 
+        expect(list[1].type, RealmValueType.map);
+
         writeIfNecessary(realm, () => list[1] = RealmValue.from({'new': 5}));
         expectMatches(obj.oneAny, [
           true,
@@ -636,6 +638,8 @@ void main() {
 
         final map = obj.oneAny.asMap();
 
+        expect(map['b']!.type, RealmValueType.map);
+
         writeIfNecessary(realm, () => map['b'] = RealmValue.from({'new': 5}));
         expectMatches(obj.oneAny, {
           'a': 5,
@@ -676,6 +680,8 @@ void main() {
         }
 
         final list = obj.oneAny.asList();
+
+        expect(list[1].type, RealmValueType.list);
 
         writeIfNecessary(realm, () => list[1] = RealmValue.from([5, true]));
         expectMatches(obj.oneAny, [
@@ -720,6 +726,8 @@ void main() {
         }
 
         final map = obj.oneAny.asMap();
+
+        expect(map['b']!.type, RealmValueType.list);
 
         writeIfNecessary(realm, () => map['b'] = RealmValue.from([999, true]));
         expectMatches(obj.oneAny, {


### PR DESCRIPTION
Works except when reassigning collections to the same managed value, which depends on https://github.com/realm/realm-core/issues/7422.