### PR TITLE
RDART-1010: Allow configuration of generator per realm model class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,25 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* Allow configuration of generator per model class. Currently support specifying the constructor style to use. 
+  ```dart
+  const config = GeneratorConfig(ctorStyle: CtorStyle.allNamed);
+  const realmModel = RealmModel.using(baseType: ObjectType.realmObject, generatorConfig: config);
+
+  @realmModel
+  class _Person {
+    late String name;
+    int age = 42;
+  }
+  ```
+  will generate a constructor like:
+  ```dart
+  Person({
+    required String name,
+    int age = 42,
+  }) { ... }
+  ```
+  (Issue [#292](https://github.com/realm/realm-dart/issues/292))
 
 ### Fixed
 * None

--- a/packages/realm_common/lib/src/realm_common_base.dart
+++ b/packages/realm_common/lib/src/realm_common_base.dart
@@ -20,7 +20,7 @@ enum ObjectType {
   /// to query or modify it.
   asymmetricObject('AsymmetricObject', 2);
 
-  const ObjectType([this._className = 'Unknown', this._flags = -1]);
+  const ObjectType(this._className, this._flags);
 
   final String _className;
   final int _flags;

--- a/packages/realm_common/lib/src/realm_common_base.dart
+++ b/packages/realm_common/lib/src/realm_common_base.dart
@@ -23,7 +23,6 @@ enum ObjectType {
   const ObjectType([this._className = 'Unknown', this._flags = -1]);
 
   final String _className;
-
   final int _flags;
 }
 
@@ -33,15 +32,49 @@ extension ObjectTypeInternal on ObjectType {
   String get className => _className;
 }
 
+/// An enum controlling the constructor type generated for a [RealmModel].
+enum CtorStyle {
+  /// Generate a constructor with only optional parameters named.
+  /// All required parameters will be positional.
+  /// This is the default, unless overridden in the build config.
+  onlyOptionalNamed,
+
+  /// Generate a constructor with all parameters named.
+  allNamed,
+}
+
+/// Class used to define the desired constructor behavior for a [RealmModel].
+///
+/// {@category Annotations}
+class GeneratorConfig {
+  /// The style to use for the generated constructor
+  final CtorStyle ctorStyle;
+
+  const GeneratorConfig({this.ctorStyle = CtorStyle.onlyOptionalNamed});
+}
+
 /// Annotation class used to define `Realm` data model classes and their properties
 ///
 /// {@category Annotations}
 class RealmModel {
-  /// The base type of the object
-  final ObjectType type;
+  /// The base type of the generated object class
+  final ObjectType baseType;
 
-  /// Creates a new instance of [RealmModel] specifying the desired base type.
-  const RealmModel([this.type = ObjectType.realmObject]);
+  /// The generator configuration to use for this model
+  final GeneratorConfig generatorConfig;
+
+  // NOTE: To avoid a breaking change, we keep this old constructor and add a new one
+  /// Creates a new instance of [RealmModel] optionally specifying the [baseType].
+  const RealmModel([
+    ObjectType baseType = ObjectType.realmObject,
+  ]) : this.using(baseType: baseType);
+
+  /// Creates a new instance of [RealmModel] optionally specifying the [baseType]
+  /// and [generatorConfig].
+  const RealmModel.using({
+    this.baseType = ObjectType.realmObject,
+    this.generatorConfig = const GeneratorConfig(),
+  });
 }
 
 /// MapTo annotation for class level and class member level.

--- a/packages/realm_common/lib/src/realm_types.dart
+++ b/packages/realm_common/lib/src/realm_types.dart
@@ -85,18 +85,12 @@ enum RealmCollectionType {
   _3, // ignore: unused_field, constant_identifier_names
   map;
 
-  String get plural {
-    switch (this) {
-      case RealmCollectionType.list:
-        return "lists";
-      case RealmCollectionType.set:
-        return "sets";
-      case RealmCollectionType.map:
-        return "maps";
-      default:
-        return "none";
-    }
-  }
+  String get plural => switch (this) {
+      RealmCollectionType.list => 'lists',
+      RealmCollectionType.set => 'sets',
+      RealmCollectionType.map => 'maps',
+      _ => 'none'
+    };
 }
 
 /// A base class of all Realm errors.

--- a/packages/realm_generator/lib/src/class_element_ex.dart
+++ b/packages/realm_generator/lib/src/class_element_ex.dart
@@ -202,7 +202,19 @@ extension ClassElementEx on ClassElement {
         }
       }
 
-      return RealmModelInfo(name, modelName, realmName, mappedFields, objectType);
+      // Get the generator configuration
+      final index = realmModelInfo?.value.getField('generatorConfig')?.getField('ctorStyle')?.getField('index')?.toIntValue();
+      final ctorStyle = index != null ? CtorStyle.values[index] : CtorStyle.onlyOptionalNamed;
+      final config = GeneratorConfig(ctorStyle: ctorStyle);
+
+      return RealmModelInfo(
+        name,
+        modelName,
+        realmName,
+        mappedFields,
+        objectType,
+        config,
+      );
     } on InvalidGenerationSourceError catch (_) {
       rethrow;
     } catch (e, s) {

--- a/packages/realm_generator/lib/src/dart_type_ex.dart
+++ b/packages/realm_generator/lib/src/dart_type_ex.dart
@@ -24,7 +24,7 @@ extension DartTypeEx on DartType {
     if (element == null) return null;
     final realmModelAnnotation = realmModelChecker.firstAnnotationOfExact(element!);
     if (realmModelAnnotation == null) return null; // not a RealmModel
-    final index = realmModelAnnotation.getField('type')!.getField('index')!.toIntValue()!;
+    final index = realmModelAnnotation.getField('baseType')!.getField('index')!.toIntValue()!;
     return ObjectType.values[index];
   }
 

--- a/packages/realm_generator/lib/src/realm_model_info.dart
+++ b/packages/realm_generator/lib/src/realm_model_info.dart
@@ -45,7 +45,7 @@ class RealmModelInfo {
       }
 
       bool required(RealmFieldInfo f) => f.isRequired || f.isPrimaryKey;
-      bool usePositional(RealmFieldInfo f) => config.ctorStyle == CtorStyle.allNamed ? false : required(f);
+      bool usePositional(RealmFieldInfo f) => config.ctorStyle != CtorStyle.allNamed && required(f);
       String paramName(RealmFieldInfo f) => usePositional(f) ? f.name : f.name.nonPrivate();
       final positional = allSettable.where(usePositional);
       final named = allSettable.except(usePositional);

--- a/packages/realm_generator/test/good_test_data/all_named_ctor.dart
+++ b/packages/realm_generator/test/good_test_data/all_named_ctor.dart
@@ -1,0 +1,12 @@
+import 'package:realm_common/realm_common.dart';
+
+part 'all_named_ctor.realm.dart';
+
+const config = GeneratorConfig(ctorStyle: CtorStyle.allNamed);
+const realmModel = RealmModel.using(baseType: ObjectType.realmObject, generatorConfig: config);
+
+@realmModel
+class _Person {
+  late String name;
+  int age = 42;
+}

--- a/packages/realm_generator/test/good_test_data/all_named_ctor.expected
+++ b/packages/realm_generator/test/good_test_data/all_named_ctor.expected
@@ -1,0 +1,82 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'all_named_ctor.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
+  static var _defaultsSet = false;
+
+  Person({
+    required String name,
+    int age = 42,
+  }) {
+    if (!_defaultsSet) {
+      _defaultsSet = RealmObjectBase.setDefaults<Person>({
+        'age': 42,
+      });
+    }
+    RealmObjectBase.set(this, 'name', name);
+    RealmObjectBase.set(this, 'age', age);
+  }
+
+  Person._();
+
+  @override
+  String get name => RealmObjectBase.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => RealmObjectBase.set(this, 'name', value);
+
+  @override
+  int get age => RealmObjectBase.get<int>(this, 'age') as int;
+  @override
+  set age(int value) => RealmObjectBase.set(this, 'age', value);
+
+  @override
+  Stream<RealmObjectChanges<Person>> get changes =>
+      RealmObjectBase.getChanges<Person>(this);
+
+  @override
+  Stream<RealmObjectChanges<Person>> changesFor([List<String>? keyPaths]) =>
+      RealmObjectBase.getChangesFor<Person>(this, keyPaths);
+
+  @override
+  Person freeze() => RealmObjectBase.freezeObject<Person>(this);
+
+  EJsonValue toEJson() {
+    return <String, dynamic>{
+      'name': name.toEJson(),
+      'age': age.toEJson(),
+    };
+  }
+
+  static EJsonValue _toEJson(Person value) => value.toEJson();
+  static Person _fromEJson(EJsonValue ejson) {
+    return switch (ejson) {
+      {
+        'name': EJsonValue name,
+        'age': EJsonValue age,
+      } =>
+        Person(
+          name: fromEJson(name),
+          age: fromEJson(age),
+        ),
+      _ => raiseInvalidEJson(ejson),
+    };
+  }
+
+  static final schema = () {
+    RealmObjectBase.registerFactory(Person._);
+    register(_toEJson, _fromEJson);
+    return SchemaObject(ObjectType.realmObject, Person, 'Person', [
+      SchemaProperty('name', RealmPropertyType.string),
+      SchemaProperty('age', RealmPropertyType.int),
+    ]);
+  }();
+
+  @override
+  SchemaObject get objectSchema => RealmObjectBase.getSchema(this) ?? schema;
+}

--- a/packages/realm_generator/test/good_test_data/all_named_ctor.realm.dart
+++ b/packages/realm_generator/test/good_test_data/all_named_ctor.realm.dart
@@ -1,0 +1,2 @@
+
+part of 'all_named_ctor.dart';

--- a/packages/realm_generator/test/good_test_data/private_fields.expected
+++ b/packages/realm_generator/test/good_test_data/private_fields.expected
@@ -13,7 +13,7 @@ class WithPrivateFields extends _WithPrivateFields
 
   WithPrivateFields(
     String _plain, {
-    int _withDefault = 0,
+    int withDefault = 0,
   }) {
     if (!_defaultsSet) {
       _defaultsSet = RealmObjectBase.setDefaults<WithPrivateFields>({
@@ -21,7 +21,7 @@ class WithPrivateFields extends _WithPrivateFields
       });
     }
     RealmObjectBase.set(this, '_plain', _plain);
-    RealmObjectBase.set(this, '_withDefault', _withDefault);
+    RealmObjectBase.set(this, '_withDefault', withDefault);
   }
 
   WithPrivateFields._();


### PR DESCRIPTION
Support per realm model configuration of the generator via the `GeneratorConfig` class. Currently we only support specifying the constructor style to use, as this has been a very frequent request (see #292).

  ```dart
  // somewhere define your preferred generator configuration and a const RealmModel that uses it
  const config = GeneratorConfig(ctorStyle: CtorStyle.allNamed);
  const realmModel = RealmModel.using(generatorConfig: config);

  @realmModel // <-- use here
  class _Person {
    late String name;
    int age = 42;
  }
  ```
  will generate a constructor like:
  ```dart
  Person({
    required String name,
    int age = 42,
  }) { ... }
  ```

Fixes: #292
Fixes: #1642 