### PR TITLE
RDART-999: Fix flutter test dlopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Fixed an issue that would cause macOS apps to be rejected with `Invalid Code Signing Entitlements` error. (Issue [#1679](https://github.com/realm/realm-dart/issues/1679))
+* Fixed a regression that makes it inconvenient to run unit tests using realm. (Issue [#1619](https://github.com/realm/realm-dart/issues/1619))
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.

--- a/packages/realm_dart/lib/src/cli/common/target_os_type.dart
+++ b/packages/realm_dart/lib/src/cli/common/target_os_type.dart
@@ -8,24 +8,19 @@ enum TargetOsType {
   ios,
   linux,
   macos,
-  windows,
+  windows;
+
+  bool get isDesktop => [TargetOsType.linux, TargetOsType.macos, TargetOsType.windows].contains(this);
 }
 
 // Cannot use Dart 2.17 enhanced enums, due to an issue with build_cli :-/
 enum Flavor {
   flutter,
-  dart,
+  dart;
 }
 
 extension FlavorEx on Flavor {
-  String get packageName {
-    switch (this) {
-      case Flavor.dart:
-        return 'realm_dart';
-      case Flavor.flutter:
-        return 'realm';
-    }
-  }
+  String get packageName => switch (this) { Flavor.dart => 'realm_dart', Flavor.flutter => 'realm' };
 }
 
 extension StringEx on String {

--- a/packages/realm_dart/lib/src/cli/install/options.dart
+++ b/packages/realm_dart/lib/src/cli/install/options.dart
@@ -8,7 +8,10 @@ part 'options.g.dart';
 
 @CliOptions()
 class Options {
-  @CliOption(help: 'The target OS to install binaries for.', abbr: 't')
+  @CliOption(help: 'The flavor to install binaries for.', abbr: 'f', provideDefaultToOverride: true)
+  Flavor? flavor;
+
+  @CliOption(help: 'The target OS to install binaries for.', abbr: 't', provideDefaultToOverride: true)
   TargetOsType? targetOsType;
 
   // use to debug install command
@@ -23,6 +26,9 @@ class Options {
 
 String get usage => _$parserForOptions.usage;
 
-ArgParser populateOptionsParser(ArgParser p) => _$populateOptionsParser(p);
+ArgParser populateOptionsParser(ArgParser parser, {
+  TargetOsType? targetOsTypeDefaultOverride,
+  Flavor? flavorDefaultOverride,
+}) => _$populateOptionsParser(parser, targetOsTypeDefaultOverride: targetOsTypeDefaultOverride, flavorDefaultOverride: flavorDefaultOverride);
 
 Options parseOptionsResult(ArgResults results) => _$parseOptionsResult(results);

--- a/packages/realm_dart/lib/src/cli/install/options.g.dart
+++ b/packages/realm_dart/lib/src/cli/install/options.g.dart
@@ -30,7 +30,15 @@ Options _$parseOptionsResult(ArgResults result) => Options(
       ),
       force: result['force'] as bool,
       debug: result['debug'] as bool,
-    );
+    )..flavor = _$nullableEnumValueHelperNullable(
+        _$FlavorEnumMapBuildCli,
+        result['flavor'] as String?,
+      );
+
+const _$FlavorEnumMapBuildCli = <Flavor, String>{
+  Flavor.flutter: 'flutter',
+  Flavor.dart: 'dart'
+};
 
 const _$TargetOsTypeEnumMapBuildCli = <TargetOsType, String>{
   TargetOsType.android: 'android',
@@ -40,23 +48,36 @@ const _$TargetOsTypeEnumMapBuildCli = <TargetOsType, String>{
   TargetOsType.windows: 'windows'
 };
 
-ArgParser _$populateOptionsParser(ArgParser parser) => parser
-  ..addOption(
-    'target-os-type',
-    abbr: 't',
-    help: 'The target OS to install binaries for.',
-    allowed: ['android', 'ios', 'linux', 'macos', 'windows'],
-  )
-  ..addFlag(
-    'debug',
-    help: 'Download binary from http://localhost:8000/.',
-    hide: true,
-  )
-  ..addFlag(
-    'force',
-    help: 'Force install, even if we would normally skip it.',
-    hide: true,
-  );
+ArgParser _$populateOptionsParser(
+  ArgParser parser, {
+  Flavor? flavorDefaultOverride,
+  TargetOsType? targetOsTypeDefaultOverride,
+}) =>
+    parser
+      ..addOption(
+        'flavor',
+        abbr: 'f',
+        help: 'The flavor to install binaries for.',
+        defaultsTo: _$FlavorEnumMapBuildCli[flavorDefaultOverride],
+        allowed: ['flutter', 'dart'],
+      )
+      ..addOption(
+        'target-os-type',
+        abbr: 't',
+        help: 'The target OS to install binaries for.',
+        defaultsTo: _$TargetOsTypeEnumMapBuildCli[targetOsTypeDefaultOverride],
+        allowed: ['android', 'ios', 'linux', 'macos', 'windows'],
+      )
+      ..addFlag(
+        'debug',
+        help: 'Download binary from http://localhost:8000/.',
+        hide: true,
+      )
+      ..addFlag(
+        'force',
+        help: 'Force install, even if we would normally skip it.',
+        hide: true,
+      );
 
 final _$parserForOptions = _$populateOptionsParser(ArgParser());
 

--- a/packages/realm_dart/lib/src/init.dart
+++ b/packages/realm_dart/lib/src/init.dart
@@ -25,14 +25,14 @@ String _getLibPathFlutter() {
     TargetOsType.android => nativeLibraryName,
     TargetOsType.ios => p.join(root, 'Frameworks', 'realm_dart.framework', nativeLibraryName),
     TargetOsType.linux => p.join(root, 'lib', nativeLibraryName),
-    TargetOsType.macos => p.join(root, 'Frameworks', nativeLibraryName),
+    TargetOsType.macos => p.join(p.dirname(root), 'Frameworks', nativeLibraryName),
     TargetOsType.windows => nativeLibraryName,
   };
 }
 
 String _getLibPathFlutterTest(Package realmPackage) {
   assert(realmPackage.name == 'realm');
-  final root = p.join(realmPackage.root.path, targetOsType.name);
+  final root = p.join(realmPackage.root.toFilePath(), targetOsType.name);
   return switch (targetOsType) {
     TargetOsType.linux => p.join(root, 'binary', 'linux', nativeLibraryName),
     TargetOsType.macos => p.join(root, nativeLibraryName),
@@ -43,7 +43,7 @@ String _getLibPathFlutterTest(Package realmPackage) {
 
 String _getLibPathDart(Package realmDartPackage) {
   assert(realmDartPackage.name == 'realm_dart');
-  final root = p.join(realmDartPackage.root.path, 'binary', targetOsType.name);
+  final root = p.join(realmDartPackage.root.toFilePath(), 'binary', targetOsType.name);
   if (targetOsType.isDesktop) {
     return p.join(root, nativeLibraryName);
   }
@@ -124,7 +124,7 @@ DynamicLibrary _openRealmLib() {
   final candidatePaths = [
     nativeLibraryName, // just ask OS..
     p.join(_exeDirName, nativeLibraryName), // try finding it next to the executable
-    _getLibPathDart(realmDartPackage)
+    _getLibPathDart(realmDartPackage), // try finding it in the package
   ];
   DynamicLibrary? lib;
   for (final path in candidatePaths) {

--- a/packages/realm_dart/lib/src/realm_dart.dart
+++ b/packages/realm_dart/lib/src/realm_dart.dart
@@ -6,6 +6,3 @@ export 'realm_class.dart' hide RealmInternal;
 /// @nodoc
 // is Realm loaded in Flutter or Dart
 const bool isFlutterPlatform = false;
-
-/// @nodoc
-const String realmBinaryName = 'realm_dart';

--- a/packages/realm_dart/lib/src/realm_flutter.dart
+++ b/packages/realm_dart/lib/src/realm_flutter.dart
@@ -6,6 +6,3 @@ export 'realm_class.dart' hide RealmInternal;
 /// @nodoc
 // is Realm loaded in Flutter or Dart
 const bool isFlutterPlatform = true;
-
-/// @nodoc
-const String realmBinaryName = 'realm_dart';


### PR DESCRIPTION
This PR changes how the native lib is loaded under `flutter test`, `dart test`, and `dart run`.

It also changes how `realm install` command works.

Fixes: #1619
