### PR TITLE
Temporary file descriptor fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,9 @@ jobs:
             --dart-define=BAAS_BAASAAS_API_KEY=$BAAS_BAASAAS_API_KEY \
             --dart-define=BAAS_DIFFERENTIATOR=$BAAS_DIFFERENTIATOR \
             --file-reporter=json:test-results.json \
-            --suppress-analytics
+            --suppress-analytics \
+            --device-id=iphone \
+            --exclude-tags=many_files # <-- temporary work-around
 
       - name: Publish Test Report
         uses: dorny/test-reporter@v1.8.0

--- a/packages/realm/tests/dart_test.yaml
+++ b/packages/realm/tests/dart_test.yaml
@@ -1,0 +1,3 @@
+tags:
+  baas: { timeout: 2x }
+  many_files: {}

--- a/packages/realm/tests/integration_test/all_tests.dart
+++ b/packages/realm/tests/integration_test/all_tests.dart
@@ -50,7 +50,7 @@ void main() {
   group('app_test.dart', app_test.main);
   group('asymmetric_test.dart', asymmetric_test.main);
   group('backlinks_test.dart', backlinks_test.main);
-  group('client_reset_test.dart', client_reset_test.main);
+  group('client_reset_test.dart', client_reset_test.main, tags: 'many_files');
   group('configuration_test.dart', configuration_test.main);
   group('credentials_test.dart', credentials_test.main);
   group('decimal128_test.dart', decimal128_test.main);
@@ -62,14 +62,14 @@ void main() {
   group('manual_test.dart', manual_test.main);
   group('migration_test.dart', migration_test.main);
   group('realm_logger_test.dart', realm_logger_test.main);
-  group('realm_map_test.dart', realm_map_test.main);
+  group('realm_map_test.dart', realm_map_test.main, tags: 'many_files');
   group('realm_object_test.dart', realm_object_test.main);
   group('realm_set_test.dart', realm_set_test.main);
   group('realm_test.dart', realm_test.main);
-  group('realm_value_test.dart', realm_value_test.main);
+  group('realm_value_test.dart', realm_value_test.main, tags: 'many_files');
   group('results_test.dart', results_test.main);
   group('session_test.dart', session_test.main);
   group('subscription_test.dart', subscription_test.main);
+  group('sync_migration_test.dart', sync_migration_test.main, tags: 'many_files');
   group('user_test.dart', user_test.main);
-  group('sync_migration_test.dart', sync_migration_test.main);
 }


### PR DESCRIPTION
After upgrading xcode/macos some tests are prone to run out of file-descriptors. Simply bumping ulimit on the host running the simulator don't work.

This PR tags some test suites as using `many_files` and exclude those when testing on iOS.