### PR TITLE
RDART-964: Add PrivacyInfo.xcprivacy for iOS and macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   }) { ... }
   ```
   (Issue [#292](https://github.com/realm/realm-dart/issues/292))
+* Add privacy manifest to apple binaries. (Issue [#1551](https://github.com/realm/realm-dart/issues/1551))
 
 ### Fixed
 * Avoid: Attempt to execute code removed by Dart AOT compiler (TFA). (Issue [#1647](https://github.com/realm/realm-dart/issues/1647))

--- a/packages/realm/ios/Resources/PrivacyInfo.xcprivacy
+++ b/packages/realm/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/realm/ios/realm.podspec
+++ b/packages/realm/ios/realm.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks       = 'realm_dart.xcframework'
   s.dependency                  'Flutter'
   s.platform                  = :ios, '8.0'
-  s.compiler_flags             = "-DBUNDLE_ID='\"#{bundleId}\"'"
+  s.compiler_flags            = "-DBUNDLE_ID='\"#{bundleId}\"'"
   s.library                   = 'c++', 'z', 'compression'
 
   s.swift_version             = '5.0'
@@ -63,4 +63,5 @@ Pod::Spec.new do |s|
                                     :execution_position => :before_compile
                                   }
                                 ]
+  s.resource_bundles          = { 'realm_privacy' => [ 'Resources/PrivacyInfo.xcprivacy' ] }
 end

--- a/packages/realm/macos/Resources/PrivacyInfo.xcprivacy
+++ b/packages/realm/macos/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/realm/macos/realm.podspec
+++ b/packages/realm/macos/realm.podspec
@@ -45,12 +45,12 @@ Pod::Spec.new do |s|
   s.license                   = { :file => '../LICENSE' }
   s.author                    = { 'Realm' => 'help@realm.io' }
   s.source                    = { :path => '.' }
-  s.source_files               = 'Classes/**/*'
+  s.source_files              = 'Classes/**/*'
   s.dependency                  'FlutterMacOS'
 
   s.platform                  = :osx, '10.11'
-  s.compiler_flags             = "-DBUNDLE_ID='\"#{bundleId}\"'"
-  s.pod_target_xcconfig        = { 'DEFINES_MODULE' => 'YES' }
+  s.compiler_flags            = "-DBUNDLE_ID='\"#{bundleId}\"'"
+  s.pod_target_xcconfig       = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version             = '5.0'
   s.vendored_libraries        = "#{realmLibName}"
   s.prepare_command           = "touch #{realmPackageDir}/librealm_dart.dylib" #librealm_dart.dylib is needed before the build is started
@@ -65,4 +65,5 @@ Pod::Spec.new do |s|
                                     :execution_position => :before_compile
                                   }
                                 ]
+  s.resource_bundles          = { 'realm_privacy' => [ 'Resources/PrivacyInfo.xcprivacy' ] }
 end


### PR DESCRIPTION
Adds privacy manifests to our iOS and macOS plugins.

While we only *need* to update the plugins listed [here](https://developer.apple.com/support/third-party-SDK-requirements/) for now (ie RealmSwift), the wording of the page:
> The following are commonly used SDKs in apps on the App Store

suggests that the list of things for which this is required is just an arbitrary cutoff rather than a conceptual distinction, so it seems safest to just assume the list will grow over time and do this for the realm flutter package as well. To be honest I don't trust that Apple got the list right.

Note that we are following the standard Flutter / Cocoapods implementation which has the following caveat:

> The large caveat is that we do not currently know if this actually works. This is the method of inclusion that seems to be [the consensus among people using Cocoapods](https://github.com/CocoaPods/CocoaPods/issues/10325), as bundling it directly as a `resource` causes problems for clients who do not use `use_frameworks`. (In theory it seems like a manifest would not actually be *required* in that case since there is no framework, but it has the potential to actually stomp top-level resources.) Hopefully the automated analysis that Apple will eventually roll out will tolerate the file being bundled in a resource bundle in the framework rather than a top-level manifest file. If not, however, it's not clear how Cocoapods can be supported, so we can adopt this common approach for now under the assumption that eventually tooling will adapt to the reality of the ecosystem, and revisit the exact bundling later if necessary.

Source: https://github.com/flutter/packages/commit/c5349bc9a5be1cbef9c13571d9d6d2b506240b20

The flutter repo is tracking the approach [here](https://github.com/flutter/flutter/issues/131940#issuecomment-2070301947). 

As to why the we (and the flutter team) add `_privacy` to the resource bundle id see 
https://github.com/flutter/packages/pull/5846#issuecomment-1881788602

The actual privacy manifest files are lifted from the realm-swift repo. 

I'll quote the [commit](https://github.com/realm/realm-swift/pull/8455) message, as to. why it looks as it does: 
>     Since we don't include the analytics code in builds for the app store, the only
>     thing we need to declare is that we call fstat() on files in the app container,
>     which core uses internally to check the size of Realm files. This is assuming
>     that if the app logs into Atlas that's something that the app itself has to
>     declare rather than us, as we don't automatically talk to the server on our own
>     behalf.
> 
>     The CocoaPods bundling might not actually work. This is the approach that most
>     of the SDKs on the mandatory privacy manifest list are taking, but since Apple
>     isn't actually checking the manifests yet no one knows if they'll accept this
>     fairly weird way of bundling the xcprivacy file. The less weird way breaks
>     building pods as non-framework static libraries.

Fixes: #1551 
Fixes: #1629 
Fixes: #1630 