### PR TITLE
RDART-1022: Drop x86 as target

### DIFF
--- a/.github/workflows/binary-combine-android.yml
+++ b/.github/workflows/binary-combine-android.yml
@@ -9,11 +9,6 @@ jobs:
     timeout-minutes: 15
     runs-on:  ubuntu-latest
     steps:
-      - name: Fetch x86 build
-        uses: actions/download-artifact@v4
-        with:
-          name: librealm-android-x86
-          path: packages/realm_dart/binary/android
       - name: Fetch x86_64 build
         uses: actions/download-artifact@v4
         with:
@@ -41,7 +36,6 @@ jobs:
         uses: geekyeggo/delete-artifact@v4
         with:
           name: |
-            librealm-android-x86
             librealm-android-x86_64
             librealm-android-armeabi-v7a
             librealm-android-arm64-v8a

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -51,6 +51,10 @@ jobs:
         if: startsWith(matrix.build, 'android')
         run: echo "ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
+      - name: Downgrade XCode for MacOS
+        if: matrix.build == 'macos'
+        run: sudo xcode-select -s /Applications/Xcode_14.0.1.app
+
       - name: Build
         if: steps.check-cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Downgrade XCode for MacOS
         if: matrix.build == 'macos'
-        run: sudo xcode-select -s /Applications/Xcode_14.0.1.app
+        run: sudo xcodes select 14.3.1
 
       - name: Build
         if: steps.check-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     with:
      runner: ubuntu-20.04
      binary: android
-     build: '["android-x86", "android-x86_64", "android-armeabi-v7a", "android-arm64-v8a"]'
+     build: '["android-x86_64", "android-armeabi-v7a", "android-arm64-v8a"]'
 
   build-ios:
     name: Build IOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,23 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* Nested collections have full support for automatic client reset. (Core 14.7.0)
 
 ### Fixed
 * Private fields did not work with default values. (Issue [#1663](https://github.com/realm/realm-dart/issues/1663))
+
+* Having links in a nested collections would leave the file inconsistent if the top object is removed. (Core 14.7.0)
+
+* Accessing App.currentUser from within a notification produced by App.switchUser() (which includes notifications for a newly logged in user) would deadlock. (Core 14.7.0)
+
+* Inserting the same typed link to the same key in a dictionary more than once would incorrectly create multiple backlinks to the object. This did not appear to cause any crashes later, but would have affecting explicit backlink count queries (eg: `...@links.@count`) and possibly notifications. (Core 14.7.0)
+
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.
 
 ### Internal
-* Using Core x.y.z.
+* Using Core 14.7.0.
 
 ## 2.2.1 (2024-05-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Internal
 * Using Core 14.6.2.
+* Drop build of `x86` android slice. (Issue [#1670](https://github.com/realm/realm-dart/issues/1670))
 
 ## 2.2.0 (2024-05-01)
 

--- a/packages/realm_dart/CMakePresets.json
+++ b/packages/realm_dart/CMakePresets.json
@@ -88,14 +88,6 @@
       }
     },
     {
-      "name": "android-x86",
-      "displayName": "Android x86",
-      "inherits": "android",
-      "cacheVariables": {
-        "CMAKE_ANDROID_ARCH_ABI": "x86"
-      }
-    },
-    {
       "name": "android-x86_64",
       "displayName": "Android x86_64",
       "inherits": "android",
@@ -136,12 +128,6 @@
       "name": "windows",
       "configurePreset": "windows",
       "displayName": "x64",
-      "configuration": "Debug"
-    },
-    {
-      "name": "android-x86",
-      "configurePreset": "android-x86",
-      "displayName": "x86",
       "configuration": "Debug"
     },
     {

--- a/packages/realm_dart/dev/lib/src/build.dart
+++ b/packages/realm_dart/dev/lib/src/build.dart
@@ -68,7 +68,6 @@ enum OS {
 enum Target {
   androidArm(Architecture.arm, OS.android),
   androidArm64(Architecture.arm64, OS.android),
-  androidIA32(Architecture.ia32, OS.android),
   androidX64(Architecture.x64, OS.android), // only for emulator
   // androidRiscv64, // not supported by realm currently
   // fuchsiaArm64, // -"- etc.

--- a/packages/realm_dart/scripts/build-android.sh
+++ b/packages/realm_dart/scripts/build-android.sh
@@ -21,11 +21,11 @@ fi
 # Start in the root directory of the project.
 cd "$(dirname "$0")/.."
 
-ABIS=(x86 x86_64 armeabi-v7a arm64-v8a)
+ABIS=(x86_64 armeabi-v7a arm64-v8a)
 
-# only building for x86 if no arguments
+# only building for arm64-v8a if no arguments
 if [ $# -eq 0 ]; then
-    ABIS=(x86)
+    ABIS=arm64-v8a)
 fi
 
 for abi in "${ABIS[@]}"; do

--- a/packages/realm_dart/src/realm_dart.cpp
+++ b/packages/realm_dart/src/realm_dart.cpp
@@ -35,12 +35,6 @@ std::string cpuArch = "arm64";
 #pragma message("Building arm64")
 #endif
 
-
-#if REALM_ARCHITECTURE_X86_32
-std::string cpuArch = "x86";
-#pragma message("Building x86")
-#endif
-
 #if REALM_ARCHITECTURE_X86_64
 std::string cpuArch = "x86_64";
 #pragma message("Building x64")

--- a/packages/realm_dart/test/app_test.dart
+++ b/packages/realm_dart/test/app_test.dart
@@ -190,7 +190,7 @@ void main() {
   baasTest('Call Atlas function that does not exist', (configuration) async {
     final app = App(configuration);
     final user = await app.logIn(Credentials.anonymous());
-    await expectLater(user.functions.call('notExisitingFunction'), throws<AppException>("function not found: 'notExisitingFunction'"));
+    await expectLater(user.functions.call('notExisitingFunction'), throws<AppException>("function not found"));
   });
 
   baasTest('Call Atlas function with no arguments', (configuration) async {

--- a/packages/realm_dart/test/app_test.dart
+++ b/packages/realm_dart/test/app_test.dart
@@ -184,7 +184,13 @@ void main() {
     await app.deleteUser(user);
     expect(user.state, UserState.removed);
 
-    await expectLater(() => loginWithRetry(app, Credentials.emailPassword(username, strongPassword)), throws<AppException>("invalid username/password"));
+    await expectLater(
+      () => loginWithRetry(app, Credentials.emailPassword(username, strongPassword)),
+      throwsA(isA<AppException>()
+          .having((e) => e.message, 'message', equals('unauthorized'))
+          .having((e) => e.statusCode, 'statusCode', 401)
+          .having((e) => e.linkToServerLogs, 'linkToServerLogs', contains('logs?co_id='))),
+    );
   });
 
   baasTest('Call Atlas function that does not exist', (configuration) async {

--- a/packages/realm_dart/test/user_test.dart
+++ b/packages/realm_dart/test/user_test.dart
@@ -382,7 +382,7 @@ void main() {
     await expectLater(
         () => app.logIn(credentials),
         throwsA(isA<AppException>()
-            .having((e) => e.message, 'message', contains('invalid API key'))
+            .having((e) => e.message, 'message', equals('unauthorized'))
             .having((e) => e.statusCode, 'statusCode', 401)
             .having((e) => e.linkToServerLogs, 'linkToServerLogs', contains('logs?co_id='))));
 
@@ -405,7 +405,7 @@ void main() {
     await expectLater(
         () => app.logIn(credentials),
         throwsA(isA<AppException>()
-            .having((e) => e.message, 'message', contains('invalid API key'))
+            .having((e) => e.message, 'message', equals('unauthorized'))
             .having((e) => e.statusCode, 'statusCode', 401)
             .having((e) => e.linkToServerLogs, 'linkToServerLogs', contains('logs?co_id='))));
   });
@@ -452,7 +452,7 @@ void main() {
     await expectLater(
         () async => await app.logIn(credentials),
         throwsA(isA<AppException>()
-            .having((e) => e.message, 'message', 'invalid API key')
+            .having((e) => e.message, 'message', 'unauthorized')
             .having((e) => e.statusCode, 'statusCode', 401)
             .having((e) => e.linkToServerLogs, 'linkToServerLogs', contains('logs?co_id='))));
   });


### PR DESCRIPTION
Reduce android bundle size.

There is no need to build for `x86` as flutter itself does not support it.

Fixes: #1670 