### PR TITLE
RDART-996: Don't serialize backlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * Using valid const, but non-literal expressions, such as negation of numbers, as an initializer would fail. (Issue [#1606](https://github.com/realm/realm-dart/issues/1606))
-* Backlinks mistakenly included in EJson serialization ([Issue #1616](https://github.com/realm/realm-dart/issues/1616))
+* Backlinks mistakenly included in EJson serialization. ([Issue #1616](https://github.com/realm/realm-dart/issues/1616))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Using valid const, but non-literal expressions, such as negation of numbers, as an initializer would fail. (Issue [#1606](https://github.com/realm/realm-dart/issues/1606))
+* Backlinks mistakenly included in EJson serialization ([Issue #1616](https://github.com/realm/realm-dart/issues/1616))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/packages/realm_dart/test/backlinks_test.dart
+++ b/packages/realm_dart/test/backlinks_test.dart
@@ -164,6 +164,23 @@ void main() {
     }
   });
 
+  test('Backlinks not serialized', () {
+    final config = Configuration.local([Target.schema, Source.schema]);
+    final realm = getRealm(config);
+
+    final target = Target();
+    final source = realm.write(() => realm.add(Source(oneTarget: target)));
+
+    expect(() => source.toEJson(), returnsNormally); // <-- would die here before fix
+    expect(source.toEJson(), isNotNull);
+    expect(
+      source.toEJson(),
+      isA<Map<String, dynamic>>() //
+          .having((m) => m['et mål'], 'forward', isNotNull)
+          .having((m) => m['et mål']!['oneToMany'], 'back', isNull), // backlink not serialized
+    );
+  });
+
   group('getBacklinks() tests', () {
     (Target theOne, List<Target> targets, Iterable<String> expectedSources) populateData() {
       final config = Configuration.local([Target.schema, Source.schema]);

--- a/packages/realm_dart/test/backlinks_test.realm.dart
+++ b/packages/realm_dart/test/backlinks_test.realm.dart
@@ -191,8 +191,6 @@ class Target extends _Target with RealmEntity, RealmObjectBase, RealmObject {
     return <String, dynamic>{
       'name': name.toEJson(),
       'source': source.toEJson(),
-      'oneToMany': oneToMany.toEJson(),
-      'manyToMany': manyToMany.toEJson(),
     };
   }
 
@@ -202,8 +200,6 @@ class Target extends _Target with RealmEntity, RealmObjectBase, RealmObject {
       {
         'name': EJsonValue name,
         'source': EJsonValue source,
-        'oneToMany': EJsonValue oneToMany,
-        'manyToMany': EJsonValue manyToMany,
       } =>
         Target(
           name: fromEJson(name),

--- a/packages/realm_generator/lib/src/realm_model_info.dart
+++ b/packages/realm_generator/lib/src/realm_model_info.dart
@@ -98,7 +98,7 @@ class RealmModelInfo {
       {
         yield 'return <String, dynamic>{';
         {
-          yield* fields.map((f) {
+          yield* allSettable.map((f) {
             return "'${f.realmName}': ${f.name}.toEJson(),";
           });
         }
@@ -115,7 +115,7 @@ class RealmModelInfo {
         {
           yield '{';
           {
-            yield* fields.map((f) {
+            yield* allSettable.map((f) {
               return "'${f.realmName}': EJsonValue ${f.name},";
             });
           }

--- a/packages/realm_generator/test/good_test_data/all_types.expected
+++ b/packages/realm_generator/test/good_test_data/all_types.expected
@@ -68,7 +68,8 @@ class Foo extends _Foo with RealmEntity, RealmObjectBase, RealmObject {
     RealmObjectBase.registerFactory(Foo._);
     register(_toEJson, _fromEJson);
     return SchemaObject(ObjectType.realmObject, Foo, 'MyFoo', [
-      SchemaProperty('x', RealmPropertyType.int, indexType: RealmIndexType.regular),
+      SchemaProperty('x', RealmPropertyType.int,
+          indexType: RealmIndexType.regular),
       SchemaProperty('bar', RealmPropertyType.object,
           optional: true, linkTarget: 'Bar'),
     ]);
@@ -255,7 +256,6 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
       'any': any.toEJson(),
       'manyAny': manyAny.toEJson(),
       'decimal': decimal.toEJson(),
-      'foos': foos.toEJson(),
     };
   }
 
@@ -279,7 +279,6 @@ class Bar extends _Bar with RealmEntity, RealmObjectBase, RealmObject {
         'any': EJsonValue any,
         'manyAny': EJsonValue manyAny,
         'decimal': EJsonValue decimal,
-        'foos': EJsonValue foos,
       } =>
         Bar(
           fromEJson(name),


### PR DESCRIPTION
Backlinks are computed values and cannot be deserialized, and shouldn't be serialized either. Especially since we don't handle cycles during serialization gracefully, and backlinks are guarenteed cycles.

Fix #1616