### PR TITLE
RDART-1016: Cleanup iOS podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* `realm_privacy` bundle mistakenly included an exe-file preventing app store submissions. (Issue [#1656](https://github.com/realm/realm-dart/issues/1656))
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.

--- a/packages/realm/ios/realm.podspec
+++ b/packages/realm/ios/realm.podspec
@@ -37,12 +37,7 @@ Pod::Spec.new do |s|
   s.library                   = 'c++', 'z', 'compression'
 
   s.swift_version             = '5.0'
-  s.pod_target_xcconfig       = { 'DEFINES_MODULE' => 'YES',
-                                  'HEADER_SEARCH_PATHS' => [
-                                    '"$(PODS_TARGET_SRCROOT)/Classes"',
-                                  ],
-                                  'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/**"'
-                                }
+  s.pod_target_xcconfig       = { 'DEFINES_MODULE' => 'YES' }
                                 #Use --debug to debug the install command on both prepare_command and script_phase below
   s.prepare_command           = "source \"#{project_dir}/Flutter/flutter_export_environment.sh\" && cd \"$FLUTTER_APPLICATION_PATH\" && \"$FLUTTER_ROOT/bin/dart\" run realm install --target-os-type ios"
   s.script_phases             = [

--- a/packages/realm/ios/realm.podspec
+++ b/packages/realm/ios/realm.podspec
@@ -38,13 +38,6 @@ Pod::Spec.new do |s|
 
   s.swift_version             = '5.0'
   s.pod_target_xcconfig       = { 'DEFINES_MODULE' => 'YES',
-                                  'CURRENT_PROJECT_VERSION' => s.version,
-                                  'VERSIONING_SYSTEM' => 'apple-generic',
-                                  'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
-                                  'CLANG_CXX_LIBRARY' => 'libc++',
-                                  # Flutter.framework does not contain a i386 slice.
-                                  # Only x86_64 simulators are supported. Using EXCLUDED_ARCHS to exclude i386 arch.
-                                  'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
                                   'HEADER_SEARCH_PATHS' => [
                                     '"$(PODS_TARGET_SRCROOT)/Classes"',
                                   ],


### PR DESCRIPTION
Had a fruitful discussion with @tgoyne

This PR removes some cruft from our ios podspec pod_target_xcconfig

In particular 'VERSIONING_SYSTEM' => 'apple-generic'. 

This will cause a realm_privacy_vers.c file to be formed and hence an exe to be build, which will cause trouble on app store connect.

Fixes: #1656 