### PR TITLE
Fix CMAKE Policy CMP0152 is not set

### DIFF
--- a/packages/realm/linux/CMakeLists.txt
+++ b/packages/realm/linux/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.19)
 
+if(POLICY CMP0152)
+  cmake_policy(SET CMP0152 OLD)
+endif()
+
 set(PROJECT_NAME "realm")
 project(${PROJECT_NAME} LANGUAGES CXX)
 

--- a/packages/realm/windows/CMakeLists.txt
+++ b/packages/realm/windows/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
+
+if(POLICY CMP0152)
+  cmake_policy(SET CMP0152 OLD)
+endif()
+
 set(PROJECT_NAME "realm")
 project(${PROJECT_NAME} LANGUAGES CXX)
 


### PR DESCRIPTION
This old policy is deprecated (see https://cmake.org/cmake/help/latest/policy/CMP0152.html) but setting the policy to the new one give errors that with my knowledge I cannot fix.

#1678