### PR TITLE
RDART-1014: Bump required sdk version to ^3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,16 @@
   (Issue [#292](https://github.com/realm/realm-dart/issues/292))
 
 ### Fixed
-* None
+* Avoid: Attempt to execute code removed by Dart AOT compiler (TFA). (Issue [#1647](https://github.com/realm/realm-dart/issues/1647))
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.
 
 ### Internal
 * Using Core x.y.z.
+* Flutter: ^3.19.0
+* Dart: ^3.3.0
+
 
 ## 2.1.0 (2024-04-17)
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -14,8 +14,8 @@ packages:
 command:
   bootstrap:
     environment:
-      sdk: ^3.0.0
-      flutter: ^3.10.0
+      sdk: ^3.3.0
+      flutter: ^3.19.0
     dev_dependencies:
       lints: ^3.0.0
 

--- a/packages/ejson/pubspec.yaml
+++ b/packages/ejson/pubspec.yaml
@@ -16,7 +16,7 @@ version: 0.3.0
 repository: https://github.com/realm/realm-dart/ejson/packages/ejson
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   collection: ^1.17.0

--- a/packages/ejson_analyzer/pubspec.yaml
+++ b/packages/ejson_analyzer/pubspec.yaml
@@ -9,7 +9,7 @@ version: 0.3.0
 repository: https://github.com/realm/realm-dart/ejson/packages/ejson_analyzer
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   analyzer: ^6.0.0

--- a/packages/ejson_annotation/pubspec.yaml
+++ b/packages/ejson_annotation/pubspec.yaml
@@ -9,7 +9,7 @@ version: 0.3.0
 repository: https://github.com/realm/realm-dart/ejson/packages/ejson_annotation
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dev_dependencies:
   lints: ^3.0.0

--- a/packages/ejson_generator/pubspec.yaml
+++ b/packages/ejson_generator/pubspec.yaml
@@ -16,7 +16,7 @@ version: 0.3.0
 repository: https://github.com/realm/realm-dart/ejson/packages/ejson_generator
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   analyzer: ^6.0.0

--- a/packages/ejson_lint/example/pubspec.yaml
+++ b/packages/ejson_lint/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   ejson_annotation: ^0.3.0

--- a/packages/ejson_lint/pubspec.yaml
+++ b/packages/ejson_lint/pubspec.yaml
@@ -9,7 +9,7 @@ version: 0.3.0
 repository: https://github.com/realm/realm-dart/ejson/packages/ejson_lint
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   analyzer: ^6.0.0

--- a/packages/realm/example/pubspec.yaml
+++ b/packages/realm/example/pubspec.yaml
@@ -5,8 +5,8 @@ version: 2.0.0-alpha.2
 publish_to: "none"
 
 environment:
-  sdk: ^3.0.0
-  flutter: ^3.10.0
+  sdk: ^3.3.0
+  flutter: ^3.19.0
 
 dependencies:
   flutter:

--- a/packages/realm/pubspec.yaml
+++ b/packages/realm/pubspec.yaml
@@ -7,8 +7,8 @@ repository: https://github.com/realm/realm-dart
 issue_tracker: https://github.com/realm/realm-dart/issues
 
 environment:
-  sdk: ^3.0.0
-  flutter: ^3.10.0
+  sdk: ^3.3.0
+  flutter: ^3.19.0
 
 dependencies:
   flutter:

--- a/packages/realm/tests/pubspec.yaml
+++ b/packages/realm/tests/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: "none"
 version: 2.0.0-alpha.2
 
 environment:
-  sdk: ^3.0.0
-  flutter: ^3.10.0
+  sdk: ^3.3.0
+  flutter: ^3.19.0
 
 dependencies:
   flutter:

--- a/packages/realm_common/pubspec.yaml
+++ b/packages/realm_common/pubspec.yaml
@@ -10,7 +10,7 @@ repository: https://github.com/realm/realm-dart
 issue_tracker: https://github.com/realm/realm-dart/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   collection: ^1.18.0

--- a/packages/realm_dart/example/pubspec.yaml
+++ b/packages/realm_dart/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: A simple command-line application using Realm Dart SDK.
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   realm_dart:

--- a/packages/realm_dart/pubspec.yaml
+++ b/packages/realm_dart/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/realm/realm-dart
 issue_tracker: https://github.com/realm/realm-dart/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   args: ^2.3.0

--- a/packages/realm_generator/pubspec.yaml
+++ b/packages/realm_generator/pubspec.yaml
@@ -10,7 +10,7 @@ repository: https://github.com/realm/realm-dart
 issue_tracker: https://github.com/realm/realm-dart/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   analyzer: ^6.0.0


### PR DESCRIPTION
This is to avoid a few Dart compiler bugs related to Finalizable objects:
- https://github.com/dart-lang/sdk/issues/54414
- https://github.com/dart-lang/sdk/issues/52596
- https://github.com/dart-lang/sdk/issues/51538

Fixes: #1647 