### PR TITLE
Android supports 16KB page size

### DIFF
--- a/packages/realm_dart/src/CMakeLists.txt
+++ b/packages/realm_dart/src/CMakeLists.txt
@@ -65,6 +65,10 @@ if(ANDROID)
     # Add a custom target to strip the binary
     add_custom_target(strip ${CMAKE_STRIP} $<TARGET_FILE:realm_dart>)
 
+    # 16 KB page size compatibility
+    target_link_options(realm_dart PRIVATE "-Wl,-z,max-page-size=16384")
+    target_link_options(realm_dart PRIVATE "-Wl,-z,common-page-size=16384")
+
 elseif(CMAKE_SYSTEM_NAME STREQUAL iOS)
     target_sources(realm_dart PRIVATE
         ios/platform.mm


### PR DESCRIPTION
Ensure Android **arm64-v8a** and **x86_64** Android supports 16KB page size

https://developer.android.com/guide/practices/page-sizes
https://github.com/realm/realm-dart/issues/1858