### PR TITLE
Wrong test for local development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 ## vNext (TBD)
 
-### Enhancements
-* None
-
-### Fixed
-* None
-
-### Compatibility
-* Realm Studio: 13.0.0 or later.
-
-### Internal
-* Using Core x.y.z.
-
-## 2.0.0-beta.2 (2024-03-20)
-
 ### Breaking Changes
 * `RealmValue.type` is now an enum of type `RealmValueType` rather than `Type`. If you need the runtime type of the value wrapped in `RealmValue`, use `RealmValue.value.runtimeType`. (Issue [#1505](https://github.com/realm/realm-dart/issues/1505))
 * Renamed `RealmValue.uint8List` constructor to `RealmValue.binary`. (PR [#1469](https://github.com/realm/realm-dart/pull/1469))

--- a/packages/realm/macos/realm.podspec
+++ b/packages/realm/macos/realm.podspec
@@ -11,7 +11,7 @@ realmLibName = "librealm_dart.dylib"
 # We need to create an absolute symlink to librealm_dart.dylib otherwises
 # Cocoapods and Xcode build look for different files from different base directories while handling `vendored_libraries`
 realmLibraryPath = "#{realmPackageDir}/#{realmLibName}";
-if realmLibraryPath.include?("realm/") && !File.exist?(realmLibraryPath)
+if realmLibraryPath.include?("packages/realm/") && !File.exist?(realmLibraryPath)
   absoluteRealRealmLibPath = File.realpath("#{realmPackageDir}/../../realm_dart/binary/macos/#{realmLibName}")
 
   if !File.exist?(absoluteRealRealmLibPath)


### PR DESCRIPTION
The test to determine if a symlink should be added for development, was not correctly updated when we switched to side-by-side package layout. It worked fine in development, but would also try to setup dev symlink for macos lib on end-users machine