### PR TITLE
 RDART-983: Refactor how we open dynamic library to give better error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### Enhancements
 * Improve file compaction performance on platforms with page sizes greater than 4k (for example arm64 Apple platforms) for files less than 256 pages in size (Core 14.4.0).
+* Add better hint to error message, if opening native library fails. (Issue [#1595](https://github.com/realm/realm-dart/issues/1595))
 
 ### Fixed
-* Using prefix expressions such as negation of numbers as an initializer would fail. (Issue [#1606](https://github.com/realm/realm-dart/issues/1606))
+* Using valid const, but non-literal expressions, such as negation of numbers, as an initializer would fail. (Issue [#1606](https://github.com/realm/realm-dart/issues/1606))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/packages/realm_dart/lib/src/init.dart
+++ b/packages/realm_dart/lib/src/init.dart
@@ -71,10 +71,10 @@ DynamicLibrary _openRealmLib() {
     throw RealmError(
       [
         'Could not open $libName. Tried:',
-        (candidatePaths.join('\n')),
+        candidatePaths.map((p) => '- "$p"').join('\n'),
         isFlutterPlatform //
-            ? 'Did you forget to add a dependency on realm package?'
-            : 'Did you forget to run `dart run realm_dart install`?'
+            ? 'Hint: Did you forget to add a dependency on the realm package?'
+            : 'Hint: Did you forget to run `dart run realm_dart install`?'
       ].join('\n'),
     );
   }

--- a/packages/realm_dart/lib/src/init.dart
+++ b/packages/realm_dart/lib/src/init.dart
@@ -5,24 +5,17 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:realm_common/realm_common.dart';
 
 import '../realm.dart' as realm show isFlutterPlatform;
 import '../realm.dart' show realmBinaryName;
 import 'cli/common/target_os_type.dart';
 import 'cli/metrics/metrics_command.dart';
 import 'cli/metrics/options.dart';
+import 'realm_class.dart';
 
 DynamicLibrary? _library;
 
-void _debugWrite(String message) {
-  assert(() {
-    print(message);
-    return true;
-  }());
-}
-
-String _getBinaryPath(String libName) {
+String _getPluginPath(String libName) {
   if (Platform.isAndroid) {
     return libName;
   }
@@ -65,26 +58,45 @@ String get _exeDirName => p.dirname(Platform.resolvedExecutable);
 
 DynamicLibrary _openRealmLib() {
   final libName = _getLibName(realmBinaryName);
-  final root = _getNearestProjectRoot(Platform.script.path) ?? _getNearestProjectRoot(p.current);
 
-  // Try to open lib from various candidate paths
-  List<String> errMessages = [];
-  for (final open in [
-    () => _open(libName), // just ask OS..
-    () => _open(p.join(_exeDirName, libName)), // try finding it next to the executable
-    if (root != null) () => _open(p.join(root, 'binary', Platform.operatingSystem, libName)), // try finding it relative to project
-    () => _open(_getBinaryPath(libName)), // find it where it is installed by plugin
-  ]) {
+  DynamicLibrary? tryOpen(String path) {
     try {
-      return open();
-    } on Error catch (e) {
-      errMessages.add(e.toString());
+      return DynamicLibrary.open(path);
+    } on Error catch (_) {
+      return null;
     }
   }
-  throw RealmError(errMessages.join('\n'));
-}
 
-DynamicLibrary _open(String lib) => DynamicLibrary.open(lib);
+  Never throwError(Iterable<String> candidatePaths) {
+    throw RealmError(
+      [
+        'Could not open $libName. Tried:',
+        (candidatePaths.join('\n')),
+        isFlutterPlatform //
+            ? 'Did you forget to add a dependency on realm package?'
+            : 'Did you forget to run `dart run realm_dart install`?'
+      ].join('\n'),
+    );
+  }
+
+  if (isFlutterPlatform) {
+    final path = _getPluginPath(libName);
+    return tryOpen(path) ?? throwError([path]);
+  } else {
+    final root = _getNearestProjectRoot(Platform.script.path) ?? _getNearestProjectRoot(p.current);
+    final candidatePaths = [
+      libName, // just ask OS..
+      p.join(_exeDirName, libName), // try finding it next to the executable
+      if (root != null) p.join(root, 'binary', Platform.operatingSystem, libName), // try finding it relative to project
+    ];
+    DynamicLibrary? lib;
+    for (final path in candidatePaths) {
+      lib = tryOpen(path);
+      if (lib != null) return lib;
+    }
+    throwError(candidatePaths);
+  }
+}
 
 /// @nodoc
 // Initializes Realm library


### PR DESCRIPTION
This PR aims to give a better error message, if we fail to load the native shared library. 

In the process It changes how we attempt to open it.

First of all it only tries one place when running under the flutter vm, which is the most common scenario. This is not only more correct, but it also improves the error message on failure by not referring to unrelated paths.

Secondly, it will report a hint to add `realm` package if it fails. It is an easy mistake to only add `realm_dart`. We have seen one example already in #1595.

Fix: #1595 

### Sample error messages

#### Dart script:
```
dart run bin/init_realm_dart.dart
Unhandled exception:
Realm error : Could not open librealm_dart.dylib. Tried:
- "librealm_dart.dylib"
- "/Users/kasper/.puro/shared/caches/e76c956498841e1ab458577d3892003e553e4f3c/dart-sdk/bin/librealm_dart.dylib"
/Users/kasper/Projects/mongodb/experiments/init_realm_dart/binary/macos/librealm_dart.dylib
Hint: Did you forget to run `dart run realm_dart install`?
#0      _openRealmLib.throwError (package:realm_dart/src/init.dart:71:5)
#1      _openRealmLib (package:realm_dart/src/init.dart:97:5)
#2      initRealm (package:realm_dart/src/init.dart:120:24)
...
```

#### Dart pre-compiled exe:
```
./bin/init_realm_dart.exe
Unhandled exception:
Realm error : Could not open librealm_dart.dylib. Tried:
- "librealm_dart.dylib"
- "/Users/kasper/Projects/mongodb/experiments/init_realm_dart/bin/librealm_dart.dylib"
- "/Users/kasper/Projects/mongodb/experiments/init_realm_dart/binary/macos/librealm_dart.dylib"
Hint: Did you forget to run `dart run realm_dart install`?
#0      _openRealmLib.throwError (package:realm_dart/src/init.dart:71)
#1      _openRealmLib (package:realm_dart/src/init.dart:97)
#2      initRealm (package:realm_dart/src/init.dart:120)
```

#### Flutter app: 
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Realm error : Could not open realm_dart. Tried:
- "/Users/kasper/Library/Developer/CoreSimulator/Devices/FB6A66E7-50AF-4C35-8118-83EFE909C4D3/data/Containers/Bundle/Application/80555876-B519-4C9E-A280-5CD535D09A4B/Runner.app/Frameworks/realm_dart.framework/realm_dart"
Hint: Did you forget to add a dependency on the realm package?
#0      _openRealmLib.throwError (package:realm_dart/src/init.dart:71:5)
#1      _openRealmLib (package:realm_dart/src/init.dart:84:29)
#2      initRealm (package:realm_dart/src/init.dart:120:24)
...
```
