### PR TITLE
RDART-1038: Drop keep alive hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,7 @@
 
 ### Internal
 * Using Core 13.26.0-13-gd12c3
+* Drop work-around for pre-dart-2.19 bug. ([#1691](https://github.com/realm/realm-dart/pull/1691))
 
 ## 1.8.0 (2024-01-29)
 

--- a/packages/realm_dart/lib/src/app.dart
+++ b/packages/realm_dart/lib/src/app.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
-import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate';
 
@@ -140,7 +139,7 @@ class AppConfiguration {
 /// * Register uses and perform various user-related operations through authentication providers
 /// * Synchronize data between the local device and a remote Realm App with Synchronized Realms
 /// {@category Application}
-class App implements Finalizable {
+class App {
   final AppHandle _handle;
 
   /// The id of this application. This is the same as the appId in the [AppConfiguration] used to
@@ -260,11 +259,6 @@ enum MetadataPersistenceMode {
 
 /// @nodoc
 extension AppInternal on App {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-  }
-
   AppHandle get handle => _handle;
 
   static App create(AppHandle handle) => App._(handle);

--- a/packages/realm_dart/lib/src/collections.dart
+++ b/packages/realm_dart/lib/src/collections.dart
@@ -1,7 +1,6 @@
 // Copyright 2022 MongoDB, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'dart:ffi';
 import 'native/collection_changes_handle.dart';
 
 /// Contains index information about objects that moved within the same collection.
@@ -46,7 +45,7 @@ class MapChanges {
 }
 
 /// Describes the changes in a Realm collection since the last time the notification callback was invoked.
-class RealmCollectionChanges implements Finalizable {
+class RealmCollectionChanges {
   final CollectionChangesHandle _handle;
   late final CollectionChanges _changes = _handle.changes;
 
@@ -73,10 +72,5 @@ class RealmCollectionChanges implements Finalizable {
 }
 
 extension RealmCollectionChangesInternal on RealmCollectionChanges {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-  }
-
   CollectionChanges get changes => _changes;
 }

--- a/packages/realm_dart/lib/src/configuration.dart
+++ b/packages/realm_dart/lib/src/configuration.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
-import 'dart:ffi';
 import 'dart:io';
 
 // ignore: no_leading_underscores_for_library_prefixes
@@ -69,7 +68,7 @@ typedef AfterResetCallback = FutureOr<void> Function(Realm beforeResetRealm, Rea
 
 /// Configuration used to create a `Realm` instance
 /// {@category Configuration}
-abstract class Configuration implements Finalizable {
+abstract class Configuration {
   /// The default realm filename to be used.
   static String get defaultRealmName => _path.basename(defaultRealmPath);
   static set defaultRealmName(String name) => defaultRealmPath = _path.join(_path.dirname(defaultRealmPath), _path.basename(name));
@@ -377,11 +376,6 @@ class FlexibleSyncConfiguration extends Configuration {
 }
 
 extension FlexibleSyncConfigurationInternal on FlexibleSyncConfiguration {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    user.keepAlive();
-  }
-
   SessionStopPolicy get sessionStopPolicy => _sessionStopPolicy;
   set sessionStopPolicy(SessionStopPolicy value) => _sessionStopPolicy = value;
 }

--- a/packages/realm_dart/lib/src/credentials.dart
+++ b/packages/realm_dart/lib/src/credentials.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
-import 'dart:ffi';
 
 import 'app.dart';
 import 'native/convert.dart';
@@ -57,7 +56,7 @@ extension AuthProviderTypeInternal on AuthProviderType {
 
 /// A class, representing the credentials used for authenticating a [User]
 /// {@category Application}
-class Credentials implements Finalizable {
+class Credentials {
   final CredentialsHandle _handle;
 
   /// Returns a [Credentials] object that can be used to authenticate an anonymous user.
@@ -100,18 +99,13 @@ class Credentials implements Finalizable {
 
 /// @nodoc
 extension CredentialsInternal on Credentials {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-  }
-
   CredentialsHandle get handle => _handle;
 }
 
 /// A class, encapsulating functionality for users, logged in with [Credentials.emailPassword()].
 /// It is always scoped to a particular app.
 /// {@category Application}
-class EmailPasswordAuthProvider implements Finalizable {
+class EmailPasswordAuthProvider {
   final App app;
 
   /// Create a new EmailPasswordAuthProvider for the [app]
@@ -160,10 +154,5 @@ class EmailPasswordAuthProvider implements Finalizable {
 }
 
 extension EmailPasswordAuthProviderInternal on EmailPasswordAuthProvider {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    app.keepAlive();
-  }
-
   static EmailPasswordAuthProvider create(App app) => EmailPasswordAuthProvider(app);
 }

--- a/packages/realm_dart/lib/src/list.dart
+++ b/packages/realm_dart/lib/src/list.dart
@@ -4,7 +4,6 @@
 import 'dart:core';
 import 'dart:async';
 import 'dart:collection';
-import 'dart:ffi';
 
 import 'package:collection/collection.dart' as collection;
 
@@ -22,7 +21,7 @@ import 'results.dart';
 /// added to or deleted from the collection or from the Realm.
 ///
 /// {@category Realm}
-abstract class RealmList<T extends Object?> with RealmEntity implements List<T>, Finalizable {
+abstract class RealmList<T extends Object?> with RealmEntity implements List<T> {
   late final RealmObjectMetadata? _metadata;
 
   /// Gets a value indicating whether this collection is still valid to use.
@@ -255,15 +254,6 @@ extension RealmListOfObject<T extends RealmObjectBase> on RealmList<T> {
 
 /// @nodoc
 extension RealmListInternal<T extends Object?> on RealmList<T> {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    final self = this;
-    if (self is ManagedRealmList<T>) {
-      realm.keepAlive();
-      self._handle.keepAlive();
-    }
-  }
-
   ManagedRealmList<T> asManaged() => this is ManagedRealmList<T> ? this as ManagedRealmList<T> : throw RealmStateError('$this is not managed');
 
   ListHandle get handle {

--- a/packages/realm_dart/lib/src/map.dart
+++ b/packages/realm_dart/lib/src/map.dart
@@ -6,7 +6,6 @@ import 'dart:collection';
 
 import 'package:collection/collection.dart' as collection;
 
-import 'dart:ffi';
 
 import 'collections.dart';
 import 'native/handle_base.dart';
@@ -19,7 +18,7 @@ import 'realm_class.dart';
 import 'results.dart';
 
 /// RealmMap is a collection that contains key-value pairs of <String, T>.
-abstract class RealmMap<T extends Object?> with RealmEntity implements MapBase<String, T>, Finalizable {
+abstract class RealmMap<T extends Object?> with RealmEntity implements MapBase<String, T> {
   /// Gets a value indicating whether this collection is still valid to use.
   ///
   /// Indicates whether the [Realm] instance hasn't been closed,
@@ -228,15 +227,6 @@ extension RealmMapOfObject<T extends RealmObjectBase> on RealmMap<T?> {
 
 /// @nodoc
 extension RealmMapInternal<T extends Object?> on RealmMap<T> {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    final self = this;
-    if (self is ManagedRealmMap<T>) {
-      realm.keepAlive();
-      self._handle.keepAlive();
-    }
-  }
-
   ManagedRealmMap<T> asManaged() => this is ManagedRealmMap<T> ? this as ManagedRealmMap<T> : throw RealmStateError('$this is not managed');
 
   MapHandle get handle {

--- a/packages/realm_dart/lib/src/native/handle_base.dart
+++ b/packages/realm_dart/lib/src/native/handle_base.dart
@@ -39,9 +39,6 @@ abstract class HandleBase<T extends NativeType> implements Finalizable {
   bool get released => pointer == nullptr;
   final bool isUnowned;
 
-  @pragma('vm:never-inline')
-  void keepAlive() {}
-
   HandleBase(this.pointer, int size) : isUnowned = false {
     pointer.raiseLastErrorIfNull();
     _finalizableHandle = realmLib.realm_attach_finalizer(this, pointer.cast(), size);

--- a/packages/realm_dart/lib/src/realm_class.dart
+++ b/packages/realm_dart/lib/src/realm_class.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
-import 'dart:ffi';
 import 'dart:io';
 
 import 'package:cancellation_token/cancellation_token.dart';
@@ -116,7 +115,7 @@ export 'user.dart' show User, UserState, ApiKeyClient, UserIdentity, ApiKey, Fun
 /// A [Realm] instance represents a `Realm` database.
 ///
 /// {@category Realm}
-class Realm implements Finalizable {
+class Realm {
   late final RealmMetadata _metadata;
   late final RealmHandle _handle;
   final bool _isInMigration;
@@ -727,15 +726,6 @@ class Transaction {
 
 /// @nodoc
 extension RealmInternal on Realm {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-    final c = config;
-    if (c is FlexibleSyncConfiguration) {
-      c.keepAlive();
-    }
-  }
-
   RealmHandle get handle {
     if (_handle.released) {
       throw RealmClosedError('Cannot access realm that has been closed');
@@ -864,7 +854,7 @@ extension RealmInternal on Realm {
 }
 
 /// @nodoc
-abstract class NotificationsController implements Finalizable {
+abstract class NotificationsController {
   NotificationTokenHandle? handle;
 
   NotificationTokenHandle subscribe();

--- a/packages/realm_dart/lib/src/realm_object.dart
+++ b/packages/realm_dart/lib/src/realm_object.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
-import 'dart:ffi';
 
 import 'package:collection/collection.dart';
 import 'package:realm_common/realm_common.dart';
@@ -365,7 +364,7 @@ extension RealmEntityInternal on RealmEntity {
 ///
 /// [RealmObject] should not be used directly as it is part of the generated class hierarchy. ex: `MyClass extends _MyClass with RealmObject`.
 /// {@category Realm}
-mixin RealmObjectBase on RealmEntity implements RealmObjectBaseMarker, Finalizable {
+mixin RealmObjectBase on RealmEntity implements RealmObjectBaseMarker {
   ObjectHandle? _handle;
   RealmAccessor _accessor = RealmValuesAccessor();
   static final Map<Type, RealmObjectBase Function()> _factories = <Type, RealmObjectBase Function()>{
@@ -646,12 +645,6 @@ extension EmbeddedObjectExtension on EmbeddedObject {
 /// @nodoc
 //RealmObject package internal members
 extension RealmObjectInternal on RealmObjectBase {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _realm?.keepAlive();
-    _handle?.keepAlive();
-  }
-
   void manage(Realm realm, ObjectHandle handle, RealmCoreAccessor accessor, bool update) {
     if (_handle != null) {
       //most certainly a bug hence we throw an Error
@@ -726,7 +719,7 @@ class UserCallbackException extends RealmException {
 }
 
 /// Describes the changes in on a single RealmObject since the last time the notification callback was invoked.
-class RealmObjectChanges<T extends RealmObjectBase> implements Finalizable {
+class RealmObjectChanges<T extends RealmObjectBase> {
   // ignore: unused_field
   final ObjectChangesHandle _handle;
 
@@ -749,12 +742,7 @@ class RealmObjectChanges<T extends RealmObjectBase> implements Finalizable {
 }
 
 /// @nodoc
-extension RealmObjectChangesInternal<T extends RealmObject> on RealmObjectChanges<T> {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-  }
-}
+extension RealmObjectChangesInternal<T extends RealmObject> on RealmObjectChanges<T> {}
 
 /// @nodoc
 class RealmObjectNotificationsController<T extends RealmObjectBase> extends NotificationsController {

--- a/packages/realm_dart/lib/src/results.dart
+++ b/packages/realm_dart/lib/src/results.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
-import 'dart:ffi';
 
 import 'package:cancellation_token/cancellation_token.dart';
 
@@ -19,7 +18,7 @@ import 'realm_object.dart';
 /// added to or deleted from the Realm that match the underlying query.
 ///
 /// {@category Realm}
-class RealmResults<T extends Object?> extends Iterable<T> with RealmEntity implements Finalizable {
+class RealmResults<T extends Object?> extends Iterable<T> with RealmEntity {
   final RealmObjectMetadata? _metadata;
   final ResultsHandle _handle;
   final int _skipOffset; // to support skip efficiently
@@ -278,11 +277,6 @@ extension RealmResultsOfRealmObject<T extends RealmObject> on RealmResults<T> {
 /// @nodoc
 //RealmResults package internal members
 extension RealmResultsInternal on RealmResults {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-  }
-
   ResultsHandle get handle {
     if (_handle.released) {
       throw RealmClosedError('Cannot access Results that belongs to a closed Realm');

--- a/packages/realm_dart/lib/src/session.dart
+++ b/packages/realm_dart/lib/src/session.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
-import 'dart:ffi';
 
 import '../realm.dart';
 import '../src/native/realm_bindings.dart';
@@ -14,7 +13,7 @@ import 'user.dart';
 /// server. Sessions are always created by the SDK and vended out through various
 /// APIs. The lifespans of sessions associated with Realms are managed automatically.
 /// {@category Sync}
-class Session implements Finalizable {
+class Session {
   final SessionHandle _handle;
 
   /// The on-disk path of the file backing the [Realm] this [Session] represents
@@ -98,11 +97,6 @@ class ConnectionStateChange {
 }
 
 extension SessionInternal on Session {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-  }
-
   static Session create(SessionHandle handle) => Session._(handle);
 
   SessionHandle get handle {

--- a/packages/realm_dart/lib/src/set.dart
+++ b/packages/realm_dart/lib/src/set.dart
@@ -4,7 +4,6 @@
 import 'dart:core';
 import 'dart:async';
 import 'dart:collection';
-import 'dart:ffi';
 
 import 'package:collection/collection.dart' as collection;
 
@@ -19,7 +18,7 @@ import 'collections.dart';
 import 'results.dart';
 
 /// RealmSet is a collection that contains no duplicate elements.
-abstract class RealmSet<T extends Object?> extends SetBase<T> with RealmEntity implements Finalizable {
+abstract class RealmSet<T extends Object?> extends SetBase<T> with RealmEntity {
   RealmObjectMetadata? _metadata;
 
   /// Gets a value indicating whether this collection is still valid to use.

--- a/packages/realm_dart/lib/src/subscription.dart
+++ b/packages/realm_dart/lib/src/subscription.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:core';
-import 'dart:ffi';
 
 import 'native/convert.dart';
 import 'native/mutable_subscription_set_handle.dart';
@@ -15,7 +14,7 @@ import 'results.dart';
 /// evaluate the query that the app subscribed to and will send data
 /// that matches it as well as remove data that no longer does.
 /// {@category Sync}
-final class Subscription implements Finalizable {
+final class Subscription {
   final SubscriptionHandle _handle;
 
   Subscription._(this._handle);
@@ -53,11 +52,6 @@ final class Subscription implements Finalizable {
 }
 
 extension SubscriptionInternal on Subscription {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-  }
-
   SubscriptionHandle get handle => _handle;
   ObjectId get id => _id;
 }
@@ -115,7 +109,7 @@ enum SubscriptionSetState {
 /// Realm is an expensive operation server-side, even if there's very little data that needs
 /// downloading.
 /// {@category Sync}
-sealed class SubscriptionSet with Iterable<Subscription> implements Finalizable {
+sealed class SubscriptionSet with Iterable<Subscription> {
   final Realm _realm;
   SubscriptionSetHandle __handle;
   SubscriptionSetHandle get _handle => __handle.nullPtrAsNull ?? (throw RealmClosedError('Cannot access a SubscriptionSet that belongs to a closed Realm'));
@@ -195,12 +189,6 @@ sealed class SubscriptionSet with Iterable<Subscription> implements Finalizable 
 }
 
 extension SubscriptionSetInternal on SubscriptionSet {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _realm.keepAlive();
-    _handle.keepAlive();
-  }
-
   SubscriptionSetHandle get handle => _handle;
 
   static SubscriptionSet create(Realm realm, SubscriptionSetHandle handle) => ImmutableSubscriptionSet._(realm, handle);

--- a/packages/realm_dart/lib/src/user.dart
+++ b/packages/realm_dart/lib/src/user.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:ffi';
 
 import 'app.dart';
 import 'credentials.dart';
@@ -162,7 +161,7 @@ class User {
 }
 
 /// @nodoc
-class UserNotificationsController implements Finalizable {
+class UserNotificationsController {
   UserNotificationTokenHandle? tokenHandle;
 
   void start() {
@@ -367,12 +366,6 @@ extension UserIdentityInternal on UserIdentity {
 
 /// @nodoc
 extension UserInternal on User {
-  @pragma('vm:never-inline')
-  void keepAlive() {
-    _handle.keepAlive();
-    _app?.keepAlive();
-  }
-
   UserHandle get handle => _handle;
 
   static User create(UserHandle handle, [App? app]) => User._(handle, app);


### PR DESCRIPTION
To work-around https://github.com/dart-lang/sdk/issues/49643 we added `Finalizable` to all classes that contains `Handles`, and _pseudo_ `keepAlive` functions that was never actually called at runtime, but only existed to prevent early disposal.

As of Dart 2.19.0 this is no longer an issue, and since we require ^3.3.0 we can get rid of this code.

The following code illustrates the original problem:
```dart
import 'dart:ffi';
import 'dart:io';

typedef Free = NativeFunction<Void Function(Pointer)>;
final free = DynamicLibrary.process().lookup<Free>('free');

final _nativeFinalizer = NativeFinalizer(free);

class A implements Finalizable {
  A() {
    _nativeFinalizer.attach(this, Pointer.fromAddress(1), detach: this, externalSize: 1 << 32); // will crash, if it ever runs
  }
}

class B implements Finalizable {
  final A a;

  B(this.a);
}

Future<void> main() async {
  final b = B(A()); // I would expect b.a to live as long as b
  final l = <int>[];
  Future.doWhile(() {
    l.add(1); // put some pressure on GC
    return true;
  });
  await ProcessSignal.sigint.watch().first;
  print(b); // b still alive here, but what about b.a?
}
```
If you compile and run with dart 2.18.6 (Flutter 3.3.10) you get:
```
puro use 3.3.10
[✓] Switched to environment `3.3.10`
puro dart compile exe bin/keep_alive.dart
Info: Compiling with sound null safety
Generated: /Users/kasper/Projects/mongodb/experiments/keep_alive/bin/keep_alive.exe
bin/keep_alive.exe
keep_alive.exe(55026,0x170227000) malloc: *** error for object 0x1: pointer being freed was not allocated
keep_alive.exe(55026,0x170227000) malloc: *** set a breakpoint in malloc_error_break to debug
fish: Job 1, 'bin/keep_alive.exe' terminated by signal SIGABRT (Abort)
```
which proves that `b.a` is reaped before `b`.

Where as with Dart 2.19.0 (Flutter 3.7.0) we get OoM (as expected):
```
puro use 3.7.0
[✓] Switched to environment `3.7.0`
puro dart compile exe bin/keep_alive.dart
Info: Compiling with sound null safety.
Generated: /Users/kasper/Projects/mongodb/experiments/keep_alive/bin/keep_alive.exe
bin/keep_alive.exe
Exhausted heap space, trying to allocate 34359738384 bytes.
Unhandled exception:
Out of Memory
#0      _GrowableList._allocateData (dart:core-patch/growable_array.dart)
#1      _GrowableList._grow (dart:core-patch/growable_array.dart)
#2      _GrowableList._growToNextCapacity (dart:core-patch/growable_array.dart)
#3      main.<anonymous closure> (file:///Users/kasper/Projects/mongodb/experiments/keep_alive/bin/keep_alive.dart)
#4      Future.doWhile.<anonymous closure> (dart:async/future.dart)
#5      _RootZone.runUnaryGuarded (dart:async/zone.dart)
#6      _RootZone.bindUnaryCallbackGuarded.<anonymous closure> (dart:async/zone.dart)
#7      Future.doWhile (dart:async/future.dart)
#8      main (file:///Users/kasper/Projects/mongodb/experiments/keep_alive/bin/keep_alive.dart)
#9      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart)
#10     _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart)
keep_alive.exe(57520,0x1f387cc00) malloc: *** error for object 0x1: pointer being freed was not allocated
keep_alive.exe(57520,0x1f387cc00) malloc: *** set a breakpoint in malloc_error_break to debug
fish: Job 1, 'bin/keep_alive.exe' terminated by signal SIGABRT (Abort)
```

Fixes: #1693 