### PR TITLE
RDART-950: Update nullability annotations for base url API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## vNext (TBD)
 
 ### Enhancements
-* Allow configuration of generator per model class. Currently support specifying the constructor style to use. 
+* Allow configuration of generator per model class. Currently support specifying the constructor style to use.
   ```dart
   const config = GeneratorConfig(ctorStyle: CtorStyle.allNamed);
   const realmModel = RealmModel.using(baseType: ObjectType.realmObject, generatorConfig: config);
@@ -24,6 +24,7 @@
 
 ### Fixed
 * Avoid: Attempt to execute code removed by Dart AOT compiler (TFA). (Issue [#1647](https://github.com/realm/realm-dart/issues/1647))
+* Fixed nullability annotations for the experimental API `App.baseUrl` and `App.updateBaseUrl`. The former is guaranteed not to be `null`, while the latter will now accept a `null` argument, in which case the base url will be restored to its default value. (Issue [#1523](https://github.com/realm/realm-dart/issues/1523))
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.

--- a/packages/realm_dart/lib/src/app.dart
+++ b/packages/realm_dart/lib/src/app.dart
@@ -219,16 +219,17 @@ class App implements Finalizable {
 
   /// Returns the current value of the base URL used to communicate with the server.
   @experimental
-  Uri? get baseUrl {
-    return Uri.tryParse(realmCore.getBaseUrl(this) ?? '');
+  Uri get baseUrl {
+    return Uri.parse(realmCore.getBaseUrl(this));
   }
 
   /// Temporarily overrides the [baseUrl] value from [AppConfiguration] with a new [baseUrl] value
-  /// used for communicating with the server.
+  /// used for communicating with the server. If set to `null`, the app will revert to the default
+  /// base url.
   ///
   /// The App will revert to using the value in [AppConfiguration] when it is restarted.
   @experimental
-  Future<void> updateBaseUrl(Uri baseUrl) async {
+  Future<void> updateBaseUrl(Uri? baseUrl) async {
     return await realmCore.updateBaseUrl(this, baseUrl);
   }
 

--- a/packages/realm_dart/lib/src/app.dart
+++ b/packages/realm_dart/lib/src/app.dart
@@ -218,6 +218,9 @@ class App implements Finalizable {
   }
 
   /// Returns the current value of the base URL used to communicate with the server.
+  ///
+  /// If an [updateBaseUrl] operation is currently in progress, this value will not
+  /// be updated with the new value until that operation has completed.
   @experimental
   Uri get baseUrl {
     return Uri.parse(realmCore.getBaseUrl(this));

--- a/packages/realm_dart/lib/src/app.dart
+++ b/packages/realm_dart/lib/src/app.dart
@@ -227,6 +227,10 @@ class App implements Finalizable {
   /// used for communicating with the server. If set to `null`, the app will revert to the default
   /// base url.
   ///
+  /// If this operation fails, the app will continue to use the original base URL. If another [App]
+  /// operation is started while this function is in progress, that request will use the original
+  /// base URL location information.
+  ///
   /// The App will revert to using the value in [AppConfiguration] when it is restarted.
   @experimental
   Future<void> updateBaseUrl(Uri? baseUrl) async {

--- a/packages/realm_dart/lib/src/native/realm_core.dart
+++ b/packages/realm_dart/lib/src/native/realm_core.dart
@@ -2420,18 +2420,18 @@ class _RealmCore {
     );
   }
 
-  String? getBaseUrl(App app) {
+  String getBaseUrl(App app) {
     final customDataPtr = _realmLib.realm_app_get_base_url(app.handle._pointer);
-    return customDataPtr.cast<Utf8>().toRealmDartString(freeRealmMemory: true);
+    return customDataPtr.cast<Utf8>().toRealmDartString(freeRealmMemory: true)!;
   }
 
-  Future<void> updateBaseUrl(App app, Uri baseUrl) {
+  Future<void> updateBaseUrl(App app, Uri? baseUrl) {
     final completer = Completer<void>();
     using((arena) {
       _realmLib.invokeGetBool(
           () => _realmLib.realm_app_update_base_url(
                 app.handle._pointer,
-                baseUrl.toString().toCharPtr(arena),
+                baseUrl?.toString().toCharPtr(arena) ?? nullptr,
                 _realmLib.addresses.realm_dart_void_completion_callback,
                 _createAsyncCallbackUserdata(completer),
                 _realmLib.addresses.realm_dart_userdata_async_free,

--- a/packages/realm_dart/test/app_test.dart
+++ b/packages/realm_dart/test/app_test.dart
@@ -299,24 +299,17 @@ void main() {
 
   baasTest('App get Base URL', (configuration) async {
     final app = App(configuration);
-    final credentials = Credentials.anonymous();
-    await app.logIn(credentials);
-    final baseUrl = app.baseUrl;
-    expect(baseUrl, isNotNull);
-    expect(baseUrl, configuration.baseUrl);
+    expect(app.baseUrl, configuration.baseUrl);
   });
 
-  baasTest('App update Base URL', (configuration) async {
-    final app = App(configuration);
-    final credentials = Credentials.anonymous();
-    await app.logIn(credentials);
-    final baseUrl = app.baseUrl;
-    expect(baseUrl, isNotNull);
+  baasTest('App update Base URL', (appConfig) async {
+    final config = await baasHelper!.getAppConfig(customBaseUrl: 'https://services.cloud.mongodb.com');
+    final app = App(config);
+    expect(app.baseUrl, Uri.parse('https://services.cloud.mongodb.com'));
     // Set it to the same thing to confirm the function works, it's not actually going to update the location
-    await app.updateBaseUrl(baseUrl!);
-    final newBaseUrl = app.baseUrl;
-    expect(newBaseUrl, isNotNull);
-    expect(newBaseUrl, baseUrl);
+    await app.updateBaseUrl(Uri.parse(baasHelper!.baseUrl));
+    expect(app.baseUrl, appConfig.baseUrl);
+    expect(app.baseUrl, isNot(Uri.parse('https://services.cloud.mongodb.com')));
   });
 
   test('bundleId is salted, hashed and encoded', () {

--- a/packages/realm_dart/test/baas_helper.dart
+++ b/packages/realm_dart/test/baas_helper.dart
@@ -177,9 +177,10 @@ class BaasHelper {
     testing.printOnFailure("Splunk logs: $splunk");
   }
 
-  Future<AppConfiguration> getAppConfig({AppName appName = AppName.flexible}) => _getAppConfig(appName.name);
+  Future<AppConfiguration> getAppConfig({AppName appName = AppName.flexible, String? customBaseUrl}) =>
+      _getAppConfig(appName.name, customBaseUrl: customBaseUrl);
 
-  Future<AppConfiguration> _getAppConfig(String appName) async {
+  Future<AppConfiguration> _getAppConfig(String appName, {String? customBaseUrl}) async {
     final app = _baasApps[appName] ??
         _baasApps.values.firstWhere((element) => element.name == BaasClient.defaultAppName, orElse: () => throw RealmError("No BAAS apps"));
     if (app.error != null) {
@@ -189,7 +190,7 @@ class BaasHelper {
     final temporaryDir = await Directory.systemTemp.createTemp('realm_test_');
     return AppConfiguration(
       app.clientAppId,
-      baseUrl: Uri.parse(baseUrl),
+      baseUrl: Uri.parse(customBaseUrl ?? baseUrl),
       baseFilePath: temporaryDir,
       maxConnectionTimeout: Duration(minutes: 10),
       defaultRequestTimeout: Duration(minutes: 7),

--- a/packages/realm_dart/test/test.dart
+++ b/packages/realm_dart/test/test.dart
@@ -597,7 +597,7 @@ Future<void> baasTest(
 
   skip = shouldSkip(skip);
 
-  test('[BAAS] $name', () async {
+  test(name, () async {
     baasHelper!.printSplunkLogLink(appName, baasHelper?.baseUrl);
     final config = await baasHelper!.getAppConfig(appName: appName);
     await testFunction(config);


### PR DESCRIPTION
Updates nullability annotations - the getter should never return `null`, while the setter should accept `null` to indicate the developer wants to reset the base url to the default value.

Fixes https://github.com/realm/realm-dart/issues/1523.