### PR TITLE
RDART-1087: Update compileSdkVersion to fix android:attr/lStar not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* For the Android platform, changed compileSdkVersion into 31 from 28 to fix the fatal `android:attr/lStar not found` error when using Flutter 3.24.
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.

--- a/packages/realm/android/build.gradle
+++ b/packages/realm/android/build.gradle
@@ -28,7 +28,7 @@ android {
         namespace 'io.realm'
     }
 
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Pull request #1773 exists but was not merged for more than a month due to some configuration mistakes concerned by cla-bot, making #1774 unsolved for long.

This pull request includes exactly the same things of what #1773 included, aiming to speed up the merging of this important update, so that the "android:attr/lStar not found" error can be fixed when using Flutter SDK 3.24. 