### PR TITLE
RDART-1045: Expose setrlimit ios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
       differentiator: fi${{ github.run_id }}${{ github.run_attempt }}
 
   flutter-tests-ios:
-    runs-on: macos-12
+    runs-on: macos-14
     name: Flutter Tests iOS
     timeout-minutes: 45
     needs:

--- a/packages/realm_dart/lib/src/native/realm_bindings.dart
+++ b/packages/realm_dart/lib/src/native/realm_bindings.dart
@@ -3971,6 +3971,21 @@ class RealmLibrary {
   late final _realm_dart_scheduler_invoke = _realm_dart_scheduler_invokePtr
       .asFunction<void Function(int, ffi.Pointer<ffi.Void>)>();
 
+  /// implemented for iOS only
+  int realm_dart_setrlimit(
+    int limit,
+  ) {
+    return _realm_dart_setrlimit(
+      limit,
+    );
+  }
+
+  late final _realm_dart_setrlimitPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int)>>(
+          'realm_dart_setrlimit');
+  late final _realm_dart_setrlimit =
+      _realm_dart_setrlimitPtr.asFunction<int Function(int)>();
+
   bool realm_dart_sync_after_reset_handler_callback(
     ffi.Pointer<ffi.Void> userdata,
     ffi.Pointer<realm_t> before_realm,
@@ -11833,6 +11848,8 @@ class _SymbolAddresses {
           .NativeFunction<ffi.Void Function(ffi.Uint64, ffi.Pointer<ffi.Void>)>>
       get realm_dart_scheduler_invoke =>
           _library._realm_dart_scheduler_invokePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Int Function(ffi.Int)>>
+      get realm_dart_setrlimit => _library._realm_dart_setrlimitPtr;
   ffi.Pointer<
       ffi.NativeFunction<
           ffi.Bool Function(

--- a/packages/realm_dart/lib/src/native/realm_bindings.dart
+++ b/packages/realm_dart/lib/src/native/realm_bindings.dart
@@ -3971,20 +3971,32 @@ class RealmLibrary {
   late final _realm_dart_scheduler_invoke = _realm_dart_scheduler_invokePtr
       .asFunction<void Function(int, ffi.Pointer<ffi.Void>)>();
 
-  /// implemented for iOS only
-  int realm_dart_setrlimit(
+  /// implemented for iOS only (for now - valid for all posix)
+  /// /**
+  ///  * Set the soft limit on number of open files
+  ///  * @param limit The requested limit. If less than zero no attempt is made.
+  ///  * @param[out] out_limit The actual limit set.
+  ///  *
+  ///  * @return true if no error occurred.
+  ///  *
+  ///  * @throws RLM_ERR_FILE_PERMISSION_DENIED if the operation was not permitted.
+  ///  */
+  bool realm_dart_set_and_get_rlimit(
     int limit,
+    ffi.Pointer<ffi.Long> out_limit,
   ) {
-    return _realm_dart_setrlimit(
+    return _realm_dart_set_and_get_rlimit(
       limit,
+      out_limit,
     );
   }
 
-  late final _realm_dart_setrlimitPtr =
-      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int)>>(
-          'realm_dart_setrlimit');
-  late final _realm_dart_setrlimit =
-      _realm_dart_setrlimitPtr.asFunction<int Function(int)>();
+  late final _realm_dart_set_and_get_rlimitPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Bool Function(ffi.Long, ffi.Pointer<ffi.Long>)>>(
+      'realm_dart_set_and_get_rlimit');
+  late final _realm_dart_set_and_get_rlimit = _realm_dart_set_and_get_rlimitPtr
+      .asFunction<bool Function(int, ffi.Pointer<ffi.Long>)>();
 
   bool realm_dart_sync_after_reset_handler_callback(
     ffi.Pointer<ffi.Void> userdata,
@@ -11848,8 +11860,11 @@ class _SymbolAddresses {
           .NativeFunction<ffi.Void Function(ffi.Uint64, ffi.Pointer<ffi.Void>)>>
       get realm_dart_scheduler_invoke =>
           _library._realm_dart_scheduler_invokePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Int Function(ffi.Int)>>
-      get realm_dart_setrlimit => _library._realm_dart_setrlimitPtr;
+  ffi.Pointer<
+          ffi
+          .NativeFunction<ffi.Bool Function(ffi.Long, ffi.Pointer<ffi.Long>)>>
+      get realm_dart_set_and_get_rlimit =>
+          _library._realm_dart_set_and_get_rlimitPtr;
   ffi.Pointer<
       ffi.NativeFunction<
           ffi.Bool Function(

--- a/packages/realm_dart/lib/src/native/realm_core.dart
+++ b/packages/realm_dart/lib/src/native/realm_core.dart
@@ -188,4 +188,8 @@ class RealmCore {
   String _getFilesPath() {
     return realmLib.realm_dart_get_files_path().cast<Utf8>().toRealmDartString()!;
   }
+
+  int setrlimit(int limit) {
+    return realmLib.realm_dart_setrlimit(limit);
+  }
 }

--- a/packages/realm_dart/lib/src/native/realm_core.dart
+++ b/packages/realm_dart/lib/src/native/realm_core.dart
@@ -189,7 +189,11 @@ class RealmCore {
     return realmLib.realm_dart_get_files_path().cast<Utf8>().toRealmDartString()!;
   }
 
-  int setrlimit(int limit) {
-    return realmLib.realm_dart_setrlimit(limit);
+  int setAndGetRLimit(int limit) {
+    return using((arena) {
+      final outLimit = arena<Long>();
+      realmLib.realm_dart_set_and_get_rlimit(limit, outLimit).raiseLastErrorIfFalse();
+      return outLimit.value;
+    });
   }
 }

--- a/packages/realm_dart/src/ios/platform.mm
+++ b/packages/realm_dart/src/ios/platform.mm
@@ -19,9 +19,10 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#include <string>
 #include "../realm_dart.h"
-#import <sys/utsname.h>
+#include <string>
+#include <sys/utsname.h>
+#include <sys/resource.h>
 
 static std::string filesDir;
 static std::string deviceModel;
@@ -48,7 +49,6 @@ std::string current_device_model()
     }
 }
 
-
 RLM_API const char* realm_dart_get_files_path() {
     if (filesDir == "") {
         filesDir = default_realm_file_directory();
@@ -73,4 +73,14 @@ RLM_API const char* realm_dart_get_device_version() {
     }
 
     return deviceVersion.c_str();
+}
+
+RLM_API int realm_dart_setrlimit(int limit) {
+    struct rlimit rlim;
+    if (limit > 0) {
+        rlim.rlim_cur = limit;
+        setrlimit(RLIMIT_NOFILE, &rlim);
+    }
+    getrlimit(RLIMIT_NOFILE, &rlim);
+    return rlim.rlim_cur;
 }

--- a/packages/realm_dart/src/realm_dart.h
+++ b/packages/realm_dart/src/realm_dart.h
@@ -36,8 +36,17 @@ RLM_API const char* realm_dart_get_device_version();
 // implemented for Android only
 RLM_API const char* realm_dart_get_bundle_id();
 
-// implemented for iOS only
-RLM_API int realm_dart_setrlimit(int limit);
+// implemented for iOS only (for now - valid for all posix)
+/**
+ * Set the soft limit on number of open files
+ * @param limit The requested limit. If less than zero no attempt is made.
+ * @param[out] out_limit The actual limit set.
+ *
+ * @return true if no error occurred.
+ *
+ * @throws RLM_ERR_FILE_PERMISSION_DENIED if the operation was not permitted.
+ */
+RLM_API bool realm_dart_set_and_get_rlimit(long limit, long* out_limit);
 
 RLM_API const char* realm_get_library_cpu_arch();
 

--- a/packages/realm_dart/src/realm_dart.h
+++ b/packages/realm_dart/src/realm_dart.h
@@ -36,6 +36,9 @@ RLM_API const char* realm_dart_get_device_version();
 // implemented for Android only
 RLM_API const char* realm_dart_get_bundle_id();
 
+// implemented for iOS only
+RLM_API int realm_dart_setrlimit(int limit);
+
 RLM_API const char* realm_get_library_cpu_arch();
 
 typedef struct realm_dart_userdata_async* realm_dart_userdata_async_t;

--- a/packages/realm_dart/test/test.dart
+++ b/packages/realm_dart/test/test.dart
@@ -430,6 +430,11 @@ void setupTests() {
       printOnFailure('${record.category} ${record.level.name}: ${record.message}');
     });
 
+    if (Platform.isIOS) {
+      final maxFiles = realmCore.setrlimit(1024);
+      print('Max files: $maxFiles');
+    }
+
     // Enable this to print platform info, including current PID
     _printPlatformInfo();
   });

--- a/packages/realm_dart/test/test.dart
+++ b/packages/realm_dart/test/test.dart
@@ -431,7 +431,7 @@ void setupTests() {
     });
 
     if (Platform.isIOS) {
-      final maxFiles = realmCore.setrlimit(1024);
+      final maxFiles = realmCore.setAndGetRLimit(1024);
       print('Max files: $maxFiles');
     }
 


### PR DESCRIPTION
There has been a change that prevents a simple ulimit call on the macos host from taking effect on the simulator. Instead we expose `setrlimit` on `RealmCore` and call it from `setUpAll`.

Related to https://github.com/realm/realm-core/issues/7740

Fixes: #1702 