### PR TITLE
Fix PseudoType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * For the Android platform, changed compileSdkVersion into 31 from 28 to fix the fatal `android:attr/lStar not found` error when using Flutter 3.24.
+* Fix breakage of `PseudoType` after Flutter 3.27.1. (Issue [#1813](https://github.com/realm/realm-dart/issues/1813))
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.

--- a/packages/CHANGELOG.ejson.md
+++ b/packages/CHANGELOG.ejson.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- Avoid name conflict on `LinkCode`. 
+
 ## 0.4.0
 
 - `fromEJson<T>` now accepts a `defaultValue` argument that is returned if  

--- a/packages/ejson_lint/lib/src/lints/mismatched_getter_type.dart
+++ b/packages/ejson_lint/lib/src/lints/mismatched_getter_type.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' as error;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:ejson_analyzer/ejson_analyzer.dart';
@@ -13,7 +13,7 @@ class MismatchedGetterType extends DartLintRule {
           code: const LintCode(
             name: 'mismatched_getter_type',
             problemMessage: 'Type of getter does not match type of constructor parameter',
-            errorSeverity: ErrorSeverity.ERROR,
+            errorSeverity: error.ErrorSeverity.ERROR,
           ),
         );
 

--- a/packages/ejson_lint/lib/src/lints/missing_getter.dart
+++ b/packages/ejson_lint/lib/src/lints/missing_getter.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' as error;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:ejson_analyzer/ejson_analyzer.dart';
@@ -13,7 +13,7 @@ class MissingGetter extends DartLintRule {
           code: const LintCode(
             name: 'missing_getter',
             problemMessage: 'Missing getter for constructor parameter',
-            errorSeverity: ErrorSeverity.ERROR,
+            errorSeverity: error.ErrorSeverity.ERROR,
           ),
         );
 

--- a/packages/ejson_lint/lib/src/lints/too_many_annotated_constructors.dart
+++ b/packages/ejson_lint/lib/src/lints/too_many_annotated_constructors.dart
@@ -1,7 +1,7 @@
 // Copyright 2024 MongoDB, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' as error;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:ejson_analyzer/ejson_analyzer.dart';
@@ -21,7 +21,7 @@ class TooManyAnnotatedConstructors extends DartLintRule {
           code: const LintCode(
             name: 'too_many_annotated_constructors',
             problemMessage: 'Only one constructor can be annotated',
-            errorSeverity: ErrorSeverity.ERROR,
+            errorSeverity: error.ErrorSeverity.ERROR,
           ),
         );
 

--- a/packages/realm_dart/lib/src/cli/metrics/metrics.g.dart
+++ b/packages/realm_dart/lib/src/cli/metrics/metrics.g.dart
@@ -39,36 +39,31 @@ Properties _$PropertiesFromJson(Map<String, dynamic> json) => Properties(
       realmCoreVersion: json['Core Version'] as String?,
     );
 
-Map<String, dynamic> _$PropertiesToJson(Properties instance) {
-  final val = <String, dynamic>{
-    'token': instance.token,
-    'distinct_id': _digestToJson(instance.distinctId),
-    'builder_id': _digestToJson(instance.builderId),
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('Anonymized MAC Address',
-      const DigestConverter().toJson(instance.anonymizedMacAddress));
-  writeNotNull('Anonymized Bundle ID',
-      const DigestConverter().toJson(instance.anonymizedBundleId));
-  val['Binding'] = instance.binding;
-  val['Language'] = instance.language;
-  val['Framework'] = instance.framework;
-  val['Framework Version'] = instance.frameworkVersion;
-  writeNotNull('Sync Enabled', instance.syncEnabled);
-  val['Realm Version'] = instance.realmVersion;
-  val['Host OS Type'] = instance.hostOsType;
-  val['Host OS Version'] = instance.hostOsVersion;
-  writeNotNull('Target OS Type', _$TargetOsTypeEnumMap[instance.targetOsType]);
-  writeNotNull('Target OS Version', instance.targetOsVersion);
-  writeNotNull('Core Version', instance.realmCoreVersion);
-  return val;
-}
+Map<String, dynamic> _$PropertiesToJson(Properties instance) =>
+    <String, dynamic>{
+      'token': instance.token,
+      'distinct_id': _digestToJson(instance.distinctId),
+      'builder_id': _digestToJson(instance.builderId),
+      if (const DigestConverter().toJson(instance.anonymizedMacAddress)
+          case final value?)
+        'Anonymized MAC Address': value,
+      if (const DigestConverter().toJson(instance.anonymizedBundleId)
+          case final value?)
+        'Anonymized Bundle ID': value,
+      'Binding': instance.binding,
+      'Language': instance.language,
+      'Framework': instance.framework,
+      'Framework Version': instance.frameworkVersion,
+      if (instance.syncEnabled case final value?) 'Sync Enabled': value,
+      'Realm Version': instance.realmVersion,
+      'Host OS Type': instance.hostOsType,
+      'Host OS Version': instance.hostOsVersion,
+      if (_$TargetOsTypeEnumMap[instance.targetOsType] case final value?)
+        'Target OS Type': value,
+      if (instance.targetOsVersion case final value?)
+        'Target OS Version': value,
+      if (instance.realmCoreVersion case final value?) 'Core Version': value,
+    };
 
 const _$TargetOsTypeEnumMap = {
   TargetOsType.android: 'android',

--- a/packages/realm_generator/lib/src/expanded_context_span.dart
+++ b/packages/realm_generator/lib/src/expanded_context_span.dart
@@ -3,7 +3,7 @@
 
 import 'package:source_span/source_span.dart';
 
-class ExpandedContextSpan with SourceSpanMixin implements FileSpan {
+class ExpandedContextSpan extends SourceSpanMixin implements FileSpan {
   final FileSpan _span, _contextSpan;
 
   ExpandedContextSpan(this._span, Iterable<FileSpan> contextSpans) : _contextSpan = contextSpans.fold<FileSpan>(_span, (acc, c) => acc.expand(c));

--- a/packages/realm_generator/lib/src/pseudo_type.dart
+++ b/packages/realm_generator/lib/src/pseudo_type.dart
@@ -20,13 +20,8 @@ class PseudoType extends TypeImpl {
 
   PseudoType(this._name, {this.nullabilitySuffix = NullabilitySuffix.none});
 
-  Never get _never => throw UnimplementedError();
-
   @override
-  R accept<R>(TypeVisitor<R> visitor) => _never;
-
-  @override
-  R acceptWithArgument<R, A>(TypeVisitorWithArgument<R, A> visitor, A argument) => _never;
+  R acceptWithArgument<R, A>(TypeVisitorWithArgument<R, A> visitor, A argument) => throw UnimplementedError();
 
   @override
   void appendTo(ElementDisplayStringBuilder builder) {
@@ -47,16 +42,13 @@ class PseudoType extends TypeImpl {
   }
 
   @override
-  String? get name => _never;
-
-  @override
   PseudoType withNullability(NullabilitySuffix nullabilitySuffix) {
     return PseudoType(_name, nullabilitySuffix: nullabilitySuffix);
   }
 
   @override
-  Element? get element2 => _never;
+  Element? get element => null;
 
   @override
-  Element? get element => null;
+  Never noSuchMethod(Invocation invocation) => throw UnimplementedError();
 }


### PR DESCRIPTION
The `PseudoType` extends the abstract class `TypeImpl` from the **analyzer** package. This makes it brittle in the face of interface changes to said class, which can occur without warning as the class is internal.

This PR tries to make it a little more "robust", by dodging compile time errors on changes to `TypeImpl`. This is done by implementing `noSuchMethod`. If any new members are added, we will no longer get a compile time error. 

We throw an exception, if the unexpected member is actually called, but that _should_ not happen as instances of `PseudoType` are only used internally by the **realm_generator**.

I think it is an acceptable compromise as this code will only ever run on the developers machine, when updating realm models. I think it is a better fix than #1814.

Fix: #1813 